### PR TITLE
Fixes issue with oninput for type radio in safari

### DIFF
--- a/kalkulator/index.html
+++ b/kalkulator/index.html
@@ -262,7 +262,8 @@ function updateValues(){
 }
 
 loadjs.ready('initCalculator', function() {
-  [].slice.call(document.querySelectorAll('input')).forEach( i => i.addEventListener('input', updateValues))
+  [].slice.call(document.querySelectorAll('input[type=radio]')).forEach( i => i.addEventListener('change', updateValues));
+  document.querySelectorAll('input[name=experience]').addEventListener('input', updateValues);
   updateValues();
 });
 

--- a/kalkulator/index.html
+++ b/kalkulator/index.html
@@ -263,7 +263,7 @@ function updateValues(){
 
 loadjs.ready('initCalculator', function() {
   [].slice.call(document.querySelectorAll('input[type=radio]')).forEach( i => i.addEventListener('change', updateValues));
-  document.querySelectorAll('input[name=experience]').addEventListener('input', updateValues);
+  document.querySelector('#experience').addEventListener('input', updateValues);
   updateValues();
 });
 


### PR DESCRIPTION
Koda det opp via Github grensesnitt, så kan være det er noe som feiler. Tenkte å prøve ut via autodeploy på PR. 

Safari støtter ikke input event på type radio inputs. Denne endringen skriver om til at radio bruker change event og input number fremdeles bruker input. Vi vil at number input skal bruke `input` event for at om noen bruker tastaturet til å endre tall skal lønn automatisk justeres. 