### PR TITLE
fix: #229 download of podcast episode now starts when you press play

### DIFF
--- a/src/rss/feed/Player.tsx
+++ b/src/rss/feed/Player.tsx
@@ -38,14 +38,15 @@ export default function AudioPlayer({
   url,
   withScrubber = true,
   children,
+  duration,
 }: {
   url: string;
   withScrubber?: boolean;
   children?: React.ReactNode;
+  duration: number;
 }) {
   const audioElement = useRef<HTMLAudioElement>(null);
   const [currentState, setCurrentState] = useState<States>('INITIAL');
-  const [duration, setDuration] = useState(0);
   const [trackProgress, setTrackProgress] = useState(0);
 
   useEffect(() => {
@@ -70,13 +71,6 @@ export default function AudioPlayer({
     };
   }, [currentState, duration]);
 
-  useEffect(() => {
-    audioElement.current?.addEventListener('loadedmetadata', (event) => {
-      const { duration } = event.target as HTMLAudioElement;
-      setDuration(duration);
-    });
-  }, []);
-
   const buttonHandler = () => {
     setCurrentState(machine[currentState].next);
   };
@@ -97,7 +91,7 @@ export default function AudioPlayer({
 
   return (
     <div className={style.player}>
-      <audio preload="metadata" ref={audioElement}>
+      <audio preload="none" ref={audioElement}>
         <source src={url} />
       </audio>
 

--- a/src/rss/feed/Podcast.tsx
+++ b/src/rss/feed/Podcast.tsx
@@ -22,7 +22,7 @@ export default function Podcast({ item }: { item: PodcastItem }) {
       </div>
       <div className={style.text}>
         <div className={style.podcast__content}>
-          <Player url={item.media.url} withScrubber={true}>
+          <Player duration={item.duration} url={item.media.url} withScrubber={true}>
             <h4 className={style.title}>
               {item.title}{' '}
               <span

--- a/src/rss/rss.ts
+++ b/src/rss/rss.ts
@@ -28,6 +28,7 @@ export type PodcastFeedItem = Item & {
     summary?: string;
     categories?: string[];
     keywords?: string[];
+    duration?: string;
   };
 };
 

--- a/src/rss/service.ts
+++ b/src/rss/service.ts
@@ -23,6 +23,7 @@ export type PodcastItem = {
   };
   description: string;
   title: string;
+  duration: number;
 } & ItemBase;
 
 export type YoutubeVideoItem = {
@@ -131,6 +132,7 @@ function mapFeedToPodcast(item: PodcastFeedItem): PodcastItem {
       url: item.enclosure?.url || '',
     },
     description: item.itunes?.summary || '',
+    duration: item.itunes?.duration? parseInt(item.itunes.duration) : 0,
   };
 }
 


### PR DESCRIPTION
fix: #229 by setting the preload attribute of the audio element to none. The podcast duration that was previously fetched using `preload="metadata"` is added in the mapFeedToPodcast function. 