### PR TITLE
fix: Fixes header baseline positioning. Fixes #76

### DIFF
--- a/src/index/index.module.css
+++ b/src/index/index.module.css
@@ -1,7 +1,7 @@
 .sayHi {
   position: absolute;
   top: 0;
-  right: 0;
+  right: -1px;
   max-width: 20%;
 }
 

--- a/src/layout/layout.module.css
+++ b/src/layout/layout.module.css
@@ -17,6 +17,7 @@
 .header__logo img {
   display: block;
   margin: 1.2rem;
+  height: 0.9rem;
 }
 .header__nav {
   flex: 1;
@@ -35,6 +36,8 @@
   color: var(--color-standard__white--text);
   text-decoration: none;
   padding: 1.2rem;
+  font-size: 1rem;
+  line-height: 1;
 
   background: linear-gradient(
     to right,


### PR DESCRIPTION
Somewhat difficult having this properly align with enough hitbox for small screens, but setting relative size for the logo to match the text does the trick I think. See preview link.

Fixes #76