### PR TITLE
fix: issue with new auth headers for CV partner

### DIFF
--- a/functions/getEmployees/index.ts
+++ b/functions/getEmployees/index.ts
@@ -19,7 +19,10 @@ Go to cv-partner and get an API key, add under "Values" in local.settings.json`,
   try {
     const request = await fetch('https://variant.cvpartner.com/api/v1/users', {
       headers: [
-        ['Authorization', `Bearer ${process.env.CV_PARTNER_API_SECRET || ''}`],
+        [
+          'Authorization',
+          `Token token="${process.env.CV_PARTNER_API_SECRET || ''}"`,
+        ],
       ],
     });
     if (request.ok) {


### PR DESCRIPTION
Det er visst ny måte å sende inn token til CV-partner på som har eksistert en stund og som nå brekker uten at vi har fått noe varsel (i alle fall så vidt jeg vet). Se docs: https://variant.cvpartner.com/help/api

Dette oppdaterer til å bruke den nye HEADER-verdien og fikser feil som er nå med at bilder ikke fungerer i ansattlisten. Dette burde vi lande tidlig nå som det kommer mange nye ansatte.