### PR TITLE
Correct year when mentioning Variantdag

### DIFF
--- a/src/jobs/index.tsx
+++ b/src/jobs/index.tsx
@@ -107,7 +107,7 @@ const JobsIndex: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
         <section className={style.omVariant}>
           <h2>Variantdag - November 2019 </h2>
           <p>
-            Første fredag hver måned har vi variantdag. I november i fjor lagde
+            Første fredag hver måned har vi variantdag. I november 2019 lagde
             vi en liten film som viser litt av hva variantdager går ut på
           </p>
           <div className={style.aspect__ratio}>

--- a/src/jobs/index.tsx
+++ b/src/jobs/index.tsx
@@ -108,7 +108,7 @@ const JobsIndex: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
           <h2>Variantdag - November 2019 </h2>
           <p>
             Første fredag hver måned har vi variantdag. I november 2019 lagde
-            vi en liten film som viser litt av hva variantdager går ut på
+            vi en liten film som viser litt av hva variantdager går ut på!
           </p>
           <div className={style.aspect__ratio}>
             <iframe


### PR DESCRIPTION
As it's no longer 2020, we should no longer refer to 2019 as last year. Also added exclamation mark at the end of the sentence! :)

This change does possibly also remove the need for mentioning November 2019 in the title?

![image](https://user-images.githubusercontent.com/21310942/128173152-079a1f38-ceca-4242-a700-5fcf7a5e4e24.png)
