### PR TITLE
fix: changes medium.com link to new blog.variant.no

### DIFF
--- a/src/index/index.module.css
+++ b/src/index/index.module.css
@@ -170,18 +170,6 @@
   }
 }
 
-.blog a {
-  color: var(--color-standard__black);
-  text-decoration: none;
-  margin-top: 2.4rem;
-  display: block;
-}
-.blog__mediumLogo {
-  display: block;
-  margin: 1.2rem auto 0;
-  max-width: 50%;
-}
-
 .cases {
   margin-top: 8.25rem;
   padding: 0 1rem;

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { getStaticProps } from 'pages/index';
 import React, { useMemo } from 'react';
-import { ButtonNextLink } from 'src/components/button';
+import { ButtonLink, ButtonNextLink } from 'src/components/button';
 import Layout from 'src/layout';
 import style from './index.module.css';
 import SayHi from './say-hi';
@@ -177,14 +177,9 @@ const Home = ({
         <div className={style.blog__text}>
           <h2>Våre ytringer</h2>
 
-          <a href="http://variant.blog">
-            Sjekk oss ut på
-            <img
-              className={style.blog__mediumLogo}
-              src={require('./images/medium.svg')}
-              alt="Logo of Medium"
-            />
-          </a>
+          <ButtonLink href="http://variant.blog">
+            Sjekk ut bloggen vår
+          </ButtonLink>
         </div>
 
         <img

--- a/src/jobs/pages/cdo-i-variant-oslo.md
+++ b/src/jobs/pages/cdo-i-variant-oslo.md
@@ -44,13 +44,13 @@ Kompensasjonen er med andre ord knyttet til verdiutviklingen av selskapet. Vi ha
 ![Workshop med Post-its](/images/design2.png)
 Variant er menneskene som jobber her. Vi har kommet sammen for å være med å skape et konsept og en filosofi vi selv tror på. Hverdagen blir mer spennende av å ha et fellesskap som engasjeres av utvikling og hvordan det påvirker hverdagen. Forretningsmodell vår er enkel: Vi tilbyr flinke folk.
 
-Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://medium.com/variant-as/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
+Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://blog.variant.no/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
 
 Konseptet og filosofien som er beskrevet over har vi behandlet i detalj, foråsidetsånn:
 
-- [Åpen og delt kompetansebygging](https://medium.com/variant-as/aapen-og-delt-kompetansebygging-c229771eee93)
-- Tillitsbasert ledelse: [del 1](https://medium.com/variant-as/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://medium.com/variant-as/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
-- [Om lønn](https://medium.com/variant-as/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
+- [Åpen og delt kompetansebygging](https://blog.variant.no/aapen-og-delt-kompetansebygging-c229771eee93)
+- Tillitsbasert ledelse: [del 1](https://blog.variant.no/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://blog.variant.no/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
+- [Om lønn](https://blog.variant.no/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
 
 ## Kontakt
 

--- a/src/jobs/pages/ceo-i-variant-oslo.md
+++ b/src/jobs/pages/ceo-i-variant-oslo.md
@@ -11,7 +11,7 @@ contact_emails: oms@variant.no
 
 Det er det vi ønsker du skal gjøre, - sammen med flere og sammen med oss. Etablere neste generasjons selskapskultur hvor medarbeideres potensial utnyttes til det fulle ved å gi tillit og transparens. En kultur som består av gjensidig raushet, åpenhet og læreglede. En kultur som har mot til å stå som et eksempel for andre og ydmykhet til å lære av det samme.
 
-Les mer om våre Oslo-vyer i [denne brosjyren](https://variant.no/oslovyer). I tillegg har Odd Morten skrevet litt om [hvorfor vi etablerer oss i Tigerstaden](https://medium.com/variant-as/hei-oslo-717ea91e45b9).
+Les mer om våre Oslo-vyer i [denne brosjyren](https://variant.no/oslovyer). I tillegg har Odd Morten skrevet litt om [hvorfor vi etablerer oss i Tigerstaden](https://blog.variant.no/hei-oslo-717ea91e45b9).
 
 ## Hvem ser vi etter?
 
@@ -43,13 +43,13 @@ Kompensasjonen er med andre ord knyttet til verdiutviklingen av selskapet. Vi ha
 ![Variant med vision](/images/flaske.png)
 Variant er menneskene som jobber her. Vi har kommet sammen for å være med å skape et konsept og en filosofi vi selv tror på. Hverdagen blir mer spennende av å ha et fellesskap som engasjeres av utvikling og hvordan det påvirker hverdagen. Forretningsmodell vår er enkel: Vi tilbyr flinke folk.
 
-Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://medium.com/variant-as/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
+Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://blog.variant.no/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
 
 Konseptet og filosofien som er beskrevet over har vi behandlet i detalj, foråsidetsånn:
 
-- [Åpen og delt kompetansebygging](https://medium.com/variant-as/aapen-og-delt-kompetansebygging-c229771eee93)
-- Tillitsbasert ledelse: [del 1](https://medium.com/variant-as/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://medium.com/variant-as/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
-- [Om lønn](https://medium.com/variant-as/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
+- [Åpen og delt kompetansebygging](https://blog.variant.no/aapen-og-delt-kompetansebygging-c229771eee93)
+- Tillitsbasert ledelse: [del 1](https://blog.variant.no/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://blog.variant.no/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
+- [Om lønn](https://blog.variant.no/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
 
 ## Kontakt
 

--- a/src/jobs/pages/cto-i-variant-oslo.md
+++ b/src/jobs/pages/cto-i-variant-oslo.md
@@ -11,7 +11,7 @@ contact_emails: cb@variant.no, mb@variant.no
 
 Det er det vi ønsker du skal gjøre, - sammen med flere og sammen med oss. Etablere neste generasjons selskapskultur hvor medarbeideres potensial utnyttes til det fulle ved å gi tillit og transparens. En kultur som består av gjensidig raushet, åpenhet og læreglede. En kultur som har mot til å stå som et eksempel for andre og ydmykhet til å lære av det samme.
 
-Les mer om våre Oslo-vyer i [denne brosjyren](https://variant.no/oslovyer). I tillegg har Odd Morten skrevet litt om [hvorfor vi etablerer oss i Tigerstaden](https://medium.com/variant-as/hei-oslo-717ea91e45b9).
+Les mer om våre Oslo-vyer i [denne brosjyren](https://variant.no/oslovyer). I tillegg har Odd Morten skrevet litt om [hvorfor vi etablerer oss i Tigerstaden](https://blog.variant.no/hei-oslo-717ea91e45b9).
 
 ## Hvem ser vi etter?
 
@@ -50,13 +50,13 @@ Kompensasjonen er med andre ord knyttet til verdiutviklingen av selskapet. Vi ha
 ![Christian, Jacob og Maciek hos Variant](/images/utvikler-jacob.png)
 Variant er menneskene som jobber her. Vi har kommet sammen for å være med å skape et konsept og en filosofi vi selv tror på. Hverdagen blir mer spennende av å ha et fellesskap som engasjeres av utvikling og hvordan det påvirker hverdagen. Forretningsmodell vår er enkel: Vi tilbyr flinke folk.
 
-Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://medium.com/variant-as/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
+Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://blog.variant.no/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
 
 Konseptet og filosofien som er beskrevet over har vi behandlet i detalj, foråsidetsånn:
 
-- [Åpen og delt kompetansebygging](https://medium.com/variant-as/aapen-og-delt-kompetansebygging-c229771eee93)
-- Tillitsbasert ledelse: [del 1](https://medium.com/variant-as/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://medium.com/variant-as/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
-- [Om lønn](https://medium.com/variant-as/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
+- [Åpen og delt kompetansebygging](https://blog.variant.no/aapen-og-delt-kompetansebygging-c229771eee93)
+- Tillitsbasert ledelse: [del 1](https://blog.variant.no/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://blog.variant.no/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
+- [Om lønn](https://blog.variant.no/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
 
 ## Kontakt
 

--- a/src/jobs/pages/designer-trondheim.md
+++ b/src/jobs/pages/designer-trondheim.md
@@ -49,8 +49,8 @@ Kundelisten endrer seg stadig, og for tiden bistår vi blant annet disse:
 
 - [Gode og rettferdige betingelser](https://handbook.variant.no/#betingelser)
 - [God lønn som er åpen for alle](https://www.variant.no/kalkulator)
-- [Innsikt og påvirkning](https://medium.com/variant-as/bli-en-bedre-variant-7e1926bdcfba#e27f) i alt som skjer
-- [Vokse faglig og hjelpe andre vokse](https://medium.com/variant-as/aapen-og-delt-kompetansebygging-c229771eee93)
+- [Innsikt og påvirkning](https://blog.variant.no/bli-en-bedre-variant-7e1926bdcfba#e27f) i alt som skjer
+- [Vokse faglig og hjelpe andre vokse](https://blog.variant.no/aapen-og-delt-kompetansebygging-c229771eee93)
 
 Vi har en [håndbok](https://handbook.variant.no/) for hva du enn måtte lure på. (Pro tip: sjekk ut "Andre goder og ytelser")
 
@@ -60,13 +60,13 @@ Variant er menneskene som jobber her. Vi har kommet sammen for å være med å s
 
 ![placeholder blob](/work_images/teal_blob.svg)
 
-Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU og flere-enn-du-tror leder [ymse meetups](https://www.meetup.com/IXDATrondheim/) i Trondheim. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://medium.com/variant-as/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
+Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU og flere-enn-du-tror leder [ymse meetups](https://www.meetup.com/IXDATrondheim/) i Trondheim. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://blog.variant.no/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
 
 Konseptet og filosofien som er beskrevet over har vi behandlet i detalj, foråsidetsånn:
 
-- [Åpen og delt kompetansebygging](https://medium.com/variant-as/aapen-og-delt-kompetansebygging-c229771eee93)
-- Tillitsbasert ledelse: [del 1](https://medium.com/variant-as/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://medium.com/variant-as/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
-- [Om lønn](https://medium.com/variant-as/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
+- [Åpen og delt kompetansebygging](https://blog.variant.no/aapen-og-delt-kompetansebygging-c229771eee93)
+- Tillitsbasert ledelse: [del 1](https://blog.variant.no/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://blog.variant.no/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
+- [Om lønn](https://blog.variant.no/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
 
 ## Kontakt
 

--- a/src/jobs/pages/utvikler-trondheim.md
+++ b/src/jobs/pages/utvikler-trondheim.md
@@ -63,8 +63,8 @@ Akkurat nå hjelper vi noen av våre kunder med blant annet:
 
 - [Gode og rettferdige betingelser](https://handbook.variant.no/#betingelser)
 - [God lønn som er åpen for alle](https://www.variant.no/kalkulator)
-- [Innsikt og påvirkning](https://medium.com/variant-as/bli-en-bedre-variant-7e1926bdcfba#e27f) i alt som skjer
-- [Vokse faglig og hjelpe andre vokse](https://medium.com/variant-as/aapen-og-delt-kompetansebygging-c229771eee93)
+- [Innsikt og påvirkning](https://blog.variant.no/bli-en-bedre-variant-7e1926bdcfba#e27f) i alt som skjer
+- [Vokse faglig og hjelpe andre vokse](https://blog.variant.no/aapen-og-delt-kompetansebygging-c229771eee93)
 
 Vi har en [håndbok](https://handbook.variant.no/) for hva du enn måtte lure på. (Pro tip: sjekk ut "Andre goder og ytelser")
 
@@ -78,14 +78,14 @@ Vi har en [håndbok](https://handbook.variant.no/) for hva du enn måtte lure p�
 
 Variant er menneskene som jobber her. Vi har kommet sammen for å være med å skape et konsept og en filosofi vi selv tror på. Hverdagen blir mer spennende av å ha et fellesskap som engasjeres av utvikling og hvordan det påvirker hverdagen. Forretningsmodellen vår er enkel: Vi tilbyr flinke folk.
 
-Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU og flere-enn-du-tror leder [ymse meetups](https://www.meetup.com/IXDATrondheim/) i Trondheim. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://medium.com/variant-as/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
+Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU og flere-enn-du-tror leder [ymse meetups](https://www.meetup.com/IXDATrondheim/) i Trondheim. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://blog.variant.no/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
 
 Konseptet og filosofien som er beskrevet over har vi behandlet i detalj, foråsidetsånn:
 
-- [Åpen og delt kompetansebygging](https://medium.com/variant-as/aapen-og-delt-kompetansebygging-c229771eee93)
-- Tillitsbasert ledelse: [del 1](https://medium.com/variant-as/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://medium.com/variant-as/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
-- [Om lønn](https://medium.com/variant-as/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
-- [På tide med bedre jobbintervjuer](https://medium.com/variant-as/paa-tide-med-bedre-jobbintervjuer-e59f6789a134)
+- [Åpen og delt kompetansebygging](https://blog.variant.no/aapen-og-delt-kompetansebygging-c229771eee93)
+- Tillitsbasert ledelse: [del 1](https://blog.variant.no/tillitsbasert-ledelse-del-1-hva-og-hvorfor-86f6aa485cf9), [del 2](https://blog.variant.no/tillitsbasert-ledelse-del-2-sette-retning-449452fcc6a6)
+- [Om lønn](https://blog.variant.no/bonusutbetaling-og-l%C3%B8nnsjusteringer-c6d340f0a6d)
+- [På tide med bedre jobbintervjuer](https://blog.variant.no/paa-tide-med-bedre-jobbintervjuer-e59f6789a134)
 
 Nylig har vi også valgt å open-source både ansettelsesavtaler og oppdragsavtaler. Onboarding står på tur etter det. Se mer på [https://github.com/varianter](https://github.com/varianter).
 

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -179,7 +179,7 @@ const Layout: React.FC<LayoutProps> = ({
               </li>
               <li>
                 <a
-                  href="https://medium.com/variant-as/tagged/b%C3%A6rekraft"
+                  href="https://blog.variant.no/tagged/b%C3%A6rekraft"
                   rel="noopener"
                   title="Les mer om Variants bærekraftsinitiativ"
                 >


### PR DESCRIPTION
Fjerner også Medium-logo fra forsiden og erstatter med dette (ikke perfekt, men trenger ikke Medium-logo her):

<img width="1061" alt="Screenshot 2021-03-10 at 20 51 39" src="https://user-images.githubusercontent.com/606374/110688940-6b6f9980-81e2-11eb-8163-eddbdd144a26.png">
