### PR TITLE
Legg til utlisting av kontaktperson(er) på annonser

### DIFF
--- a/functions/getEmployees/index.ts
+++ b/functions/getEmployees/index.ts
@@ -33,9 +33,10 @@ Go to cv-partner and get an API key, add under "Values" in local.settings.json`,
           employee.roles.some((role) => role === 'countrymanager'),
       );
       context.res = {
-        body: employeeList.map(({ name, telephone, image }) => ({
+        body: employeeList.map(({ name, telephone, image, email }) => ({
           name,
           telephone,
+          email,
           image,
         })),
       };

--- a/src/employees/index.tsx
+++ b/src/employees/index.tsx
@@ -17,6 +17,7 @@ export type Employee = {
   fullName: string;
   name: string;
   phone: string;
+  email: string;
   imageSlug: string;
 };
 
@@ -193,6 +194,7 @@ export const massageEmployee = (
   return {
     fullName: employee.name,
     name: employee.name.split(' ')[0],
+    email: employee.email,
     phone: (employee.telephone.startsWith('+47')
       ? employee.telephone.slice(3)
       : employee.telephone

--- a/src/jobs/listing/listing.tsx
+++ b/src/jobs/listing/listing.tsx
@@ -95,24 +95,28 @@ export const ContactTile: React.FC<{ contact: Employee }> = ({
 }) => {
   return (
     <div className={style.contact}>
-      <Image
-        width={300}
-        height={300}
-        alt={`Bilde av ${name}`}
-        src={`/employees/${imageSlug}.png`}
-        loading="lazy"
-      />
+      <div className={style.contact__img}>
+        <Image
+          width={80}
+          height={80}
+          alt={`Bilde av ${name}`}
+          src={`/employees/${imageSlug}.png`}
+          loading="lazy"
+        />
+      </div>
 
-      <h4 className={and(style.contact__name, 'fancy')}>{fullName}</h4>
-      <a href={`mailto:${email}`} className={style.contact__type}>
-        📬 {email}
-      </a>
-      <a
-        href={`tel:+47${phone.replace(/\s*/g, '')}`}
-        className={style.contact__type}
-      >
-        📞 {phone}
-      </a>
+      <div className={style.contact__content}>
+        <h4 className={and(style.contact__name, 'fancy')}>{fullName}</h4>
+        <a href={`mailto:${email}`} className={style.contact__type}>
+          📬 {email}
+        </a>
+        <a
+          href={`tel:+47${phone.replace(/\s*/g, '')}`}
+          className={style.contact__type}
+        >
+          📞 {phone}
+        </a>
+      </div>
     </div>
   );
 };

--- a/src/jobs/listing/listing.tsx
+++ b/src/jobs/listing/listing.tsx
@@ -97,8 +97,8 @@ export const ContactTile: React.FC<{ contact: Employee }> = ({
     <div className={style.contact}>
       <div className={style.contact__img}>
         <Image
-          width={80}
-          height={80}
+          width={120}
+          height={120}
           alt={`Bilde av ${name}`}
           src={`/employees/${imageSlug}.png`}
           loading="lazy"

--- a/src/jobs/listing/listing.tsx
+++ b/src/jobs/listing/listing.tsx
@@ -4,9 +4,12 @@ import { NextPage, InferGetStaticPropsType } from 'next';
 import { getStaticProps } from 'pages/jobs/[listing]';
 import Layout from 'src/layout';
 import Head from 'next/head';
+import Image from 'next/image';
 import MarkdownIt from 'markdown-it';
 import { ButtonLink } from 'src/components/button';
 import style from './listings.module.css';
+import { Employee } from 'src/employees';
+import { and } from 'src/utils/css';
 
 const Listing: NextPage<
   InferGetStaticPropsType<typeof getStaticProps>
@@ -19,6 +22,7 @@ const Listing: NextPage<
     });
     return { __html: md.render(listing.content) };
   }, [listing.content]);
+
   return (
     <Layout>
       <Head>
@@ -35,10 +39,19 @@ const Listing: NextPage<
             </ButtonLink>
           </div>
         </div>
-        <article
-          className={style.rendered__markdown__wrapper}
-          dangerouslySetInnerHTML={innerHtml}
-        />
+        <div>
+          <article
+            className={style.rendered__markdown__wrapper}
+            dangerouslySetInnerHTML={innerHtml}
+          />
+          {!!listing.contacts.length && (
+            <div className={style.contacts__layout}>
+              {listing.contacts.map((c) => (
+                <ContactTile key={c.email} contact={c} />
+              ))}
+            </div>
+          )}
+        </div>
         <div className={style.button__bottom}>
           <ButtonLink href={listing.careers_apply_url} mode="primary">
             Søk på stillingen
@@ -76,5 +89,32 @@ const Listing: NextPage<
     </Layout>
   );
 });
+
+export const ContactTile: React.FC<{ contact: Employee }> = ({
+  contact: { fullName, name, email, phone, imageSlug },
+}) => {
+  return (
+    <div className={style.contact}>
+      <Image
+        width={300}
+        height={300}
+        alt={`Bilde av ${name}`}
+        src={`/employees/${imageSlug}.png`}
+        loading="lazy"
+      />
+
+      <h4 className={and(style.contact__name, 'fancy')}>{fullName}</h4>
+      <a href={`mailto:${email}`} className={style.contact__type}>
+        📬 {email}
+      </a>
+      <a
+        href={`tel:+47${phone.replace(/\s*/g, '')}`}
+        className={style.contact__type}
+      >
+        📞 {phone}
+      </a>
+    </div>
+  );
+};
 
 export default Listing;

--- a/src/jobs/listing/listings.module.css
+++ b/src/jobs/listing/listings.module.css
@@ -138,3 +138,81 @@
 .rendered__markdown__wrapper :global(.polaroid) figcaption:nth-child(2) {
   margin: 0;
 }
+
+.contacts__layout {
+  --image-width: 300px;
+  --column-margin: 0.8rem;
+  --columns: 1;
+
+  --total-margin: calc(var(--column-margin) * 2 * var(--columns));
+  --total-images-width: calc(var(--image-width) * var(--columns));
+
+  max-width: calc(var(--total-images-width) + var(--total-margin));
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: 1rem;
+}
+
+.contact {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.contact img {
+  width: var(--image-width);
+  height: var(--image-width);
+  display: grid;
+  place-content: center;
+  color: var(--color-primary__tint1--text);
+}
+
+@media (max-width: 760px) {
+  .contact {
+    margin: 0;
+  }
+  /* .contact:not(:first-of-type) {
+    margin-top: 4.8rem;
+  } */
+  .contacts__layout {
+    justify-content: center;
+  }
+}
+@media (min-width: 760px) and (max-width: 1100px) {
+  .contacts__layout {
+    --columns: 2;
+  }
+}
+@media (min-width: 1100px) {
+  .contacts__layout {
+    --columns: 3;
+  }
+}
+
+.contact__name {
+  max-width: var(--image-width);
+  text-align: center;
+  margin-top: 1.2rem;
+  margin-bottom: 0;
+}
+
+.contact__type {
+  text-decoration: none;
+  font-size: 1rem;
+  color: var(--color-standard__white--text);
+  padding: 0.6rem 1.2rem;
+  line-height: 1;
+
+  background: linear-gradient(
+    to right,
+    var(--color-secondary1),
+    var(--color-primary__shade1),
+    var(--color-secondary2)
+  );
+  background-size: 200% 200%;
+  background-clip: text;
+  transition: color 0.2s ease-in-out;
+}
+.contact__type:hover {
+  color: rgba(0, 0, 0, 0);
+}

--- a/src/jobs/listing/listings.module.css
+++ b/src/jobs/listing/listings.module.css
@@ -140,67 +140,26 @@
 }
 
 .contacts__layout {
-  --image-width: 300px;
-  --column-margin: 0.8rem;
-  --columns: 1;
-
-  --total-margin: calc(var(--column-margin) * 2 * var(--columns));
-  --total-images-width: calc(var(--image-width) * var(--columns));
-
-  max-width: calc(var(--total-images-width) + var(--total-margin));
-  display: flex;
+  display: grid;
   flex-wrap: wrap;
-  padding-top: 1rem;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, 400px);
 }
-
 .contact {
+  margin: 1rem 0;
   display: flex;
-  flex-direction: column;
   align-items: center;
 }
-
-.contact img {
-  width: var(--image-width);
-  height: var(--image-width);
-  display: grid;
-  place-content: center;
-  color: var(--color-primary__tint1--text);
+.contact__img {
+  margin-right: 0.5rem;
 }
-
-@media (max-width: 760px) {
-  .contact {
-    margin: 0;
-  }
-  /* .contact:not(:first-of-type) {
-    margin-top: 4.8rem;
-  } */
-  .contacts__layout {
-    justify-content: center;
-  }
-}
-@media (min-width: 760px) and (max-width: 1100px) {
-  .contacts__layout {
-    --columns: 2;
-  }
-}
-@media (min-width: 1100px) {
-  .contacts__layout {
-    --columns: 3;
-  }
-}
-
 .contact__name {
-  max-width: var(--image-width);
-  text-align: center;
-  margin-top: 1.2rem;
-  margin-bottom: 0;
+  margin: 0;
 }
-
 .contact__type {
   text-decoration: none;
   font-size: 1rem;
   color: var(--color-standard__white--text);
-  padding: 0.6rem 1.2rem;
   line-height: 1;
 
   background: linear-gradient(
@@ -212,6 +171,9 @@
   background-size: 200% 200%;
   background-clip: text;
   transition: color 0.2s ease-in-out;
+}
+.contact__type:not(:last-child) {
+  margin-right: 1rem;
 }
 .contact__type:hover {
   color: rgba(0, 0, 0, 0);

--- a/src/jobs/listing/listings.module.css
+++ b/src/jobs/listing/listings.module.css
@@ -160,7 +160,7 @@
   text-decoration: none;
   font-size: 1rem;
   color: var(--color-standard__white--text);
-  line-height: 1;
+  display: block;
 
   background: linear-gradient(
     to right,

--- a/src/jobs/pages/ceo-i-variant-oslo.md
+++ b/src/jobs/pages/ceo-i-variant-oslo.md
@@ -2,6 +2,7 @@
 title: Daglig leder for Variant Oslo AS
 h1_title: Daglig leder for Variant Oslo AS
 slug: ceo-i-variant-oslo
+contact_emails: oms@variant.no
 ---
 
 ## Vi søker etter noen som vil utvikle Oslo
@@ -53,6 +54,4 @@ Konseptet og filosofien som er beskrevet over har vi behandlet i detalj, foråsi
 
 ## Kontakt
 
-<div class="small"><img alt="Bilde av Odd Morten" src="/employees/odd-morten.png"/> </div>
-
-Har du spørsmål eller ønsker å snakke med oss om dette? Ikke vær redd for å kontakte vår konsernleder Odd Morten Sveås på 928 07 375 eller oms@variant.no
+Har du spørsmål eller ønsker å snakke med oss om dette? Ikke vær redd for å kontakte vår konsernleder Odd Morten Sveås.

--- a/src/jobs/utils/getListings.ts
+++ b/src/jobs/utils/getListings.ts
@@ -17,7 +17,7 @@ export const getListing = async (
   );
   const matterFile = matter(file);
 
-  const matterData = matterFile.data as Listing;
+  const matterData = matterFile.data as ListingMetadata;
   const metadata = findStatus(metadataList, matterData.slug);
 
   return {
@@ -28,13 +28,19 @@ export const getListing = async (
   } as Listing;
 };
 
-export type Listing = {
-  id: number;
+type ListingMetadata = {
   title: string;
   h1_title: string;
+  slug: string;
+  contact_emails?: string;
+};
+
+export type Listing = {
+  id: number;
   name: string;
   content: string;
-} & Offer;
+} & ListingMetadata &
+  Offer;
 export async function getFileListingData(): Promise<Listing[]> {
   const files = await getListings();
   const metadataList = await getValidityStatuses();


### PR DESCRIPTION
Kan legge til kontaktpersoner i en annonse, ved å sette `contact_emails` på i metadata på markdown-filen. Hvis det er flere kontaktpersoner så kan e-postene legges separert med komma.