### PR TITLE
Add decorative boxes as a reuasble component

### DIFF
--- a/src/components/decorative-boxes/index.tsx
+++ b/src/components/decorative-boxes/index.tsx
@@ -163,5 +163,5 @@ function getColor(color: keyof AllColorNames | HexColorAsString): string {
 }
 
 function isHexColor(color: string): color is HexColorAsString {
-  return /(^#[a-f\d]{6}$)/.test(color);
+  return /(^#[a-f\d]{6}$)/.test(color.toLowerCase());
 }

--- a/src/components/decorative-boxes/index.tsx
+++ b/src/components/decorative-boxes/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import style from './style.module.css';
 type BoxProperties = {
   color: `--color-${DefaultColors}${ColorModifiers}` | HexColorAsString;
@@ -30,6 +31,35 @@ const DecorativeBoxes: React.FC<DecorativeBoxesProps> = ({
   box1Properties,
   box2Properties,
 }) => {
+  const box1HorizontalDistance = useRef(
+    calculateDistanceToSide(
+      getNumericalBoxSize(boxSize),
+      box1Properties.position,
+      'left',
+    ),
+  );
+  const box1VerticalDistance = useRef(
+    calculateDistanceToSide(
+      getNumericalBoxSize(boxSize),
+      box1Properties.position,
+      'top',
+    ),
+  );
+  const box2HorizontalDistance = useRef(
+    calculateDistanceToSide(
+      getNumericalBoxSize(boxSize),
+      box2Properties.position,
+      'left',
+    ),
+  );
+  const box2VerticalDistance = useRef(
+    calculateDistanceToSide(
+      getNumericalBoxSize(boxSize),
+      box2Properties.position,
+      'top',
+    ),
+  );
+
   return (
     <div className={style['main-container']}>
       <div
@@ -37,18 +67,12 @@ const DecorativeBoxes: React.FC<DecorativeBoxesProps> = ({
         style={{
           width: getNumericalBoxSize(boxSize) + '%',
           backgroundColor: `var(${box1Properties.color})`,
-          left:
-            calculateDistanceToSide(
-              getNumericalBoxSize(boxSize),
-              box1Properties.position,
-              'left',
-            ) + '%',
-          top:
-            calculateDistanceToSide(
-              getNumericalBoxSize(boxSize),
-              box1Properties.position,
-              'top',
-            ) + '%',
+          left: box1HorizontalDistance.current + '%',
+          top: box1VerticalDistance.current + '%',
+          transform: `translate(
+            -${box1HorizontalDistance.current}%, 
+            -${box1VerticalDistance.current}%
+            )`,
         }}
       >
         {box1Properties.text ? box1Properties.text : ''}
@@ -58,18 +82,12 @@ const DecorativeBoxes: React.FC<DecorativeBoxesProps> = ({
         style={{
           width: getNumericalBoxSize(boxSize) + '%',
           backgroundColor: `var(${box2Properties.color})`,
-          left:
-            calculateDistanceToSide(
-              getNumericalBoxSize(boxSize),
-              box2Properties.position,
-              'left',
-            ) + '%',
-          top:
-            calculateDistanceToSide(
-              getNumericalBoxSize(boxSize),
-              box2Properties.position,
-              'top',
-            ) + '%',
+          left: box2HorizontalDistance.current + '%',
+          top: box2VerticalDistance.current + '%',
+          transform: `translate(
+            -${box2HorizontalDistance.current}%, 
+            -${box2VerticalDistance.current}%
+            )`,
         }}
       >
         {box2Properties.text ? box2Properties.text : ''}
@@ -97,15 +115,15 @@ function calculateDistanceToSide(
         return 0;
       case 'leftish':
       case 'topish':
-        return (100 - boxSize) * 0.25;
+        return 25;
       case 'middle':
-        return (100 - boxSize) * 0.5;
+        return 50;
       case 'rightish':
       case 'bottomish':
-        return (100 - boxSize) * 0.75;
+        return 75;
       case 'right':
       case 'bottom':
-        return 100 - boxSize;
+        return 100;
     }
   } else if (
     // object with exact numerical position has been used
@@ -126,11 +144,11 @@ function calculateDistanceToSide(
 function getNumericalBoxSize(boxSize: BoxSize): number {
   switch (boxSize) {
     case 'small':
-      return 50;
+      return 40;
     case 'medium':
-      return 60;
+      return 50;
     case 'large':
-      return 70;
+      return 60;
     default:
       return boxSize;
   }

--- a/src/components/decorative-boxes/index.tsx
+++ b/src/components/decorative-boxes/index.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { AllColorNames, allColors } from '@variant/profile/lib/colors';
 import style from './style.module.css';
 type BoxProperties = {
@@ -30,33 +29,25 @@ function DecorativeBoxes({
   box1Properties,
   box2Properties,
 }: DecorativeBoxesProps) {
-  const box1HorizontalDistance = useRef(
-    calculateDistanceToSide(
-      getNumericalBoxSize(boxSize),
-      box1Properties.position,
-      'left',
-    ),
+  const box1HorizontalDistance = calculateDistanceToSide(
+    getNumericalBoxSize(boxSize),
+    box1Properties.position,
+    'left',
   );
-  const box1VerticalDistance = useRef(
-    calculateDistanceToSide(
-      getNumericalBoxSize(boxSize),
-      box1Properties.position,
-      'top',
-    ),
+  const box1VerticalDistance = calculateDistanceToSide(
+    getNumericalBoxSize(boxSize),
+    box1Properties.position,
+    'top',
   );
-  const box2HorizontalDistance = useRef(
-    calculateDistanceToSide(
-      getNumericalBoxSize(boxSize),
-      box2Properties.position,
-      'left',
-    ),
+  const box2HorizontalDistance = calculateDistanceToSide(
+    getNumericalBoxSize(boxSize),
+    box2Properties.position,
+    'left',
   );
-  const box2VerticalDistance = useRef(
-    calculateDistanceToSide(
-      getNumericalBoxSize(boxSize),
-      box2Properties.position,
-      'top',
-    ),
+  const box2VerticalDistance = calculateDistanceToSide(
+    getNumericalBoxSize(boxSize),
+    box2Properties.position,
+    'top',
   );
 
   return (
@@ -66,11 +57,11 @@ function DecorativeBoxes({
         style={{
           width: getNumericalBoxSize(boxSize) + '%',
           backgroundColor: getColor(box1Properties.color),
-          left: box1HorizontalDistance.current + '%',
-          top: box1VerticalDistance.current + '%',
+          left: box1HorizontalDistance + '%',
+          top: box1VerticalDistance + '%',
           transform: `translate(
-            -${box1HorizontalDistance.current}%, 
-            -${box1VerticalDistance.current}%
+            -${box1HorizontalDistance}%,
+            -${box1VerticalDistance}%
             )`,
         }}
       >
@@ -81,11 +72,11 @@ function DecorativeBoxes({
         style={{
           width: getNumericalBoxSize(boxSize) + '%',
           backgroundColor: getColor(box2Properties.color),
-          left: box2HorizontalDistance.current + '%',
-          top: box2VerticalDistance.current + '%',
+          left: box2HorizontalDistance + '%',
+          top: box2VerticalDistance + '%',
           transform: `translate(
-            -${box2HorizontalDistance.current}%, 
-            -${box2VerticalDistance.current}%
+            -${box2HorizontalDistance}%,
+            -${box2VerticalDistance}%
             )`,
         }}
       >

--- a/src/components/decorative-boxes/index.tsx
+++ b/src/components/decorative-boxes/index.tsx
@@ -1,7 +1,8 @@
 import { useRef } from 'react';
+import { AllColorNames, allColors } from '@variant/profile/lib/colors';
 import style from './style.module.css';
 type BoxProperties = {
-  color: `--color-${DefaultColors}${ColorModifiers}` | HexColorAsString;
+  color: keyof AllColorNames | HexColorAsString;
   position: `${VerticalPosition}-${HorizontalPosition}` | NumericPosition;
   text?: string | undefined;
 };
@@ -13,8 +14,6 @@ type NumericPosition = {
 type BoxSize = 'small' | 'medium' | 'large' | number;
 type VerticalPosition = 'top' | 'topish' | 'middle' | 'bottomish' | 'bottom';
 type HorizontalPosition = 'left' | 'leftish' | 'middle' | 'rightish' | 'right';
-type DefaultColors = 'primary' | `secondary${1 | 2 | 3 | 4}`;
-type ColorModifiers = '' | `__${'tint' | 'shade'}${1 | 2 | 3 | 4}`;
 type HexColorAsString = `#${string}`;
 
 export interface DecorativeBoxesProps
@@ -66,7 +65,7 @@ const DecorativeBoxes: React.FC<DecorativeBoxesProps> = ({
         className={style['decorative-box']}
         style={{
           width: getNumericalBoxSize(boxSize) + '%',
-          backgroundColor: `var(${box1Properties.color})`,
+          backgroundColor: getColor(box1Properties.color),
           left: box1HorizontalDistance.current + '%',
           top: box1VerticalDistance.current + '%',
           transform: `translate(
@@ -81,7 +80,7 @@ const DecorativeBoxes: React.FC<DecorativeBoxesProps> = ({
         className={style['decorative-box']}
         style={{
           width: getNumericalBoxSize(boxSize) + '%',
-          backgroundColor: `var(${box2Properties.color})`,
+          backgroundColor: getColor(box2Properties.color),
           left: box2HorizontalDistance.current + '%',
           top: box2VerticalDistance.current + '%',
           transform: `translate(
@@ -152,4 +151,17 @@ function getNumericalBoxSize(boxSize: BoxSize): number {
     default:
       return boxSize;
   }
+}
+
+function getColor(color: keyof AllColorNames | HexColorAsString): string {
+  if (isHexColor(color)) {
+    return color;
+  } else if (color in allColors) {
+    return allColors[color];
+  }
+  return '#000';
+}
+
+function isHexColor(color: string): color is HexColorAsString {
+  return /(^#[a-f\d]{6}$)/.test(color);
 }

--- a/src/components/decorative-boxes/index.tsx
+++ b/src/components/decorative-boxes/index.tsx
@@ -100,7 +100,7 @@ export default DecorativeBoxes;
 
 function calculateDistanceToSide(
   boxSize: number,
-  position: `${VerticalPosition}-${HorizontalPosition}` | NumericPosition,
+  position: BoxProperties['position'],
   distanceToCalculate: 'top' | 'left',
 ): number {
   if (typeof position === 'string') {

--- a/src/components/decorative-boxes/index.tsx
+++ b/src/components/decorative-boxes/index.tsx
@@ -24,12 +24,12 @@ export interface DecorativeBoxesProps
   box2Properties: BoxProperties;
 }
 
-const DecorativeBoxes: React.FC<DecorativeBoxesProps> = ({
+function DecorativeBoxes({
   children,
   boxSize = 'medium',
   box1Properties,
   box2Properties,
-}) => {
+}: DecorativeBoxesProps) {
   const box1HorizontalDistance = useRef(
     calculateDistanceToSide(
       getNumericalBoxSize(boxSize),
@@ -94,7 +94,7 @@ const DecorativeBoxes: React.FC<DecorativeBoxesProps> = ({
       <div className={style['child-container']}>{children}</div>
     </div>
   );
-};
+}
 
 export default DecorativeBoxes;
 

--- a/src/components/decorative-boxes/index.tsx
+++ b/src/components/decorative-boxes/index.tsx
@@ -1,0 +1,137 @@
+import style from './style.module.css';
+type BoxProperties = {
+  color: `--color-${DefaultColors}${ColorModifiers}` | HexColorAsString;
+  position: `${VerticalPosition}-${HorizontalPosition}` | NumericPosition;
+  text?: string | undefined;
+};
+
+type NumericPosition = {
+  horizontalPosition: number;
+  verticalPosition: number;
+};
+type BoxSize = 'small' | 'medium' | 'large' | number;
+type VerticalPosition = 'top' | 'topish' | 'middle' | 'bottomish' | 'bottom';
+type HorizontalPosition = 'left' | 'leftish' | 'middle' | 'rightish' | 'right';
+type DefaultColors = 'primary' | `secondary${1 | 2 | 3 | 4}`;
+type ColorModifiers = '' | `__${'tint' | 'shade'}${1 | 2 | 3 | 4}`;
+type HexColorAsString = `#${string}`;
+
+export interface DecorativeBoxesProps
+  extends React.ComponentPropsWithoutRef<any> {
+  children: JSX.Element;
+  boxSize?: BoxSize;
+  box1Properties: BoxProperties;
+  box2Properties: BoxProperties;
+}
+
+const DecorativeBoxes: React.FC<DecorativeBoxesProps> = ({
+  children,
+  boxSize = 'medium',
+  box1Properties,
+  box2Properties,
+}) => {
+  return (
+    <div className={style['main-container']}>
+      <div
+        className={style['decorative-box']}
+        style={{
+          width: getNumericalBoxSize(boxSize) + '%',
+          backgroundColor: `var(${box1Properties.color})`,
+          left:
+            calculateDistanceToSide(
+              getNumericalBoxSize(boxSize),
+              box1Properties.position,
+              'left',
+            ) + '%',
+          top:
+            calculateDistanceToSide(
+              getNumericalBoxSize(boxSize),
+              box1Properties.position,
+              'top',
+            ) + '%',
+        }}
+      >
+        {box1Properties.text ? box1Properties.text : ''}
+      </div>
+      <div
+        className={style['decorative-box']}
+        style={{
+          width: getNumericalBoxSize(boxSize) + '%',
+          backgroundColor: `var(${box2Properties.color})`,
+          left:
+            calculateDistanceToSide(
+              getNumericalBoxSize(boxSize),
+              box2Properties.position,
+              'left',
+            ) + '%',
+          top:
+            calculateDistanceToSide(
+              getNumericalBoxSize(boxSize),
+              box2Properties.position,
+              'top',
+            ) + '%',
+        }}
+      >
+        {box2Properties.text ? box2Properties.text : ''}
+      </div>
+      <div className={style['child-container']}>{children}</div>
+    </div>
+  );
+};
+
+export default DecorativeBoxes;
+
+function calculateDistanceToSide(
+  boxSize: number,
+  position: `${VerticalPosition}-${HorizontalPosition}` | NumericPosition,
+  distanceToCalculate: 'top' | 'left',
+): number {
+  if (typeof position === 'string') {
+    const positionAsString =
+      distanceToCalculate === 'top'
+        ? position.split('-')[0]
+        : position.split('-')[1];
+    switch (positionAsString) {
+      case 'left':
+      case 'top':
+        return 0;
+      case 'leftish':
+      case 'topish':
+        return (100 - boxSize) * 0.25;
+      case 'middle':
+        return (100 - boxSize) * 0.5;
+      case 'rightish':
+      case 'bottomish':
+        return (100 - boxSize) * 0.75;
+      case 'right':
+      case 'bottom':
+        return 100 - boxSize;
+    }
+  } else if (
+    // object with exact numerical position has been used
+    'verticalPosition' in position &&
+    'horizontalPosition' in position
+  ) {
+    if (distanceToCalculate === 'top') {
+      return ((100 - boxSize) * position['verticalPosition']) / 100;
+    } else if (distanceToCalculate === 'left') {
+      return ((100 - boxSize) * position['horizontalPosition']) / 100;
+    }
+  }
+  // Fallback + keeps typescript happy
+  return 0;
+}
+
+// defines box sizes. 'medium' is the standard size.
+function getNumericalBoxSize(boxSize: BoxSize): number {
+  switch (boxSize) {
+    case 'small':
+      return 50;
+    case 'medium':
+      return 60;
+    case 'large':
+      return 70;
+    default:
+      return boxSize;
+  }
+}

--- a/src/components/decorative-boxes/index.tsx
+++ b/src/components/decorative-boxes/index.tsx
@@ -89,7 +89,7 @@ function DecorativeBoxes({
             )`,
         }}
       >
-        {box2Properties.text ? box2Properties.text : ''}
+        {box2Properties.text ?? ''}
       </div>
       <div className={style['child-container']}>{children}</div>
     </div>

--- a/src/components/decorative-boxes/style.module.css
+++ b/src/components/decorative-boxes/style.module.css
@@ -1,0 +1,26 @@
+.main-container {
+  padding: 2rem;
+  position: relative;
+  height: min-content;
+  width: min-content;
+}
+
+.decorative-box {
+  position: absolute;
+  top: 0;
+  left: 0;
+  aspect-ratio: 1;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 0.25rem 0.5rem;
+  overflow-wrap: break-word;
+  font-size: 0.75rem;
+}
+
+.child-container {
+  position: relative;
+  height: fit-content;
+  width: fit-content;
+}

--- a/src/components/decorative-boxes/style.module.css
+++ b/src/components/decorative-boxes/style.module.css
@@ -1,8 +1,9 @@
 .main-container {
   padding: 2rem;
   position: relative;
-  height: min-content;
-  width: min-content;
+  height: fit-content;
+  max-height: 100%;
+  max-width: 100%;
 }
 
 .decorative-box {
@@ -20,7 +21,12 @@
 }
 
 .child-container {
+  display: grid;
+  place-items: center;
+}
+
+.main-container > * :not(.decorative-box) {
   position: relative;
-  height: fit-content;
-  width: fit-content;
+  max-width: 100%;
+  max-height: 100%;
 }

--- a/src/index/index.module.css
+++ b/src/index/index.module.css
@@ -186,6 +186,7 @@
 }
 .cases__case {
   display: grid;
+  gap: 2rem 2rem;
   padding: 2rem 0;
   grid-template-columns: minmax(20rem, 2fr) minmax(23rem, 1fr);
 }
@@ -208,62 +209,6 @@
   text-underline-offset: 0.3rem;
   display: block;
   margin-top: 1.2rem;
-}
-.cases__case > figure {
-  position: relative;
-  height: min-content;
-}
-.cases__case figure img {
-  display: block;
-  max-width: 100%;
-  margin: 0 auto;
-  padding: 1.25rem;
-}
-.cases__decorationBox {
-  width: 50%;
-  border-radius: 0.5rem;
-  position: absolute;
-  z-index: -1;
-}
-/* Creates a 1:1 aspect ratio */
-.cases__decorationBox::before {
-  content: '';
-  display: block;
-  padding-top: 100%;
-}
-.cases__case:nth-of-type(2n-1) .cases__decorationBox:nth-of-type(1) {
-  top: 0;
-  left: 20%;
-}
-.cases__case:nth-of-type(2n-1) .cases__decorationBox:nth-of-type(2) {
-  bottom: 0;
-  left: 0;
-}
-.cases__case:nth-of-type(2n) .cases__decorationBox:nth-of-type(1) {
-  top: 0;
-  right: 0;
-}
-.cases__case:nth-of-type(2n) .cases__decorationBox:nth-of-type(2) {
-  bottom: 0;
-  right: 30%;
-}
-.cases__case:nth-of-type(3n-2) .cases__decorationBox:nth-of-type(1) {
-  background-color: var(--color-secondary3);
-}
-.cases__case:nth-of-type(3n-2) .cases__decorationBox:nth-of-type(2) {
-  background-color: var(--color-secondary1__tint4);
-}
-.cases__case:nth-of-type(3n-1) .cases__decorationBox:nth-of-type(1) {
-  background-color: var(--color-secondary2__tint4);
-}
-.cases__case:nth-of-type(3n-1) .cases__decorationBox:nth-of-type(2) {
-  background-color: var(--color-secondary3__tint1);
-}
-.cases__case:nth-of-type(3n) .cases__decorationBox:nth-of-type(1) {
-  background-color: var(--color-primary__tint3);
-}
-.cases__case:nth-of-type(3n) .cases__decorationBox:nth-of-type(2) {
-  background-color: var(--color-secondary2__tint4);
 }
 
 .employees {

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -1,3 +1,4 @@
+import DecorativeBoxes from '@components/decorative-boxes';
 import { InferGetStaticPropsType } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
@@ -17,7 +18,7 @@ const Home = ({
   feeds,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const cases = useMemo(() => {
-    return randomCases.map((caseItem) => (
+    return randomCases.map((caseItem, index) => (
       <article className={style.cases__case} key={caseItem.heading}>
         <div className={style.cases__caseContent}>
           <h4>{caseItem.heading}</h4>
@@ -30,11 +31,28 @@ const Home = ({
             <a title="Prosjektinfo">Les mer</a>
           </Link> */}
         </div>
-        <figure>
-          <div className={style.cases__decorationBox} />
-          <div className={style.cases__decorationBox} />
+        <DecorativeBoxes
+          box1Properties={{
+            color:
+              index % 3 === 0
+                ? '--color-secondary3'
+                : index % 3 === 1
+                ? '--color-secondary2__tint4'
+                : '--color-primary__tint3',
+            position: index % 2 === 1 ? 'top-right' : 'top-leftish',
+          }}
+          box2Properties={{
+            color:
+              index % 3 === 0
+                ? '--color-secondary1__tint4'
+                : index % 3 === 1
+                ? '--color-secondary3__tint2'
+                : '--color-secondary2__tint4',
+            position: index % 2 === 1 ? 'bottom-middle' : 'bottom-left',
+          }}
+        >
           <img src={caseItem.case_image} alt={caseItem.image_alt} />
-        </figure>
+        </DecorativeBoxes>
       </article>
     ));
   }, [randomCases]);

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -1,6 +1,7 @@
 import DecorativeBoxes from '@components/decorative-boxes';
 import { InferGetStaticPropsType } from 'next';
 import Head from 'next/head';
+import { decorativeBoxColorPairs } from './utils/decorative-box-colors';
 import Image from 'next/image';
 import Link from 'next/link';
 import { getStaticProps } from 'pages/index';
@@ -33,21 +34,18 @@ const Home = ({
         </div>
         <DecorativeBoxes
           box1Properties={{
+            // color pairs follow a pattern defined by decorativeBoxColorPairs
             color:
-              index % 3 === 0
-                ? '--color-secondary3'
-                : index % 3 === 1
-                ? '--color-secondary2__tint4'
-                : '--color-primary__tint3',
+              decorativeBoxColorPairs[
+                index % decorativeBoxColorPairs.length
+              ][0],
             position: index % 2 === 1 ? 'top-right' : 'top-leftish',
           }}
           box2Properties={{
             color:
-              index % 3 === 0
-                ? '--color-secondary1__tint4'
-                : index % 3 === 1
-                ? '--color-secondary3__tint2'
-                : '--color-secondary2__tint4',
+              decorativeBoxColorPairs[
+                index % decorativeBoxColorPairs.length
+              ][1],
             position: index % 2 === 1 ? 'bottom-middle' : 'bottom-left',
           }}
         >

--- a/src/index/utils/decorative-box-colors.ts
+++ b/src/index/utils/decorative-box-colors.ts
@@ -1,0 +1,8 @@
+import { AllColorNames } from '@variant/profile/lib/colors';
+
+type colorName = keyof AllColorNames;
+export const decorativeBoxColorPairs: colorName[][] = [
+  ['secondary3', 'secondary1__tint4'],
+  ['secondary2__tint4', 'secondary3__tint1'],
+  ['primary__tint3', 'secondary2__tint4'],
+];

--- a/src/index/utils/decorative-box-colors.ts
+++ b/src/index/utils/decorative-box-colors.ts
@@ -1,6 +1,6 @@
 import { AllColorNames } from '@variant/profile/lib/colors';
 
-type colorName = keyof AllColorNames;
+type colorName = keyof AllColorNames | `#${string}`;
 export const decorativeBoxColorPairs: colorName[][] = [
   ['secondary3', 'secondary1__tint4'],
   ['secondary2__tint4', 'secondary3__tint1'],


### PR DESCRIPTION
Fixes #270 

Ble opprinnelig jobba på i Styleguide, men flyttet hit grunnet en kombinasjon av nøsting med yarn og mangel på behov på å ha tilgang til komponenten utenfor variant.no. 

Opprinnelig PR er her, finnes litt diskusjon der: https://github.com/varianter/styleguide/pull/37

I denne PRen ligger den nye komponenten, pluss kode som bytter ut de dekorative boksene **på forsida av variant.no** med komponenten, slik at komponenten kan testes. 

Boksene som ligger på blant annet intervjusidene er ikke byttet enda, tanken er å gjøre det på resten av boksene på sida i en senere PR, siden denne allerede er omfattende nok.