### PR TITLE
fix: dont show error with missing azure storage data as it is optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+
+# Required
+CV_PARTNER_API_SECRET=
+
+# Optional to test Image Blob Storage usage
+AZURE_STORAGE_ACCOUNT_ACCESS_KEY=
+AZURE_STORAGE_ACCOUNT_NAME=variantno
+BLOB_OVERRIDE=true

--- a/src/employees/utils/getEmployeesList.ts
+++ b/src/employees/utils/getEmployeesList.ts
@@ -1,4 +1,4 @@
-import { handleImages } from 'src/employees/utils/imageHandler';
+import handleImages from 'src/employees/utils/imageHandler';
 import { Office } from 'src/office-selector';
 import { ApiEmployee, EmployeeItem } from '../types';
 import { requestByEmails, requestEmployees } from './request';

--- a/src/employees/utils/imageHandler/blob.ts
+++ b/src/employees/utils/imageHandler/blob.ts
@@ -26,7 +26,7 @@ const blobServiceClient = new BlobServiceClient(
 
 const containerName = 'employees';
 
-export const handleImages = async (employee: ApiEmployee) => {
+export default async (employee: ApiEmployee) => {
   // Check if images exsist already
   const userFileName = toFileName(employee.name);
   const containerClient = blobServiceClient.getContainerClient(containerName);

--- a/src/employees/utils/imageHandler/index.ts
+++ b/src/employees/utils/imageHandler/index.ts
@@ -1,7 +1,11 @@
-import { handleImages as handleImages_blob } from './blob';
-import { handleImages as handleImages_local } from './local';
+import { ApiEmployee } from 'src/employees/types';
 
-export const handleImages =
-  process.env.NODE_ENV !== 'development' || process.env.BLOB_OVERRIDE == 'true'
-    ? handleImages_blob
-    : handleImages_local;
+export default async function handleImages(employee: ApiEmployee) {
+  const handler =
+    process.env.NODE_ENV !== 'development' ||
+    process.env.BLOB_OVERRIDE == 'true'
+      ? await import('./blob')
+      : await import('./local');
+
+  return handler.default(employee);
+}

--- a/src/employees/utils/imageHandler/local.ts
+++ b/src/employees/utils/imageHandler/local.ts
@@ -6,7 +6,7 @@ import { ApiEmployee } from 'src/employees/types';
 // Temp comment to retrigger deployemtn
 const employeeDirectory = path.join(process.cwd(), 'public/employees');
 
-export const handleImages = async (employee: ApiEmployee) => {
+export default async (employee: ApiEmployee) => {
   // Check if images exsist already
   const userFileName = toFileName(employee.name);
 


### PR DESCRIPTION
Gjør storage ENV-vars faktisk optional med lazy loading.
CV_PARTNER API må fortsatt være med.