### PR TITLE
Legger til lønnskalkulator i footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,7 @@
             <li><a href="https://handbook.variant.no">Håndbok</a></li>
             <li><a href="https://medium.com/variant-as">Blogg</a></li>
             <li><a href="https://github.com/varianter">Open Source</a></li>
+            <li><a href="https://www.variant.no/kalkulator/">Lønnskalkulator</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
Nå er det ingen permanent måte å se lønnskalkulatoren på. Det burde være en måte å navigere seg til den på. Denne PR-en legger til en lenke til kalkisen i footeren.