### PR TITLE
Reduserer margin top for design slot under hva vi gjør

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -248,6 +248,7 @@ _:-ms-fullscreen,
   padding-top: var(--verticalSpace);
 }
 .textContainer--salesDesign {
+  margin-top: 0;
   margin-left: 0;
 }
 .textContainer--salesTeaching {

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
           <h2 id="career" class="career__title">Bli en variant</h2>
         </header>
 
-        <div class="textContainer textContainer--imgLeft">
+        <div class="textContainer textContainer--top textContainer--imgLeft">
           <figure class="textContainer__img">
             <picture>
               <source srcset="./assets/photos/marius-landscape.jpg" media="(max-width: 750px)" />


### PR DESCRIPTION
Det er veldig mye initial whitespace før beskrivelsen av hva vi gjør for design. Sammen med overskriften og grafikken der blir det for mye. Denne fiksen fjerner margin på toppen av sales pitch.

