### PR TITLE
Fix: Feed mobile fixes

### DIFF
--- a/src/rss/feed/feed.module.css
+++ b/src/rss/feed/feed.module.css
@@ -19,6 +19,8 @@
 .title {
   margin-bottom: 0.5rem;
   font-size: 1.5rem;
+  overflow-wrap: anywhere;
+  hyphens: auto;
 }
 
 .card__title__container {

--- a/src/rss/feed/feed.module.css
+++ b/src/rss/feed/feed.module.css
@@ -19,8 +19,13 @@
 .title {
   margin-bottom: 0.5rem;
   font-size: 1.5rem;
-  overflow-wrap: anywhere;
-  hyphens: auto;
+}
+
+@media (max-width: 600px) {
+  .title {
+    overflow-wrap: anywhere;
+    hyphens: auto;
+  }
 }
 
 .card__title__container {


### PR DESCRIPTION
@carinamnk fant en bug som oppsto når det var lange ord i tittelen på blog/podcast/youtube-posts i feeden (både på forsida og på /feed). Mangel på word wrap gjorde at det i praksis ble satt en minstebredde på tittelelementet, og når det lengste ordet var langt gjorde det at feed-kortene overflowa til høyre for siden.

Eksempel:

<img width="526" alt="image" src="https://user-images.githubusercontent.com/31799931/186834606-3042f750-9465-4ebd-8ed4-435c859ccf98.png">

Kjapp fiks som gjør word wrap mulig på mobilversjonen av siden. Caniuse.com sier Safari ikke støtter overflow-wrap: anywhere, men fungerer som forventa på Safari 13 hvertfall. Overflow-wrap: break-word fungerer derimot ikke i Safari (kan hende at det er intended altså, men er ikke så dreven på akkurat [nyansene](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap).
