### PR TITLE
fix: increase padding for third section to avoid text overlap

### DIFF
--- a/src/summersplash/index.module.css
+++ b/src/summersplash/index.module.css
@@ -478,6 +478,10 @@ h3 {
     padding-left: 2rem;
   }
 
+  .thirdSection {
+    padding: 2rem 2rem;
+  }
+
   .firstSection .imageBlob {
     bottom: -12rem;
     right: -2rem;


### PR DESCRIPTION
Quickfix for å bare gjøre det slik at første bildet til venstre ikke overlapper med teksten på små skjermer. Ikke en ekte fiks som fikser årsaken til feilen, men bare en quick workaround for nå.


Slik blir det nå:

<img width="877" alt="Screenshot 2021-09-17 at 21 32 51" src="https://user-images.githubusercontent.com/606374/133843851-55516924-ae39-4575-89f8-ca3cfac84115.png">
