### PR TITLE
fix: konsekvent bruk av overskrifter og informasjonshierarki

### DIFF
--- a/src/community/community.module.css
+++ b/src/community/community.module.css
@@ -1,41 +1,20 @@
 .header {
-  margin: 8rem 1rem;
+  margin: 4rem 1rem;
   display: grid;
   grid-template:
-    'title image' 8rem
+    'title image' 12rem
     'description image'
     / 1fr 1fr;
   grid-column-gap: 2rem;
 }
 
-/* remove once new header-component is in place */
-.header__title {
-  font-weight: 500;
-  font-size: 4.5rem;
-
-  background: linear-gradient(
-    120deg,
-    var(--color-primary),
-    var(--color-secondary1),
-    var(--color-secondary2)
-  );
-  background-size: 130% 130%;
-  background-clip: text;
-  color: rgba(0, 0, 0, 0);
-  background-position-x: 60%;
-}
-
 @media (max-width: 500px) {
   .header {
     grid-template:
-      'title' 6rem
+      'title' 10rem
       'description'
       'image';
-    margin: 4rem 1rem 8rem 1rem;
-  }
-
-  .header__title {
-    font-size: 3.5rem;
+    margin: 0rem 1rem 8rem 1rem;
   }
 }
 
@@ -51,12 +30,13 @@
   grid-area: image;
   width: 180%;
   max-width: 60vw;
-  margin-top: 3rem;
+  margin-top: 7rem;
 }
 @media (max-width: 500px) {
   .header img {
     width: 115%;
     max-width: unset;
+    margin-top: 3rem;
   }
 }
 

--- a/src/community/index.tsx
+++ b/src/community/index.tsx
@@ -4,6 +4,7 @@ import Layout from 'src/layout';
 import style from './community.module.css';
 import DecorativeBoxes from '@components/decorative-boxes';
 import Link from 'next/link';
+import PageTitle from '@components/page-title';
 
 const blobUrl = require('./contact-blob.svg');
 
@@ -23,7 +24,7 @@ function Community() {
 
       <header className={style.header}>
         {/* Switch with title component once it has been merged in */}
-        <h1 className={style.header__title}>Læreglede</h1>
+        <PageTitle title="Læreglede" />
         <div className={style['text-container']}>
           <p>
             Vi ønsker å bidra til åpen læreglede der hvor vi finnes. Derfor

--- a/src/components/page-title/index.tsx
+++ b/src/components/page-title/index.tsx
@@ -1,9 +1,19 @@
 import React from 'react';
+import { and } from 'src/utils/css';
 import style from './page-title.module.css';
 type PageTitleProps = {
   element?: 'h2' | 'h1';
   title: string;
+  bold?: boolean;
 };
-export default function PageTitle({ element = 'h1', title }: PageTitleProps) {
-  return React.createElement(element, { className: style.title }, [title]);
+export default function PageTitle({
+  element = 'h1',
+  title,
+  bold = false,
+}: PageTitleProps) {
+  return React.createElement(
+    element,
+    { className: and(style.title, bold ? style['title--bold'] : undefined) },
+    [title],
+  );
 }

--- a/src/components/page-title/index.tsx
+++ b/src/components/page-title/index.tsx
@@ -4,16 +4,16 @@ import style from './page-title.module.css';
 type PageTitleProps = {
   element?: 'h2' | 'h1';
   title: string;
-  bold?: boolean;
+  jumbo?: boolean;
 };
 export default function PageTitle({
   element = 'h1',
   title,
-  bold = false,
+  jumbo = false,
 }: PageTitleProps) {
   return React.createElement(
     element,
-    { className: and(style.title, bold ? style['title--bold'] : undefined) },
+    { className: and(style.title, jumbo ? style['title--jumbo'] : undefined) },
     [title],
   );
 }

--- a/src/components/page-title/index.tsx
+++ b/src/components/page-title/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import style from './page-title.module.css';
+type PageTitleProps = {
+  element?: 'h2' | 'h1';
+  title: string;
+};
+export default function PageTitle({ element = 'h1', title }: PageTitleProps) {
+  return React.createElement(element, { className: style.title }, [title]);
+}

--- a/src/components/page-title/page-title.module.css
+++ b/src/components/page-title/page-title.module.css
@@ -1,6 +1,7 @@
 .title {
-  margin: 4.8rem 0;
-  font-size: 4.8rem;
+  font-weight: 500;
+  margin: 4rem 0 2rem;
+  font-size: 4rem;
 
   background: linear-gradient(
     120deg,
@@ -14,6 +15,8 @@
   background-position-x: 60%;
 }
 
-.title--bold {
+.title--jumbo {
   font-weight: bold;
+  margin: 4.8rem 0;
+  font-size: 4.8rem;
 }

--- a/src/components/page-title/page-title.module.css
+++ b/src/components/page-title/page-title.module.css
@@ -15,6 +15,12 @@
   background-position-x: 60%;
 }
 
+@media (max-width: 500px) {
+  .title {
+    font-size: 3.5rem;
+  }
+}
+
 .title--jumbo {
   font-weight: bold;
   margin: 4.8rem 0;

--- a/src/components/page-title/page-title.module.css
+++ b/src/components/page-title/page-title.module.css
@@ -1,0 +1,16 @@
+.title {
+  font-weight: bold;
+  margin: 4.8rem 0;
+  font-size: 4.8rem;
+
+  background: linear-gradient(
+    120deg,
+    var(--color-primary),
+    var(--color-secondary1),
+    var(--color-secondary2)
+  );
+  background-size: 130% 130%;
+  background-clip: text;
+  color: rgba(0, 0, 0, 0);
+  background-position-x: 60%;
+}

--- a/src/components/page-title/page-title.module.css
+++ b/src/components/page-title/page-title.module.css
@@ -1,5 +1,4 @@
 .title {
-  font-weight: bold;
   margin: 4.8rem 0;
   font-size: 4.8rem;
 
@@ -13,4 +12,8 @@
   background-clip: text;
   color: rgba(0, 0, 0, 0);
   background-position-x: 60%;
+}
+
+.title--bold {
+  font-weight: bold;
 }

--- a/src/diversity/diversity.module.css
+++ b/src/diversity/diversity.module.css
@@ -6,23 +6,6 @@
   font-size: 1.5rem;
 }
 
-.header__title {
-  font-weight: 500;
-  margin: 4rem 0 2rem 0;
-  font-size: 4rem;
-
-  background: linear-gradient(
-    120deg,
-    var(--color-primary),
-    var(--color-secondary1),
-    var(--color-secondary2)
-  );
-  background-size: 130% 130%;
-  background-clip: text;
-  color: rgba(0, 0, 0, 0);
-  background-position-x: 60%;
-}
-
 .primary-container {
   display: flex;
   flex-direction: column;
@@ -37,7 +20,7 @@
   }
 }
 
-.primary-container h4 {
+.primary-container h2 {
   font-size: 1.75rem;
   margin-bottom: 1rem;
 }

--- a/src/diversity/index.tsx
+++ b/src/diversity/index.tsx
@@ -1,4 +1,5 @@
 import { ButtonLink } from '@components/button';
+import PageTitle from '@components/page-title';
 import Head from 'next/head';
 import Layout from 'src/layout';
 import style from './diversity.module.css';
@@ -18,7 +19,7 @@ const Diversity = () => {
       </Head>
 
       <header className={style.header}>
-        <h2 className={style.header__title}>Mangfold</h2>
+        <PageTitle title="Mangfold" />
         <p>
           Mangfold skaper inkluderende og fullgode løsninger, som gir verdi og
           nytte for absolutt alle. Vi i Variant samarbeider med de som aktivt
@@ -41,7 +42,7 @@ const Diversity = () => {
         <section className={style['project-category']}>
           <article id="ada" className={style['project-article']}>
             <section className={style['project-article__text']}>
-              <h4>Ada</h4>
+              <h2>Ada</h2>
               <p>
                 Ada jobber for å øke kjønnsbalansen på ingeniør- og
                 teknologistudiene ved NTNU. Formålet deres er å motivere kvinner
@@ -67,7 +68,7 @@ const Diversity = () => {
 
           <article className={style['project-article']}>
             <section className={style['project-article__text']}>
-              <h4>Hils på Sarah</h4>
+              <h2>Hils på Sarah</h2>
               <p>
                 Sarah er mangfoldsansvarlig i Variant og brenner for å få flere
                 jenter inn i teknologibransjen. Hun har jobbet i Kodeklubben og
@@ -83,7 +84,7 @@ const Diversity = () => {
 
           <article id="tenk" className={style['project-article']}>
             <section className={style['project-article__text']}>
-              <h4>TENK Tech Camp</h4>
+              <h2>TENK Tech Camp</h2>
               <p>
                 TENK Tech Camp er en gratis teknologicamp for jenter i alderen
                 13-18 år. Formålet med campen er å motivere jenter til å velge
@@ -106,7 +107,7 @@ const Diversity = () => {
         </section>
 
         <section className={style.contact}>
-          <h4>Har du et initiativ vi kan samarbeide om?</h4>
+          <h2>Har du et initiativ vi kan samarbeide om?</h2>
           <div className={style['contact__button__wrapper']}>
             <ButtonLink href="mailto:post@variant.no">Send e-post</ButtonLink>
           </div>
@@ -115,7 +116,7 @@ const Diversity = () => {
         <section className={style['project-category']}>
           <article id="oda" className={style['project-article']}>
             <section className={style['project-article__text']}>
-              <h4>ODA-nettverket</h4>
+              <h2>ODA-nettverket</h2>
               <p>
                 ODA-nettverket jobber aktivt for å skape mangfold innen
                 teknologi. De jobber spesielt med kvinner i bransjen ved å
@@ -136,7 +137,7 @@ const Diversity = () => {
 
           <article className={style['project-article']}>
             <section className={style['project-article__text']}>
-              <h4>Hils på Linn</h4>
+              <h2>Hils på Linn</h2>
               <p>
                 Linn er en av variantene som er engasjert i ODA-nettverket. Hun
                 bidrar med kunnskap, erfaring og sprer læreglede som mentor og

--- a/src/employees/employees.module.css
+++ b/src/employees/employees.module.css
@@ -8,8 +8,16 @@
 }
 
 .employees__header {
-  margin-top: 4.8rem;
-  margin-bottom: 1rem;
+  width: 70%;
+  padding: 0 1rem 3.2rem;
+  position: relative;
+}
+
+@media (max-width: 500px) {
+  .employees__header {
+    width: 100%;
+    margin-bottom: 1rem;
+  }
 }
 
 .employees__text {
@@ -82,6 +90,10 @@
   text-align: center;
   margin-top: 1.2rem;
   margin-bottom: 0;
+  line-height: 1.3;
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
 }
 
 .employee__phone {

--- a/src/employees/index.tsx
+++ b/src/employees/index.tsx
@@ -1,3 +1,4 @@
+import PageTitle from '@components/page-title';
 import { BaseBlob } from '@variant/components/lib/blob';
 import { colors } from '@variant/profile/lib';
 import { InferGetStaticPropsType } from 'next';
@@ -13,6 +14,53 @@ import { and } from 'src/utils/css';
 import style from './employees.module.css';
 import { EmployeeItem } from './types';
 
+const getSoMeMetadata = (officeName?: Office) => {
+  let description;
+  switch (officeName) {
+    case 'oslo':
+      description =
+        'Oversikt over alle ansatte i Variant Oslo. Her finner du alle varianter i Oslo og hvordan du kan ta kontakt for spørsmål.';
+      break;
+    case 'trondheim':
+      description =
+        'Oversikt over alle ansatte i Variant Trondheim. Her finner du alle varianter i Trondheim og hvordan du kan ta kontakt for spørsmål.';
+      break;
+    case 'bergen':
+      description =
+        'Oversikt over alle ansatte i Variant Bergen. Her finner du alle varianter i Bergen og hvordan du kan ta kontakt for spørsmål.';
+      break;
+    default:
+      description =
+        'Oversikt over alle ansatte i Variant. Her finner du alle varianter og hvordan du kan ta kontakt for spørsmål.';
+  }
+
+  return (
+    <Head>
+      <meta property="og:description" content={description} />
+      <meta name="description" content={description} />
+    </Head>
+  );
+};
+
+const getTitle = (officeName?: Office) => {
+  let title;
+  switch (officeName) {
+    case 'oslo':
+      title = 'Varianter i Oslo';
+      break;
+    case 'trondheim':
+      title = 'Varianter i Trondheim';
+      break;
+    case 'bergen':
+      title = 'Varianter i Bergen';
+      break;
+    default:
+      title = 'Alle varianter';
+  }
+
+  return title;
+};
+
 export default function Employees({
   employeeList,
   officeName,
@@ -26,43 +74,13 @@ export default function Employees({
 
   const indexToInsertLink = Math.floor((employeeList.length / 3) * 2);
 
-  const getSoMeMetadata = (officeName?: Office) => {
-    let description;
-    switch (officeName) {
-      case 'oslo':
-        description =
-          'Oversikt over alle ansatte i Variant Oslo. Her finner du alle varianter i Oslo og hvordan du kan ta kontakt for spørsmål.';
-        break;
-      case 'trondheim':
-        description =
-          'Oversikt over alle ansatte i Variant Trondheim. Her finner du alle varianter i Trondheim og hvordan du kan ta kontakt for spørsmål.';
-        break;
-      case 'bergen':
-        description =
-          'Oversikt over alle ansatte i Variant Bergen. Her finner du alle varianter i Bergen og hvordan du kan ta kontakt for spørsmål.';
-        break;
-      default:
-        description =
-          'Oversikt over alle ansatte i Variant. Her finner du alle varianter og hvordan du kan ta kontakt for spørsmål.';
-    }
-
-    return (
-      <Head>
-        <meta property="og:description" content={description} />
-        <meta name="description" content={description} />
-      </Head>
-    );
-  };
-
   return (
     <Layout fullWidth title="Alle varianter – Variant">
       {getSoMeMetadata(officeName)}
 
       <div className={style.employeesContainer}>
-        <header>
-          <h2 className={and(style.employees__header, 'fancy')}>
-            Vi i Variant
-          </h2>
+        <header className={style.employees__header}>
+          <PageTitle title={getTitle(officeName)} />
           <p className={style.employees__text}>
             Vi har i Variant en god gjeng erfarne og dyktige mennesker. Dette er
             faglige fyrtårn i byen og personer som virkelig ønsker å lære bort
@@ -122,7 +140,7 @@ export const EmployeeTile: React.FC<{ employee: EmployeeItem }> = ({
         src={imageUrl}
         loading="lazy"
       />
-      <h4 className={and(style.employee__name, 'fancy')}>{fullName}</h4>
+      <h2 className={and(style.employee__name, 'fancy')}>{fullName}</h2>
       <div className={style.employee__office}>{officeName}</div>
       <a
         href={`tel:+47${telephone.replace(/\s*/g, '')}`}

--- a/src/index/index.module.css
+++ b/src/index/index.module.css
@@ -27,26 +27,6 @@
   }
 }
 
-.omVariant__title {
-  font-weight: bold;
-  margin: 4.8rem 0;
-  font-size: 4.8rem;
-
-  background: linear-gradient(
-    120deg,
-    var(--color-primary),
-    var(--color-secondary1),
-    var(--color-secondary2)
-  );
-  background-size: 130% 130%;
-  background-clip: text;
-  color: rgba(0, 0, 0, 0);
-  background-position-x: 60%;
-}
-.omVariant__title[data-no-animation='true'] {
-  animation: none;
-}
-
 .omVariant__p1 {
   margin: 2rem 3rem;
   font-size: 1.5rem;

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -12,6 +12,7 @@ import style from './index.module.css';
 import { EmployeeItem } from 'src/employees/types';
 import { CaseJSON } from 'src/case/Case';
 import { HighlightedItemsLists } from 'src/rss/service';
+import PageTitle from '@components/page-title';
 
 export type HomeProps = {
   randomEmployee: EmployeeItem;
@@ -73,7 +74,8 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
         />
       </Head>
       <section className={style.omVariant}>
-        <h2 className={style.omVariant__title}>Raus, åpen og læreglad</h2>
+        <PageTitle title="Raus, åpen og læreglad" element="h2" />
+
         <p className={style.omVariant__p1}>
           IT handler ikke om designskisser, linjer av kode eller infrastruktur,
           men om samarbeid og forståelse. IT bør være åpenhet, ærlighet og

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -74,7 +74,7 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
         />
       </Head>
       <section className={style.omVariant}>
-        <PageTitle title="Raus, åpen og læreglad" bold element="h2" />
+        <PageTitle title="Raus, åpen og læreglad" jumbo element="h2" />
 
         <p className={style.omVariant__p1}>
           IT handler ikke om designskisser, linjer av kode eller infrastruktur,

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -74,7 +74,7 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
         />
       </Head>
       <section className={style.omVariant}>
-        <PageTitle title="Raus, åpen og læreglad" element="h2" />
+        <PageTitle title="Raus, åpen og læreglad" bold element="h2" />
 
         <p className={style.omVariant__p1}>
           IT handler ikke om designskisser, linjer av kode eller infrastruktur,

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -61,7 +61,7 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
   }, [randomCases]);
 
   return (
-    <Layout crazy>
+    <Layout crazy homepage>
       <Head>
         <meta
           property="og:description"

--- a/src/jobs/index.module.css
+++ b/src/jobs/index.module.css
@@ -11,26 +11,6 @@
   }
 }
 
-.omVariant__title {
-  font-weight: bold;
-  margin: 1.8rem 0;
-  font-size: 3.3rem;
-
-  background: linear-gradient(
-    to right,
-    var(--color-primary),
-    var(--color-secondary1),
-    var(--color-secondary2)
-  );
-  background-size: 200% 200%;
-  background-clip: text;
-  transition: color 0.2s ease-in-out;
-  color: rgba(0, 0, 0, 0);
-}
-.omVariant__title[data-no-animation='true'] {
-  animation: none;
-}
-
 .omVariant__subTitle {
   font-size: 1.4rem;
   margin: 0 0 2.3rem 1.5rem;
@@ -90,6 +70,13 @@
 
 .job__listing__container:nth-child(2n) {
   background-color: var(--color-secondary3);
+}
+
+.job__title {
+  line-height: 1.3;
+  font-size: 1.5rem;
+  font-weight: normal;
+  margin-bottom: 0.5rem;
 }
 
 .aspect__ratio {

--- a/src/jobs/index.tsx
+++ b/src/jobs/index.tsx
@@ -10,6 +10,7 @@ import { colors } from '@variant/profile';
 import { and } from 'src/utils/css';
 import JobListingItem from './list-item';
 import { OfficeSelector } from 'src/office-selector';
+import PageTitle from '@components/page-title';
 
 const JobsIndex: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   listings,
@@ -47,7 +48,8 @@ const JobsIndex: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
           <title>Variant - Ledige stillinger</title>
         </Head>
         <section className={style.omVariant}>
-          <h2 className={style.omVariant__title}>Hva står vi for?</h2>
+          <PageTitle title="Bli en variant" />
+
           <article className={style.omVariant__wrapper}>
             <div className={style.omVariant__blob}>
               <BaseBlob
@@ -90,9 +92,9 @@ const JobsIndex: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
           </article>
         </section>
         <section className={style.job__listing}>
-          <h3 className={and(style.withSubTitle, 'fancy')}>
+          <h2 className={and(style.withSubTitle, 'fancy')}>
             Ledige stillinger
-          </h3>
+          </h2>
 
           <OfficeSelector
             currentOffice={office}

--- a/src/jobs/list-item.tsx
+++ b/src/jobs/list-item.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ButtonNextLink } from 'src/components/button';
+import { and } from 'src/utils/css';
 import style from './index.module.css';
 
 export type JobItem = {
@@ -14,7 +15,7 @@ export default function JobListingItem({ item }: JobListingItemProps) {
   return (
     <section className={style.job__listing__container}>
       <div>
-        <h4>{item.title}</h4>
+        <h3 className={and(style.job__title, 'fancy')}>{item.title}</h3>
         <span>{item.location}</span>
       </div>
       <ButtonNextLink href={`/jobs/${item.name}`}>

--- a/src/jobs/listing/listing.tsx
+++ b/src/jobs/listing/listing.tsx
@@ -10,120 +10,120 @@ import { ButtonLink } from 'src/components/button';
 import style from './listings.module.css';
 import { and } from 'src/utils/css';
 import { EmployeeItem } from 'src/employees/types';
+import PageTitle from '@components/page-title';
 
-const Listing: NextPage<
-  InferGetStaticPropsType<typeof getStaticProps>
-> = React.memo(({ listing }) => {
-  const innerHtml = useMemo(() => {
-    const md = new MarkdownIt({
-      linkify: true,
-      html: true,
-      typographer: true,
-    });
-    return { __html: md.render(listing.content) };
-  }, [listing.content]);
+const Listing: NextPage<InferGetStaticPropsType<typeof getStaticProps>> =
+  React.memo(({ listing }) => {
+    const innerHtml = useMemo(() => {
+      const md = new MarkdownIt({
+        linkify: true,
+        html: true,
+        typographer: true,
+      });
+      return { __html: md.render(listing.content) };
+    }, [listing.content]);
 
-  return (
-    <Layout title={`${listing.title} - ${listing.company_name}`}>
-      <Head>
-        <meta
-          property="og:url"
-          content={`https://www.variant.no/jobs/${listing.name}`}
-          key="og:url"
-        />
-        {listing.meta_title && (
+    return (
+      <Layout title={`${listing.title} - ${listing.company_name}`}>
+        <Head>
           <meta
-            property="og:title"
-            content={listing.meta_title}
-            key="og:title"
+            property="og:url"
+            content={`https://www.variant.no/jobs/${listing.name}`}
+            key="og:url"
           />
-        )}
-        {listing.meta_description && (
-          <>
+          {listing.meta_title && (
             <meta
-              name="description"
-              content={listing.meta_description}
-              key="description"
+              property="og:title"
+              content={listing.meta_title}
+              key="og:title"
             />
+          )}
+          {listing.meta_description && (
+            <>
+              <meta
+                name="description"
+                content={listing.meta_description}
+                key="description"
+              />
+              <meta
+                property="og:description"
+                content={listing.meta_description}
+                key="og:description"
+              />
+            </>
+          )}
+          {listing.meta_image && (
             <meta
-              property="og:description"
-              content={listing.meta_description}
-              key="og:description"
+              property="og:image"
+              content={listing.meta_image}
+              key="og:image"
             />
-          </>
-        )}
-        {listing.meta_image && (
-          <meta
-            property="og:image"
-            content={listing.meta_image}
-            key="og:image"
-          />
-        )}
-      </Head>
-      <section className={style.jobArticle}>
-        <div className={style.titleWrapper}>
-          <h2 className={style.jobArticle__title}>{listing.h1_title}</h2>
-          <div className={style.button__top}>
+          )}
+        </Head>
+        <section className={style.jobArticle}>
+          <div className={style.titleWrapper}>
+            <PageTitle title={listing.h1_title} />
+            <div className={style.button__top}>
+              <ButtonLink
+                href={listing.careers_apply_url ?? 'https://jobs.variant.no/'}
+              >
+                Søk på stillingen
+              </ButtonLink>
+            </div>
+          </div>
+          <div>
+            <article
+              className={style.rendered__markdown__wrapper}
+              dangerouslySetInnerHTML={innerHtml}
+            />
+            {!!listing.contacts.length && (
+              <div className={style.contacts__layout}>
+                {listing.contacts.map((c) => (
+                  <ContactTile key={c.email} contact={c} />
+                ))}
+              </div>
+            )}
+          </div>
+          <div className={style.button__bottom}>
             <ButtonLink
               href={listing.careers_apply_url ?? 'https://jobs.variant.no/'}
+              mode="primary"
             >
               Søk på stillingen
             </ButtonLink>
           </div>
-        </div>
-        <div>
-          <article
-            className={style.rendered__markdown__wrapper}
-            dangerouslySetInnerHTML={innerHtml}
-          />
-          {!!listing.contacts.length && (
-            <div className={style.contacts__layout}>
-              {listing.contacts.map((c) => (
-                <ContactTile key={c.email} contact={c} />
-              ))}
-            </div>
-          )}
-        </div>
-        <div className={style.button__bottom}>
-          <ButtonLink
-            href={listing.careers_apply_url ?? 'https://jobs.variant.no/'}
-            mode="primary"
-          >
-            Søk på stillingen
-          </ButtonLink>
-        </div>
-      </section>
-      <>
-        <svg height={0} width={0}>
-          <defs>
-            <path
-              id="blob1"
-              d="M205,355.2864986526615C248.7150970150467,350.80041339631816,282.01344382004675,322.4100717494572,312.29985923253014,290.56878236877077C348.03453998052447,252.9995192147581,394.76852528571646,214.67590934522775,387.5869487338381,163.3257204426926C380.014635332008,109.18165878655554,329.5087091111076,72.21709159678429,278.8776946654294,51.59138629779804C232.2092175370184,32.57991148257735,179.52865730619052,36.161082904203,135.4703774818946,60.62025114555632C94.41409617922676,83.41284531289631,73.8609713625924,126.9431683679426,61.52886001189853,172.25364853440013C48.297933884731954,220.86654204635448,34.925451154935786,276.1921460800724,66.00646251044944,315.8436473745453C97.26527953212276,355.7219836816004,154.59524114834886,360.459083433981,205,355.286498652661"
-            />
-            <path
-              id="blob2"
-              d="M225,392.6338598816929C284.9764927827312,391.55164306860047,350.25887890965123,401.1392634694311,392.64696961471276,358.6939969945104C439.6504937650968,311.6270714822181,459.10169838294456,239.74644281597477,441.83183448619616,175.50954873848067C425.19500811560096,113.62729768294105,370.9499690960947,67.7278685811003,309.51949094996144,49.493468615003124C257.5764576183983,34.075225524546966,207.75912938146752,64.73765226263988,161.02677160651086,92.15822243311086C120.76704396969669,115.78092711292703,88.16026359278979,146.5268705982898,70.50442838577555,189.73739395687718C47.10626747132736,247.00156565350048,12.11520036810903,315.66792180435,49.59087833421807,364.88410669569697C87.32143609615235,414.4350209858756,162.7294163076919,393.7574713085401,225,392.6338598816929"
-            />
-            <clipPath id="blobClip1" clipPathUnits="objectBoundingBox">
-              <use
-                xlinkHref="#blob1"
-                href="#blob1"
-                transform="scale(0.0024) translate(.5, .5)"
+        </section>
+        <>
+          <svg height={0} width={0}>
+            <defs>
+              <path
+                id="blob1"
+                d="M205,355.2864986526615C248.7150970150467,350.80041339631816,282.01344382004675,322.4100717494572,312.29985923253014,290.56878236877077C348.03453998052447,252.9995192147581,394.76852528571646,214.67590934522775,387.5869487338381,163.3257204426926C380.014635332008,109.18165878655554,329.5087091111076,72.21709159678429,278.8776946654294,51.59138629779804C232.2092175370184,32.57991148257735,179.52865730619052,36.161082904203,135.4703774818946,60.62025114555632C94.41409617922676,83.41284531289631,73.8609713625924,126.9431683679426,61.52886001189853,172.25364853440013C48.297933884731954,220.86654204635448,34.925451154935786,276.1921460800724,66.00646251044944,315.8436473745453C97.26527953212276,355.7219836816004,154.59524114834886,360.459083433981,205,355.286498652661"
               />
-            </clipPath>
-            <clipPath id="blobClip2" clipPathUnits="objectBoundingBox">
-              <use
-                xlinkHref="#blob2"
-                href="#blob2"
-                transform="scale(0.002) translate(-0, -0)"
+              <path
+                id="blob2"
+                d="M225,392.6338598816929C284.9764927827312,391.55164306860047,350.25887890965123,401.1392634694311,392.64696961471276,358.6939969945104C439.6504937650968,311.6270714822181,459.10169838294456,239.74644281597477,441.83183448619616,175.50954873848067C425.19500811560096,113.62729768294105,370.9499690960947,67.7278685811003,309.51949094996144,49.493468615003124C257.5764576183983,34.075225524546966,207.75912938146752,64.73765226263988,161.02677160651086,92.15822243311086C120.76704396969669,115.78092711292703,88.16026359278979,146.5268705982898,70.50442838577555,189.73739395687718C47.10626747132736,247.00156565350048,12.11520036810903,315.66792180435,49.59087833421807,364.88410669569697C87.32143609615235,414.4350209858756,162.7294163076919,393.7574713085401,225,392.6338598816929"
               />
-            </clipPath>
-          </defs>
-        </svg>
-      </>
-    </Layout>
-  );
-});
+              <clipPath id="blobClip1" clipPathUnits="objectBoundingBox">
+                <use
+                  xlinkHref="#blob1"
+                  href="#blob1"
+                  transform="scale(0.0024) translate(.5, .5)"
+                />
+              </clipPath>
+              <clipPath id="blobClip2" clipPathUnits="objectBoundingBox">
+                <use
+                  xlinkHref="#blob2"
+                  href="#blob2"
+                  transform="scale(0.002) translate(-0, -0)"
+                />
+              </clipPath>
+            </defs>
+          </svg>
+        </>
+      </Layout>
+    );
+  });
 
 export const ContactTile: React.FC<{ contact: EmployeeItem }> = ({
   contact: { fullName, name, email, telephone, imageUrl },

--- a/src/jobs/listing/listings.module.css
+++ b/src/jobs/listing/listings.module.css
@@ -15,23 +15,6 @@
   margin-bottom: 1rem;
 }
 
-.jobArticle__title {
-  margin: 1.8rem 0;
-  padding-right: 3rem;
-  font-weight: bold;
-
-  background: linear-gradient(
-    to right,
-    var(--color-primary),
-    var(--color-secondary1),
-    var(--color-secondary2)
-  );
-  background-size: 200% 200%;
-  background-clip: text;
-  transition: color 0.2s ease-in-out;
-  color: rgba(0, 0, 0, 0);
-}
-
 .button__bottom {
   grid-area: d;
   margin: 4rem 0 0;

--- a/src/jobs/pages/nyutdannet-designer-2022.md
+++ b/src/jobs/pages/nyutdannet-designer-2022.md
@@ -8,9 +8,7 @@ meta_description: Vi ser etter læreglade designere til å starte i fast jobb ho
 meta_image: https://www.variant.no/work_images/nyutdannet-meta-promo-1.jpg
 ---
 
-<br />
-
-### Hvem søker vi?
+## Hvem søker vi?
 
 Vi søker 1 nyutdannet designer som engasjerer og motiverer, med oppstart 1. august 2022 til vårt kontor i [Trondheim](https://handbook.variant.no/avdelinger/trondheim). Det er ikke viktig hvilke verktøy eller metodikk du bruker. Det er langt viktigere at du bryr deg. Bryr deg om brukeren du designer noe for og bryr deg om kunden du leverer til.
 
@@ -22,7 +20,7 @@ Vi søker 1 nyutdannet designer som engasjerer og motiverer, med oppstart 1. aug
 
 Gjennom både strukturert og impulsiv kunnskapsutveksling lærer vi av hverandre og de vi jobber med for å bli flinkere, modigere og rausere. Vi elsker utfordringer hvor design- og teknologikompetanse finner sammen og tar plass i kundens kultur. Her oppdager vi stadig at en helhetlig tilnærming til utvikling og design skaper entusiasme og tilfører ekstra verdi. Variant er et selskap av og for de ansatte, der læreglede står i sentrum. Deler du også denne filosofien?
 
-### Hvorfor jobbe i Variant?
+## Hvorfor jobbe i Variant?
 
 Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad](https://handbook.variant.no/handbook#form%C3%A5l-og-verdier). Disse verdiene ligger til grunn for hvordan vi møter hverandre og våre kunder. Vi er en gjeng dyktige [utviklere, designere og prosjektledere](https://www.variant.no/ansatte) som ønsker å både tilegne og dele kunnskap. Sammen skaper vi løsninger som tjener samfunnet. Hos oss er det din kompetanse og dine ønsker som påvirker våre neste oppdrag. Kundelisten vår endrer seg stadig, men for tiden bistår vi blant annet på disse prosjektene:
 
@@ -38,7 +36,7 @@ Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad]
 
 </div>
 
-### Hva kan vi tilby?
+## Hva kan vi tilby?
 
 Som nyutdannet konsulent i Variant blir du en del av utviklingsprogrammet vi kaller [Variant:skudd](https://handbook.variant.no/handbook#utviklingsprogram). Programmet er skreddersydd for deg som kommer rett fra skolen, og bidrar til at du raskt blir en skikkelig god konsulent. Samtidig tror vi at du lærer best ute i prosjekt, og det vil derfor ikke gå lang tid før du starter i oppdrag hos en av våre kunder. Du vil samarbeide med andre varianter, og få god [oppfølging](https://handbook.variant.no/quality_manual#personaloppf%C3%B8lging) underveis.
 
@@ -50,18 +48,18 @@ I Variant jobber vi for å være åpne og rause, og dette gjenspeiles blant anne
 
 </div>
 
-### Hva skjer etter at du har søkt?
+## Hva skjer etter at du har søkt?
 
 Alle søknader til fast jobb behandles fortløpende, og aktuelle kandidater inviteres like etterpå til det vi kaller [kaffeprat](https://handbook.variant.no/quality_manual#1-kaffeprat-%EF%B8%8F-30-min). Kaffepraten er en uformell samtale hvor vi finner ut om begge parter har felles verdier og mål. Og nei - du er selvsagt ikke nødt til å drikke kaffe. Dersom begge er interessert, fortsetter [ansettelsesprosessen](https://handbook.variant.no/quality_manual#ansettelse-og-jobbintervju). Her samarbeider vi først om å løse en avgrenset problemstilling, før sluttkandidatene inviteres til en forventningssamtale. Vi vil være sikre på at begge parter ønsker seg i samme retning, og gjennom en mer praktisk rettet samtale tilrettelegges det for å snakke litt mer sammen og avklare om vi er en match.
 
 Dersom du får jobbtilbud og takker ja, inkluderes du straks i Variant. Du får tilgang til vår Slack, og mulighet til å delta på alle faglige og [sosiale arrangementer](https://handbook.variant.no/quality_manual#sosiale-aktiviteter). Dette inkluderer blant annet spill- og fagkvelder, nyttårskalas og [variantdager](https://handbook.variant.no/handbook#variantdag), som er fine muligheter til å bli bedre kjent før oppstart i august.
 
-### Har du spørsmål?
+## Har du spørsmål?
 
 Vi håper du søker, og ser frem til å bli bedre kjent med deg. Har du spørsmål om jobben eller Variant?  
 Ta gjerne kontakt med meg.
 
-### Søknadsfrist
+## Søknadsfrist
 
 <p>
 27. mars 2022

--- a/src/jobs/pages/nyutdannet-designer-2023.md
+++ b/src/jobs/pages/nyutdannet-designer-2023.md
@@ -8,9 +8,7 @@ meta_description: Vi ser etter læreglade designere til å starte i fast jobb ho
 meta_image: https://www.variant.no/work_images/nyutdannet-meta-promo_2023.png
 ---
 
-<br />
-
-### Hvem søker vi?
+## Hvem søker vi?
 
 Vi søker nyutdannede designere som engasjerer og motiverer, med oppstart 1. august 2023 til våre kontorer i [Trondheim](https://handbook.variant.no/avdelinger/trondheim) og [Bergen](https://handbook.variant.no/avdelinger/bergen). Det er ikke viktig hvilke verktøy eller metodikk du bruker. Det er langt viktigere at du bryr deg. Bryr deg om brukeren du designer noe for og bryr deg om kunden du leverer til.
 
@@ -22,7 +20,7 @@ Vi søker nyutdannede designere som engasjerer og motiverer, med oppstart 1. aug
 
 Gjennom både strukturert og impulsiv kunnskapsutveksling lærer vi av hverandre og de vi jobber med for å bli flinkere, modigere og rausere. Vi elsker utfordringer hvor design- og teknologikompetanse finner sammen og tar plass i kundens kultur. Her oppdager vi stadig at en helhetlig tilnærming til utvikling og design skaper entusiasme og tilfører ekstra verdi. Variant er et selskap av og for de ansatte, der læreglede står i sentrum. Deler du også denne filosofien?
 
-### Hvorfor jobbe i Variant?
+## Hvorfor jobbe i Variant?
 
 Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad](https://handbook.variant.no/handbook#form%C3%A5l-og-verdier). Disse verdiene ligger til grunn for hvordan vi møter hverandre og våre kunder. Vi er en gjeng dyktige [utviklere, designere og prosjektledere](https://www.variant.no/ansatte) som ønsker å både tilegne og dele kunnskap. Sammen skaper vi løsninger som tjener samfunnet. Hos oss er det din kompetanse og dine ønsker som påvirker våre neste oppdrag. Kundelisten vår endrer seg stadig, men for tiden bistår vi blant annet på disse prosjektene:
 
@@ -38,7 +36,7 @@ Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad]
 
 </div>
 
-### Hva kan vi tilby?
+## Hva kan vi tilby?
 
 Som nyutdannet i Variant blir du en del av utviklingsprogrammet vi kaller [Variant:skudd](https://handbook.variant.no/handbook#utviklingsprogram). Programmet er skreddersydd for deg som kommer rett fra skolen, og bidrar til at du blir en trygg og god konsulent. En viktig del av programmet er Startskudd. En hel uke dedikert til å lære om Variant, konsulentvirket og andre nye (og gamle) Varianter bedre å kjenne. I 2022 gjennomførte vi Startskudd i idylliske omgivelser på Bjerkeløkkja på Oppdal, med fjelltur, kubb og øl-kurs som noen av aktivitetene som bidro til en god sosial ramme rundt det hele. Læreglede står sterkt, også i Variant:skudd. Likevel tror vi at du lærer best når du kommer ut i oppdrag, og vi jobber derfor for at du raskt skal komme ut og jobbe med våre kunder. Du vil samarbeide med andre varianter, og få god [oppfølging](https://handbook.variant.no/quality_manual#personaloppf%C3%B8lging) underveis. Selv om vi jobber ute hos mange ulike kunder på ulike oppdrag, så har du alltid tryggheten av å ha hele Variants fagmiljø i ryggen om du trenger noen å sparre med eller få hjelp.
 
@@ -52,19 +50,19 @@ I Variant jobber vi for å være åpne og rause, og dette gjenspeiles blant anne
 
 </div>
 
-### Hva skjer etter at du har søkt?
+## Hva skjer etter at du har søkt?
 
 Alle søknader behandles i hovedsak etter at søknadsfristen har utløpt, men send oss gjerne en e-post om du skulle ha behov for at vi ser på søknaden din før den tid. Etter søknadsfristens utløp inviteres aktuelle kandidater til det vi kaller [kaffeprat](https://handbook.variant.no/quality_manual#1-kaffeprat-%EF%B8%8F-30-min). Kaffepraten er en uformell samtale hvor vi finner ut om begge parter har felles verdier og mål. Og nei - du er selvsagt ikke nødt til å drikke kaffe. Dersom begge er interessert, fortsetter [ansettelsesprosessen](https://handbook.variant.no/quality_manual#ansettelse-og-jobbintervju). Her samarbeider vi først om å løse en avgrenset problemstilling, før sluttkandidatene inviteres til en forventningssamtale. Vi vil være sikre på at begge parter ønsker seg i samme retning, og gjennom en mer praktisk rettet samtale tilrettelegges det for å snakke litt mer sammen og avklare om vi er en match.
 
 Dersom du får jobbtilbud og takker ja, inkluderes du straks i Variant. Du får tilgang til vår Slack, og mulighet til å delta på alle faglige og [sosiale arrangementer](https://handbook.variant.no/quality_manual#sosiale-aktiviteter). Dette inkluderer blant annet spill- og fagkvelder, nyttårskalas og [variantdager](https://handbook.variant.no/handbook#variantdag), som er fine muligheter til å bli bedre kjent før oppstart i august.
 
-### Søknadsfrist
+## Søknadsfrist
 
 <p>
 2. oktober 2022
 </p>
 
-### Har du spørsmål?
+## Har du spørsmål?
 
 Vi håper du søker, og ser frem til å bli bedre kjent med deg. Har du spørsmål om jobben eller Variant?  
 Ta gjerne kontakt med meg.

--- a/src/jobs/pages/nyutdannet-utvikler-2022.md
+++ b/src/jobs/pages/nyutdannet-utvikler-2022.md
@@ -8,9 +8,7 @@ meta_description: Vi ser etter læreglade utviklere til å starte i fast jobb ho
 meta_image: https://www.variant.no/work_images/nyutdannet-meta-promo-2.jpg
 ---
 
-<br />
-
-### Hvem søker vi?
+## Hvem søker vi?
 
 Vi søker 2 nyutdannede utviklere som engasjerer og motiverer, med oppstart 1. august 2022 til vårt kontor i [Trondheim](https://handbook.variant.no/avdelinger/trondheim). Det er ikke viktig hvilke verktøy eller språk du bruker. Det er langt viktigere at du bryr deg. Bryr deg om koden du skriver og bryr deg om kunden du leverer til.
 
@@ -22,7 +20,7 @@ Vi søker 2 nyutdannede utviklere som engasjerer og motiverer, med oppstart 1. a
 
 Gjennom både strukturert og impulsiv kunnskapsutveksling lærer vi av hverandre og de vi jobber med for å bli flinkere, modigere og rausere. Vi elsker utfordringer hvor design- og teknologikompetanse finner sammen og tar plass i kundens kultur. Her oppdager vi stadig at en helhetlig tilnærming til utvikling og design skaper entusiasme og tilfører ekstra verdi. Variant er et selskap av og for de ansatte, der læreglede står i sentrum. Deler du også denne filosofien?
 
-### Hvorfor jobbe i Variant?
+## Hvorfor jobbe i Variant?
 
 Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad](https://handbook.variant.no/handbook#form%C3%A5l-og-verdier). Disse verdiene ligger til grunn for hvordan vi møter hverandre og våre kunder. Vi er en gjeng dyktige [utviklere, designere og prosjektledere](https://www.variant.no/ansatte) som ønsker å både tilegne og dele kunnskap. Sammen skaper vi løsninger som tjener samfunnet. Hos oss er det din kompetanse og dine ønsker som påvirker våre neste oppdrag. Kundelisten vår endrer seg stadig, men for tiden bistår vi blant annet på disse prosjektene:
 
@@ -38,7 +36,7 @@ Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad]
 
 </div>
 
-### Hva kan vi tilby?
+## Hva kan vi tilby?
 
 Som nyutdannet konsulent i Variant blir du en del av utviklingsprogrammet vi kaller [Variant:skudd](https://handbook.variant.no/handbook#utviklingsprogram). Programmet er skreddersydd for deg som kommer rett fra skolen, og bidrar til at du raskt blir en skikkelig god konsulent. En viktig del av programmet er Startskudd, ei hel uke dedikert til å lære Variant, konsulentvirket og andre nye (og gamle) Varianter bedre å kjenne. I 2022 gjennomførte vi Startskudd i idylliske omgivelser på Bjerkeløkkja på Oppdal, med fjelltur og kubb og øl-kurs som noen av aktivitetene som bidro til en god sosial ramme rundt hele. Læreglede står sterkt, også i Variant:skudd. Likevel tror vi at du lærer best ute i prosjekt, og det vil derfor ikke gå lang tid før du starter i oppdrag hos en av våre kunder. Du vil samarbeide med andre varianter, og få god [oppfølging](https://handbook.variant.no/quality_manual#personaloppf%C3%B8lging) underveis.
 
@@ -50,18 +48,18 @@ I Variant jobber vi for å være åpne og rause, og dette gjenspeiles blant anne
 
 </div>
 
-### Hva skjer etter at du har søkt?
+## Hva skjer etter at du har søkt?
 
 Alle søknader til fast jobb behandles fortløpende, og aktuelle kandidater inviteres like etterpå til det vi kaller [kaffeprat](https://handbook.variant.no/quality_manual#1-kaffeprat-%EF%B8%8F-30-min). Kaffepraten er en uformell samtale hvor vi finner ut om begge parter har felles verdier og mål. Og nei - du er selvsagt ikke nødt til å drikke kaffe. Dersom begge er interessert, fortsetter [ansettelsesprosessen](https://handbook.variant.no/quality_manual#ansettelse-og-jobbintervju). Her samarbeider vi først om å løse en avgrenset problemstilling, før sluttkandidatene inviteres til en forventningssamtale. Vi vil være sikre på at begge parter ønsker seg i samme retning, og gjennom en mer praktisk rettet samtale tilrettelegges det for å snakke litt mer sammen og avklare om vi er en match.
 
 Dersom du får jobbtilbud og takker ja, inkluderes du straks i Variant. Du får tilgang til vår Slack, og mulighet til å delta på alle faglige og [sosiale arrangementer](https://handbook.variant.no/quality_manual#sosiale-aktiviteter). Dette inkluderer blant annet spill- og fagkvelder, nyttårskalas og [variantdager](https://handbook.variant.no/handbook#variantdag), som er fine muligheter til å bli bedre kjent før oppstart i august.
 
-### Har du spørsmål?
+## Har du spørsmål?
 
 Vi håper du søker, og ser frem til å bli bedre kjent med deg. Har du spørsmål om jobben eller Variant?  
 Ta gjerne kontakt med meg.
 
-### Søknadsfrist
+## Søknadsfrist
 
 <p>
 27. mars 2022

--- a/src/jobs/pages/nyutdannet-utvikler-2023.md
+++ b/src/jobs/pages/nyutdannet-utvikler-2023.md
@@ -8,8 +8,6 @@ meta_description: Vi ser etter læreglade utviklere til å starte i fast jobb ho
 meta_image: https://www.variant.no/work_images/nyutdannet-meta-promo-2_2023.png
 ---
 
-<br />
-
 ## Hvem søker vi?
 
 Vi søker nyutdannede utviklere som engasjerer og motiverer, med oppstart 1. august 2023 til våre kontorer i [Trondheim](https://handbook.variant.no/avdelinger/trondheim) og [Bergen](https://handbook.variant.no/avdelinger/bergen). Det er ikke viktig hvilke verktøy eller språk du bruker. Det er langt viktigere at du bryr deg. Bryr deg om koden du skriver og bryr deg om kunden du leverer til.

--- a/src/jobs/pages/nyutdannet-utvikler-2023.md
+++ b/src/jobs/pages/nyutdannet-utvikler-2023.md
@@ -10,7 +10,7 @@ meta_image: https://www.variant.no/work_images/nyutdannet-meta-promo-2_2023.png
 
 <br />
 
-### Hvem søker vi?
+## Hvem søker vi?
 
 Vi søker nyutdannede utviklere som engasjerer og motiverer, med oppstart 1. august 2023 til våre kontorer i [Trondheim](https://handbook.variant.no/avdelinger/trondheim) og [Bergen](https://handbook.variant.no/avdelinger/bergen). Det er ikke viktig hvilke verktøy eller språk du bruker. Det er langt viktigere at du bryr deg. Bryr deg om koden du skriver og bryr deg om kunden du leverer til.
 
@@ -22,7 +22,7 @@ Vi søker nyutdannede utviklere som engasjerer og motiverer, med oppstart 1. aug
 
 Gjennom både strukturert og impulsiv kunnskapsutveksling lærer vi av hverandre og de vi jobber med for å bli flinkere, modigere og rausere. Vi elsker utfordringer hvor design- og teknologikompetanse finner sammen og tar plass i kundens kultur. Her oppdager vi stadig at en helhetlig tilnærming til utvikling og design skaper entusiasme og tilfører ekstra verdi. Variant er et selskap av og for de ansatte, der læreglede står i sentrum. Deler du også denne filosofien?
 
-### Hvorfor jobbe i Variant?
+## Hvorfor jobbe i Variant?
 
 Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad](https://handbook.variant.no/handbook#form%C3%A5l-og-verdier). Disse verdiene ligger til grunn for hvordan vi møter hverandre og våre kunder. Vi er en gjeng dyktige [utviklere, designere og prosjektledere](https://www.variant.no/ansatte) som ønsker å både tilegne og dele kunnskap. Sammen skaper vi løsninger som tjener samfunnet. Hos oss er det din kompetanse og dine ønsker som påvirker våre neste oppdrag. Kundelisten vår endrer seg stadig, men for tiden bistår vi blant annet på disse prosjektene:
 
@@ -38,7 +38,7 @@ Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad]
 
 </div>
 
-### Hva kan vi tilby?
+## Hva kan vi tilby?
 
 Som nyutdannet i Variant blir du en del av utviklingsprogrammet vi kaller [Variant:skudd](https://handbook.variant.no/handbook#utviklingsprogram). Programmet er skreddersydd for deg som kommer rett fra skolen, og bidrar til at du blir en trygg og god konsulent. En viktig del av programmet er Startskudd. En hel uke dedikert til å lære om Variant, konsulentvirket og andre nye (og gamle) Varianter bedre å kjenne. I 2022 gjennomførte vi Startskudd i idylliske omgivelser på Bjerkeløkkja på Oppdal, med fjelltur, kubb og øl-kurs som noen av aktivitetene som bidro til en god sosial ramme rundt det hele. Læreglede står sterkt, også i Variant:skudd. Likevel tror vi at du lærer best når du kommer ut i oppdrag, og vi jobber derfor for at du raskt skal komme ut og jobbe med våre kunder. Du vil samarbeide med andre varianter, og få god [oppfølging](https://handbook.variant.no/quality_manual#personaloppf%C3%B8lging) underveis. Selv om vi jobber ute hos mange ulike kunder på ulike oppdrag, så har du alltid tryggheten av å ha hele Variants fagmiljø i ryggen om du trenger noen å sparre med eller få hjelp.
 
@@ -52,18 +52,18 @@ I Variant jobber vi for å være åpne og rause, og dette gjenspeiles blant anne
 
 </div>
 
-### Hva skjer etter at du har søkt?
+## Hva skjer etter at du har søkt?
 
 Alle søknader til fast jobb behandles i hovedsak etter at søknadsfristen har utløpet, men send oss gjerne en e-post om du skulle ha behov for at vi ser på søknaden din før den tid. Etter søknadsfristens utløp inviteres aktuelle kandidater til det vi kaller [kaffeprat](https://handbook.variant.no/quality_manual#1-kaffeprat-%EF%B8%8F-30-min). Kaffepraten er en uformell samtale hvor vi finner ut om begge parter har felles verdier og mål. Og nei - du er selvsagt ikke nødt til å drikke kaffe. Dersom begge er interessert, fortsetter [ansettelsesprosessen](https://handbook.variant.no/quality_manual#ansettelse-og-jobbintervju). Her samarbeider vi først om å løse en avgrenset problemstilling, før sluttkandidatene inviteres til en forventningssamtale. Vi vil være sikre på at begge parter ønsker seg i samme retning, og gjennom en mer praktisk rettet samtale tilrettelegges det for å snakke litt mer sammen og avklare om vi er en match.
 
 Dersom du får jobbtilbud og takker ja, inkluderes du straks i Variant. Du får tilgang til vår Slack, og mulighet til å delta på alle faglige og [sosiale arrangementer](https://handbook.variant.no/quality_manual#sosiale-aktiviteter). Dette inkluderer blant annet spill- og fagkvelder, nyttårskalas og [variantdager](https://handbook.variant.no/handbook#variantdag), som er fine muligheter til å bli bedre kjent før oppstart i august.
 
-### Søknadsfrist
+## Søknadsfrist
 
 <p>
 2. oktober 2022
 </p>
 
-### Har du spørsmål?
+## Har du spørsmål?
 
 Vi håper du søker, og ser frem til å bli bedre kjent med deg. Har du spørsmål om jobben eller Variant? Ta gjerne kontakt med meg.

--- a/src/jobs/pages/sommerjobb-designer-2022.md
+++ b/src/jobs/pages/sommerjobb-designer-2022.md
@@ -8,9 +8,7 @@ meta_description: Vi ser etter læreglade designere til å ha sommerjobb hos oss
 meta_image: https://www.variant.no/images/sommerjobb_designer_2022_meta.jpg
 ---
 
-<br />
-
-### Hva går sommerjobben ut på?
+## Hva går sommerjobben ut på?
 
 En sommerjobb i Variant er en fin mulighet til å anvende det du har lært på skolen i praksis. Det forventes ikke at du er utlært, men at du ønsker å lære mer. Det viktigste er at du bryr deg. Bryr deg om brukeren du designer noe for og bryr deg om kunden du leverer til. I tverrfaglige team bestående av designere og utviklere kommer dere til å jobbe sammen på et av de spennende kundeprosjektene vi har. Underveis får du god oppfølging og tilrettelegging fra erfarne konsulenter som ønsker at du lykkes.
 
@@ -24,7 +22,7 @@ I 2022 tilbyr vi sommerjobb i både [Trondheim](https://handbook.variant.no/avde
 
 Årets sommervarianter var utleid til Oppdal Skisenter og Vital Things. Mathilde, Morten og Neva lagde et nytt system for administrasjon av skiheiser for Oppdal Skisenter. Her var de en del av produktet hele veien fra idèfase til implementasjon og brukertesting. Magnus og Adam jobbet med sensorteknologi hos Vital Things. Her fikk de bryne seg på et spennende domene innefor helseteknologi og lagde prototyper til Vital Things' videre produktutvikling.
 
-### Hvorfor jobbe i Variant?
+## Hvorfor jobbe i Variant?
 
 Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad](https://handbook.variant.no/handbook#form%C3%A5l-og-verdier). Disse verdiene ligger til grunn for hvordan vi møter hverandre og våre kunder. Vi er en gjeng hyggelige og dyktige [mennesker](https://www.variant.no/ansatte) som ønsker å både tilegne og dele kunnskap. Sammen skaper vi løsninger som tjener samfunnet.
 
@@ -36,7 +34,7 @@ I Variant har alle innsyn i alt - selv som sommerstudent. Derfor trenger du selv
 
 </div>
 
-### Hva skjer etter søknadsfristen?
+## Hva skjer etter søknadsfristen?
 
 Vi liker ikke tradisjonelle intervjuer. De plasserer søker i en unaturlig situasjon, og man blir ikke godt kjent med hverandre. Etter at vi har vurdert alle søknadene inviterer vi utvalgte kandidater til en uformell samtale. Dette er det vi kaller [kaffeprat](https://handbook.variant.no/quality_manual#1-kaffeprat-%EF%B8%8F-30-min). Hensikten med samtalen er å finne ut om begge parter har felles verdier og mål. Og nei – du er selvsagt ikke nødt til å drikke kaffe.
 
@@ -48,16 +46,16 @@ Dersom du får jobbtilbud og takker ja, inkluderes du straks i Variant på lik l
 
 </div>
 
-### Hva ser vi etter i en søknad?
+## Hva ser vi etter i en søknad?
 
 Vi setter pris på en søknad med CV, motivasjonsbrev og karakterutskrift. Det viktigste for oss er å få et helhetlig bilde. Både av deg som person, din eksisterende kompetanse og dine ambisjoner. Så hvem er du og hvorfor søker du sommerjobb i Variant? Vi trenger mennesker som bryr seg om å skape en bedre hverdag. Er det deg?
 
-### Har du spørsmål?
+## Har du spørsmål?
 
 Vi håper du søker, og ser frem til å bli bedre kjent med deg. Har du spørsmål om jobben eller Variant?
 Ta gjerne kontakt med meg.
 
-### Søknadsfrist
+## Søknadsfrist
 
 <p>
 3. oktober 2021

--- a/src/jobs/pages/sommerjobb-designer-2023.md
+++ b/src/jobs/pages/sommerjobb-designer-2023.md
@@ -8,7 +8,7 @@ meta_description: Vi ser etter læreglade designere til å ha sommerjobb hos oss
 meta_image: https://www.variant.no/images/sommerjobb_designer_2023_meta.png
 ---
 
-### Hva går sommerjobben ut på?
+## Hva går sommerjobben ut på?
 
 En sommerjobb i Variant er en fin mulighet til å anvende det du har lært på skolen i praksis. Det forventes ikke at du er utlært, men at du ønsker å lære mer. Det viktigste er at du bryr deg. Bryr deg om brukerne du designer for, bryr deg om kunden du leverer til og bryr deg om dine medstudenter og kollegaer.
 
@@ -23,7 +23,7 @@ Vi har tro på at både kunder og sluttbrukere får det beste resultatet når vi
 
 Årets sommervarianter fikk blant annet bryne seg på tjenestekartlegging for Opplev Oppdal, bookingtjeneste for Inatur, oppfølging av fiskehelse for Piscada og digital støtte av trafikksikkerhetsinspeksjoner i Statens vegvesen.
 
-### Hvorfor jobbe i Variant?
+## Hvorfor jobbe i Variant?
 
 Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad](https://handbook.variant.no/handbook#form%C3%A5l-og-verdier). Disse verdiene ligger til grunn for hvordan vi møter hverandre og våre kunder. Vi er en gjeng hyggelige og dyktige [mennesker](https://www.variant.no/ansatte) som ønsker å både tilegne og dele kunnskap. Sammen skaper vi løsninger som tjener samfunnet.
 
@@ -37,13 +37,13 @@ Sommerjobben varer i fire + to uker med tre uker ferie i mellom, og vil gi god i
 
 I Variant har alle innsyn i alt - selv som sommerstudent. Derfor trenger du selvsagt ikke å lure på hvordan [kontrakten din](https://avtaler.variant.no/avtaler/ansettelse-sommerjobb.html) vil se ut for sommeren. Lønna trenger du heller ikke å lure på. Du får 271.83 kr (eller 100e) for hver time, slik at du havner rett under fribeløpet! Dersom du har lyst til å lese mer om hva Variant står for kan du sjekke ut vår egen [håndbok](https://handbook.variant.no/).
 
-### Hva skjer etter søknadsfristen?
+## Hva skjer etter søknadsfristen?
 
 Vi liker ikke tradisjonelle intervjuer. De plasserer søker i en unaturlig situasjon, og man blir ikke godt kjent med hverandre. Etter at vi har vurdert alle søknadene inviterer vi derfor utvalgte kandidater til en uformell samtale. Dette er det vi kaller [kaffeprat](https://handbook.variant.no/quality_manual#1-kaffeprat-%EF%B8%8F-30-min). Hensikten med samtalen er å finne ut om begge parter har felles verdier og mål. Og nei – du er selvsagt ikke nødt til å drikke kaffe.
 
 Dersom du får jobbtilbud og takker ja, inkluderes du straks i Variant på lik linje med de fast ansatte. Du får tilgang til vår Slack, og mulighet til å delta på alle faglige og [sosiale arrangementer](https://handbook.variant.no/quality_manual#sosiale-aktiviteter). Dette inkluderer blant annet spill- og fagkvelder, nyttårskalas og [variantdager](https://handbook.variant.no/handbook#variantdag), som er fine muligheter til å bli bedre kjent før sommerjobben starter i juni.
 
-### Hvordan ser alt dette ut i kalendertid?
+## Hvordan ser alt dette ut i kalendertid?
 
 </br>
 
@@ -60,18 +60,18 @@ I 2023 vil første arbeidsperiode være fra 12. juni - 7. juli (4 uker). Andre a
 
 </div>
 
-### Hva ser vi etter i en søknad?
+## Hva ser vi etter i en søknad?
 
 Vi setter pris på en søknad med CV, motivasjonsbrev og karakterutskrift. Det viktigste for oss er å få et helhetlig bilde. Både av deg som person, din eksisterende kompetanse og dine ambisjoner. Så hvem er du og hvorfor søker du sommerjobb i Variant? Vi ser etter mennesker som bryr seg om å skape en bedre hverdag.
 
 Du bestemmer selv hvor du vil søke, men vi er ærlige på at vi håper at sommerjobben kan være første skritt mot å bli en fast Variant. Da kan det være lurt å tenke gjennom hvor du kan se for deg å slå røtter etter studiet. I sommerjobben har du nemlig muligheten til å bli kjent med folk som kan bli dine nærmeste kollegaer etter endt studie, og sommerjobben er like mye for at du også skal kjenne på om Variant er et sted du føler deg komfortabel og hjemme.
 
-### Søknadsfrist
+## Søknadsfrist
 
 <p>
 2. oktober 2022
 </p>
 
-### Har du spørsmål?
+## Har du spørsmål?
 
 Vi håper du søker, og ser frem til å bli bedre kjent med deg. Har du spørsmål om jobben eller Variant? Ta gjerne kontakt med meg.

--- a/src/jobs/pages/sommerjobb-utvikler-2022.md
+++ b/src/jobs/pages/sommerjobb-utvikler-2022.md
@@ -8,9 +8,7 @@ meta_description: Vi ser etter læreglade utviklere til å ha sommerjobb hos oss
 meta_image: https://www.variant.no/images/sommerjobb_utvikler_2022_meta.jpg
 ---
 
-<br/>
-
-### Hva går sommerjobben ut på?
+## Hva går sommerjobben ut på?
 
 En sommerjobb i Variant er en fin mulighet til å anvende det du har lært på skolen i praksis. Det forventes ikke at du er utlært, men at du ønsker å lære mer. Det viktigste er at du bryr deg. Bryr deg om koden du skriver og bryr deg om kunden du leverer til. I tverrfaglige team bestående av utviklere og designere kommer dere til å jobbe sammen på et av de spennende kundeprosjektene vi har. Underveis får du god oppfølging og tilrettelegging fra erfarne konsulenter som ønsker at du lykkes.
 
@@ -24,7 +22,7 @@ I 2022 tilbyr vi sommerjobb i både [Trondheim](https://handbook.variant.no/avde
 
 Årets sommervarianter var utleid til Oppdal Skisenter og Vital Things. Mathilde, Morten og Neva lagde et nytt system for administrasjon av skiheiser for Oppdal Skisenter. Her var de en del av produktet hele veien fra idèfase til implementasjon og brukertesting. Magnus og Adam jobbet med sensorteknologi hos Vital Things. Her fikk de bryne seg på et spennende domene innefor helseteknologi og lagde prototyper til Vital Things' videre produktutvikling.
 
-### Hvorfor jobbe i Variant?
+## Hvorfor jobbe i Variant?
 
 Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad](https://handbook.variant.no/handbook#form%C3%A5l-og-verdier). Disse verdiene ligger til grunn for hvordan vi møter hverandre og våre kunder. Vi er en gjeng hyggelige og dyktige [mennesker](https://www.variant.no/ansatte) som ønsker å både tilegne og dele kunnskap. Sammen skaper vi løsninger som tjener samfunnet.
 
@@ -36,7 +34,7 @@ I Variant har alle innsyn i alt - selv som sommerstudent. Derfor trenger du selv
 
 </div>
 
-### Hva skjer etter søknadsfristen?
+## Hva skjer etter søknadsfristen?
 
 Vi liker ikke tradisjonelle intervjuer. De plasserer søker i en unaturlig situasjon, og man blir ikke godt kjent med hverandre. Etter at vi har vurdert alle søknadene inviterer vi utvalgte kandidater til en uformell samtale. Dette er det vi kaller [kaffeprat](https://handbook.variant.no/quality_manual#1-kaffeprat-%EF%B8%8F-30-min). Hensikten med samtalen er å finne ut om begge parter har felles verdier og mål. Og nei – du er selvsagt ikke nødt til å drikke kaffe.
 
@@ -48,16 +46,16 @@ Dersom du får jobbtilbud og takker ja, inkluderes du straks i Variant på lik l
 
 </div>
 
-### Hva ser vi etter i en søknad?
+## Hva ser vi etter i en søknad?
 
 Vi setter pris på en søknad med CV, motivasjonsbrev og karakterutskrift. Det viktigste for oss er å få et helhetlig bilde. Både av deg som person, din eksisterende kompetanse og dine ambisjoner. Så hvem er du og hvorfor søker du sommerjobb i Variant? Vi trenger mennesker som bryr seg om å skape en bedre hverdag. Er det deg?
 
-### Har du spørsmål?
+## Har du spørsmål?
 
 Vi håper du søker, og ser frem til å bli bedre kjent med deg. Har du spørsmål om jobben eller Variant?
 Ta gjerne kontakt med meg.
 
-### Søknadsfrist
+## Søknadsfrist
 
 <p>
 3. oktober 2021

--- a/src/jobs/pages/sommerjobb-utvikler-2023.md
+++ b/src/jobs/pages/sommerjobb-utvikler-2023.md
@@ -8,7 +8,7 @@ meta_description: Vi ser etter læreglade utviklere til å ha sommerjobb hos oss
 meta_image: https://www.variant.no/images/sommerjobb_utvikler_2023_meta.png
 ---
 
-### Hva går sommerjobben ut på?
+## Hva går sommerjobben ut på?
 
 En sommerjobb i Variant er en fin mulighet til å anvende det du har lært på skolen i praksis. Det forventes ikke at du er utlært, men at du ønsker å lære mer. Det viktigste er at du bryr deg. Bryr deg om koden du skriver, bryr deg om kunden du leverer til og bryr deg om dine medstudenter og kollegaer.
 
@@ -23,7 +23,7 @@ Vi har tro på at både kunder og sluttbrukere får det beste resultatet når vi
 
 Årets sommervarianter fikk blant annet bryne seg på bookingtjeneste for Inatur, oppfølging av fiskehelse for Piscada og digital støtte av trafikksikkerhetsinspeksjoner i Statens vegvesen.
 
-### Hvorfor jobbe i Variant?
+## Hvorfor jobbe i Variant?
 
 Variant er en variant av et konsulentselskap som er [raust, åpent og læreglad](https://handbook.variant.no/handbook#form%C3%A5l-og-verdier). Disse verdiene ligger til grunn for hvordan vi møter hverandre og våre kunder. Vi er en gjeng hyggelige og dyktige [mennesker](https://www.variant.no/ansatte) som ønsker å både tilegne og dele kunnskap. Sammen skaper vi løsninger som tjener samfunnet.
 
@@ -37,13 +37,13 @@ I Variant har alle innsyn i alt - selv som sommerstudent. Derfor trenger du selv
 
 </div>
 
-### Hva skjer etter søknadsfristen?
+## Hva skjer etter søknadsfristen?
 
 Vi liker ikke tradisjonelle intervjuer. De plasserer søker i en unaturlig situasjon, og man blir ikke godt kjent med hverandre. Etter at vi har vurdert alle søknadene inviterer vi derfor utvalgte kandidater til en uformell samtale. Dette er det vi kaller [kaffeprat](https://handbook.variant.no/quality_manual#1-kaffeprat-%EF%B8%8F-30-min). Hensikten med samtalen er å finne ut om begge parter har felles verdier og mål. Og nei – du er selvsagt ikke nødt til å drikke kaffe.
 
 Dersom du får jobbtilbud og takker ja, inkluderes du straks i Variant på lik linje med de fast ansatte. Du får tilgang til vår Slack, og mulighet til å delta på alle faglige og [sosiale arrangementer](https://handbook.variant.no/quality_manual#sosiale-aktiviteter). Dette inkluderer blant annet spill- og fagkvelder, nyttårskalas og [variantdager](https://handbook.variant.no/handbook#variantdag), som er fine muligheter til å bli bedre kjent før sommerjobben starter i juni.
 
-### Hvordan ser alt dette ut i kalendertid?
+## Hvordan ser alt dette ut i kalendertid?
 
 </br>
 
@@ -60,18 +60,18 @@ I 2023 vil første arbeidsperiode være fra 12. juni - 7. juli (4 uker). Andre a
 
 </div>
 
-### Hva ser vi etter i en søknad?
+## Hva ser vi etter i en søknad?
 
 Vi setter pris på en søknad med CV, motivasjonsbrev og karakterutskrift. Det viktigste for oss er å få et helhetlig bilde. Både av deg som person, din eksisterende kompetanse og dine ambisjoner. Så hvem er du og hvorfor søker du sommerjobb i Variant? Vi ser etter mennesker som bryr seg om å skape en bedre hverdag.
 
 Du bestemmer selv hvor du vil søke, men vi er ærlige på at vi håper at sommerjobben kan være første skritt mot å bli en fast Variant. Da kan det være lurt å tenke gjennom hvor du kan se for deg å slå røtter etter studiet. I sommerjobben har du nemlig muligheten til å bli kjent med folk som kan bli dine nærmeste kollegaer etter endt studie, og sommerjobben er like mye for at du også skal kjenne på om Variant er et sted du føler deg komfortabel og hjemme.
 
-### Søknadsfrist
+## Søknadsfrist
 
 <p>
 2. oktober 2022
 </p>
 
-### Har du spørsmål?
+## Har du spørsmål?
 
 Vi håper du søker, og ser frem til å bli bedre kjent med deg. Har du spørsmål om jobben eller Variant? Ta gjerne kontakt med meg.

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -12,6 +12,7 @@ type LayoutProps = {
   title?: string;
   fullWidth?: boolean;
   crazy?: boolean;
+  homepage?: boolean;
   zenMode?: boolean;
 };
 
@@ -20,6 +21,7 @@ const Layout: React.FC<LayoutProps> = ({
   title = 'Variant – En variant av et konsulentselskap',
   fullWidth = false,
   crazy = false,
+  homepage = false,
   zenMode = false,
 }) => {
   const modalRef = React.createRef<HTMLDivElement>();
@@ -69,13 +71,27 @@ const Layout: React.FC<LayoutProps> = ({
         )}
       >
         <header className={style.header}>
-          <h1 className={style.header__logo}>
-            <Link href="/">
-              <a>
-                <img src={require('./variant.svg')} alt="Variant" />
-              </a>
-            </Link>
-          </h1>
+          {homepage ? (
+            <h1 className={style.header__logo}>
+              <Link href="/">
+                <a>
+                  <img src={require('./variant.svg')} alt="Variant" />
+                </a>
+              </Link>
+            </h1>
+          ) : (
+            <div className={style.header__logo}>
+              <Link href="/">
+                <a>
+                  <img
+                    src={require('./variant.svg')}
+                    alt="Variant"
+                    aria-label="Variant startside"
+                  />
+                </a>
+              </Link>
+            </div>
+          )}
 
           {!zenMode && (
             <>
@@ -274,8 +290,7 @@ const Layout: React.FC<LayoutProps> = ({
               >
                 Spaces Vaskerelven
               </a>{' '}
-              i Bergen. Kom innom for en kopp kaffe eller bare en hyggelig
-              prat.
+              i Bergen. Kom innom for en kopp kaffe eller bare en hyggelig prat.
             </p>
           </div>
         </div>
@@ -298,7 +313,8 @@ const Layout: React.FC<LayoutProps> = ({
             <address>
               <strong>Variant Oslo AS</strong>
               <br />
-              Tollbugata 24<br />
+              Tollbugata 24
+              <br />
               0157 Oslo
             </address>
           </div>

--- a/src/rss/feed/feed.module.css
+++ b/src/rss/feed/feed.module.css
@@ -8,9 +8,6 @@
   }
 }
 
-.feed__title {
-  margin-bottom: 1rem;
-}
 .feed__head {
   max-width: 30rem;
   margin: 4.8rem auto 1rem;

--- a/src/rss/feed/index.tsx
+++ b/src/rss/feed/index.tsx
@@ -1,8 +1,8 @@
+import PageTitle from '@components/page-title';
 import Layout from 'src/layout';
 import List from 'src/rss/feed/List';
 import { FeedInput } from 'src/rss/rss';
 import { chronologicalFeedList, MediaItem } from 'src/rss/service';
-import { and } from 'src/utils/css';
 import style from './feed.module.css';
 
 interface FeedProps {
@@ -14,7 +14,7 @@ export default function RSSFeed({ items }: FeedProps) {
     <Layout>
       <div className={style.feed}>
         <div className={style.feed__head}>
-          <h2 className={and(style.feed__title, 'fancy')}>Meninger og sånn</h2>
+          <PageTitle title="Meninger og sånn" />
           <p>
             Du har funnet feeden vår! Her har vi samlet det siste vi har gjort
             av{' '}

--- a/src/salary-calculator/index.module.css
+++ b/src/salary-calculator/index.module.css
@@ -77,6 +77,7 @@
 .title {
   margin: 2.4rem 0 1.2rem;
   hyphens: auto;
+  font-size: 3.4rem;
 }
 
 .graduation {

--- a/src/salary-calculator/index.tsx
+++ b/src/salary-calculator/index.tsx
@@ -101,7 +101,7 @@ export const Calculator = (props: Props) => {
         </div>
 
         <fieldset className={style.contentContainer}>
-          <h2 className={style.title}>Lønnskalkulator</h2>
+          <h1 className={style.title}>Lønnskalkulator</h1>
 
           <p>
             Vil du vite hva du vil tjene hos oss? Svar på to enkle spørsmål:
@@ -112,9 +112,9 @@ export const Calculator = (props: Props) => {
             role="group"
             aria-labelledby="degree-title"
           >
-            <h3 className={style.question} id="degree-title">
+            <h2 className={style.question} id="degree-title">
               Hvilken grad har eller får du?
-            </h3>
+            </h2>
 
             <RadioButton
               changed={setDegree}
@@ -135,9 +135,9 @@ export const Calculator = (props: Props) => {
             />
           </div>
 
-          <h3 className={style.question}>
+          <h2 className={style.question}>
             Når ble eller blir du ferdig med graden?
-          </h3>
+          </h2>
           <div className={style.barSliderContainer}>
             <button
               onClick={decrementYear}
@@ -167,7 +167,7 @@ export const Calculator = (props: Props) => {
 
           <footer className={style.summary}>
             <div className={style.calculation}>
-              <h3 className={style.question}>Da blir lønnen din sånn:</h3>
+              <h2 className={style.question}>Da blir lønnen din sånn:</h2>
 
               <dl>
                 {!!props.addition && (

--- a/src/vidsyn/index.tsx
+++ b/src/vidsyn/index.tsx
@@ -1,3 +1,4 @@
+import PageTitle from '@components/page-title';
 import Head from 'next/head';
 import Layout from 'src/layout';
 import { and } from 'src/utils/css';
@@ -13,7 +14,7 @@ export default function Invitation() {
         <section className={style.omVariant}>
           <header>
             <p className={style.supertitle}>Velkommen til </p>
-            <h1 className={style.omVariant__title}>Vidsyn 22</h1>
+            <PageTitle title="Vidsyn 22" />
             <p className={style.subtitle}>Retrospektiv og perspektiv!</p>
           </header>
           <div>

--- a/src/vidsyn/index.tsx
+++ b/src/vidsyn/index.tsx
@@ -4,163 +4,198 @@ import { and } from 'src/utils/css';
 import style from './vidsyn.module.css';
 
 export default function Invitation() {
-    return (
-        <Layout>
-            <div>
-                <Head>
-                    <title>Vidsyn 22</title>
-                </Head>
-                <section className={style.omVariant}>
-                    <header>
-                        <p className={style.supertitle}>Velkommen til </p>
-                        <h2 className={style.omVariant__title}>Vidsyn 22</h2>
-                        <p className={style.subtitle}>Retrospektiv og perspektiv!</p>
-                    </header>
-                    <div>
-                        <img
-                            className={and(style.right_image, style.image)}
-                            src="/images/vidsyn.png"
-                            alt="Oversiktssbilde over et landskap"
-                            />
-                        
-                        <p>
-                            Det er med stor glede vi inviterer til Variants årlige ledersamling Vidsyn. Ved jevne
-                            mellomrom har vi behov for å stoppe opp, løfte blikket og tenke lengre og bredere tanker.
-                            Vidsyn defineres som en åpen og fordomsfri innstilling. Som en tenkemåte preget av
-                            bredde i erfaringer, kunnskaper. Dette er målet med samlingen.
-                        </p>
-                        <p>
-                            Vidsyn inngår i Variants ledelsessyklus, og er en felles samling på konsernnivå, hvor
-                            ledelsen i alle selskaper sammen med konsernets ledelse samles. De enkelte selskapene har
-                            utover dette egne ledersamlinger med fokus på sitt selskap.
-                        </p>
-                        <p>
-                            Denne gangen legger vi vekt på tre hovedområder. Det ene, <strong>retrospektiv</strong>, handler om å lære 
-                            av våre første levemåneder som et konsern med kontor i flere byer. Det andre 
-                            er <strong>forretningsmodell</strong> hvor vi prøver å se på hvordan våre ulike strategier henger sammen, 
-                            og om vi kan utvikle nye tjenesteområder eller forbedre de eksisterende. Det siste området 
-                            er <strong>perspektiv</strong>. Her prøver vi å løfte blikket enda lenger fram, ja helt til 2028. 
-                        </p>
+  return (
+    <Layout>
+      <div>
+        <Head>
+          <title>Vidsyn 22</title>
+        </Head>
+        <section className={style.omVariant}>
+          <header>
+            <p className={style.supertitle}>Velkommen til </p>
+            <h1 className={style.omVariant__title}>Vidsyn 22</h1>
+            <p className={style.subtitle}>Retrospektiv og perspektiv!</p>
+          </header>
+          <div>
+            <img
+              className={and(style.right_image, style.image)}
+              src="/images/vidsyn.png"
+              alt="Oversiktssbilde over et landskap"
+            />
 
-                    </div>
+            <p>
+              Det er med stor glede vi inviterer til Variants årlige
+              ledersamling Vidsyn. Ved jevne mellomrom har vi behov for å stoppe
+              opp, løfte blikket og tenke lengre og bredere tanker. Vidsyn
+              defineres som en åpen og fordomsfri innstilling. Som en tenkemåte
+              preget av bredde i erfaringer, kunnskaper. Dette er målet med
+              samlingen.
+            </p>
+            <p>
+              Vidsyn inngår i Variants ledelsessyklus, og er en felles samling
+              på konsernnivå, hvor ledelsen i alle selskaper sammen med
+              konsernets ledelse samles. De enkelte selskapene har utover dette
+              egne ledersamlinger med fokus på sitt selskap.
+            </p>
+            <p>
+              Denne gangen legger vi vekt på tre hovedområder. Det ene,{' '}
+              <strong>retrospektiv</strong>, handler om å lære av våre første
+              levemåneder som et konsern med kontor i flere byer. Det andre er{' '}
+              <strong>forretningsmodell</strong> hvor vi prøver å se på hvordan
+              våre ulike strategier henger sammen, og om vi kan utvikle nye
+              tjenesteområder eller forbedre de eksisterende. Det siste området
+              er <strong>perspektiv</strong>. Her prøver vi å løfte blikket enda
+              lenger fram, ja helt til 2028.
+            </p>
+          </div>
 
-                    <div>
-                        <h3 className="fancy">Tidsplan 28. februar - 1. mars</h3>
-                        Mandag 28. februar
-                        <ul className={style.agenda}>
-                            <li>
-                                <span className={style.time}> 09.00-12.00</span> 👀 Retrospektiv
-                            </li>
-                            <li>
-                                <span className={style.time}> 12.00-13.00</span> 🥙 Lunsj
-                            </li>
-                            <li>
-                                <span className={style.time}> 13.00-17.00</span> 🏦 Forretningsmodell og tjenesteområder
-                            </li>
-                            <li>
-                                <span className={style.time}> 18.00-19.00</span> 🌺 Flower shower
-                            </li>
-                            <li>
-                                <span className={style.time}> 19.00-23.30</span> 🍽 Middag
-                            </li>
-                        </ul>
-                        Tirsdag 20. april
-                        <ul className={style.agenda}>
-                            <li>
-                                <span className={style.time}> 07.00-08.00</span> 🍳 Frokost
-                            </li>
-                            <li>
-                                <span className={style.time}> 08.00-09.00</span> 🙋🏻 Min rollemodell
-                            </li>
-                            <li>
-                                <span className={style.time}> 09.00-11.30</span> 🧑🏻‍🔧 Tjenesteområder
-                            </li>
-                            <li>
-                                <span className={style.time}> 11.30-12.30</span> 🥪 Lunsj
-                            </li>
-                            <li>
-                                <span className={style.time}> 12.30-15.300</span> 🌍 Perspektiv
-                            </li>
-                        </ul>
-                    </div>
-                    <div >
-                        <h3 className="fancy">Retrospektiv, nåtid og perspektiv</h3>
-                        <div className={style.agendaDetails}>
-                                <p className={style.agendaItem} > Retrospektive</p>
-                                <p className={style.topic}>Samspillet mellom konsernet, Trondheim og Oslo. 
-                                    Hva fungerer bra, og hva kan bli bedre? Hvilke læringsmomenter er det viktig å ta med 
-                                    nå som vi etablerer i Bergen?</p> 
-                                <p className={style.initiator}>Fasilitering <strong>Tore</strong></p>
+          <div>
+            <h2 className="fancy">Tidsplan 28. februar - 1. mars</h2>
+            Mandag 28. februar
+            <ul className={style.agenda}>
+              <li>
+                <span className={style.time}> 09.00-12.00</span> 👀 Retrospektiv
+              </li>
+              <li>
+                <span className={style.time}> 12.00-13.00</span> 🥙 Lunsj
+              </li>
+              <li>
+                <span className={style.time}> 13.00-17.00</span> 🏦
+                Forretningsmodell og tjenesteområder
+              </li>
+              <li>
+                <span className={style.time}> 18.00-19.00</span> 🌺 Flower
+                shower
+              </li>
+              <li>
+                <span className={style.time}> 19.00-23.30</span> 🍽 Middag
+              </li>
+            </ul>
+            Tirsdag 20. april
+            <ul className={style.agenda}>
+              <li>
+                <span className={style.time}> 07.00-08.00</span> 🍳 Frokost
+              </li>
+              <li>
+                <span className={style.time}> 08.00-09.00</span> 🙋🏻 Min
+                rollemodell
+              </li>
+              <li>
+                <span className={style.time}> 09.00-11.30</span> 🧑🏻‍🔧
+                Tjenesteområder
+              </li>
+              <li>
+                <span className={style.time}> 11.30-12.30</span> 🥪 Lunsj
+              </li>
+              <li>
+                <span className={style.time}> 12.30-15.300</span> 🌍 Perspektiv
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h2 className="fancy">Retrospektiv, nåtid og perspektiv</h2>
+            <div className={style.agendaDetails}>
+              <p className={style.agendaItem}> Retrospektive</p>
+              <p className={style.topic}>
+                Samspillet mellom konsernet, Trondheim og Oslo. Hva fungerer
+                bra, og hva kan bli bedre? Hvilke læringsmomenter er det viktig
+                å ta med nå som vi etablerer i Bergen?
+              </p>
+              <p className={style.initiator}>
+                Fasilitering <strong>Tore</strong>
+              </p>
 
-                                <p className={style.agendaItem} > Forretningsmodell</p>
-                                <p className={style.topic}>Hvordan henger vår forretningsmodell sammen? 
-                                Hvordan og hvor godt passer våre ulike strategier med vår forretningsmodell. Harmonerer våre strategier, og 
-                                har vi gode måter å styre etter disse strategiene. 
-                                </p>
-                                <p className={style.initiator}>Innledning <strong>Odd Morten</strong></p>
+              <p className={style.agendaItem}> Forretningsmodell</p>
+              <p className={style.topic}>
+                Hvordan henger vår forretningsmodell sammen? Hvordan og hvor
+                godt passer våre ulike strategier med vår forretningsmodell.
+                Harmonerer våre strategier, og har vi gode måter å styre etter
+                disse strategiene.
+              </p>
+              <p className={style.initiator}>
+                Innledning <strong>Odd Morten</strong>
+              </p>
 
-                                <p className={style.agendaItem}>Tjenesteområder</p>
-                                <p className={style.topic}>Hvilke tjenesteområder har vi i dag? 
-                                Hvor godt treffe de kunder og ansatte? Finnes det andre områder? Det er ønskelig at vi kommer fram til 
-                                flere ambisjoner på konsernnivå, som de ulike driftsselskapene velge blant for å jobbe mot.  </p>
-                                <p className={style.initiator}>Innledning <strong>Anders</strong> </p>
+              <p className={style.agendaItem}>Tjenesteområder</p>
+              <p className={style.topic}>
+                Hvilke tjenesteområder har vi i dag? Hvor godt treffe de kunder
+                og ansatte? Finnes det andre områder? Det er ønskelig at vi
+                kommer fram til flere ambisjoner på konsernnivå, som de ulike
+                driftsselskapene velge blant for å jobbe mot.{' '}
+              </p>
+              <p className={style.initiator}>
+                Innledning <strong>Anders</strong>{' '}
+              </p>
 
-                                <p className={style.agendaItem}>Min rollemodell</p>
-                                <p className={style.topic}> Dette er noen øvelser som går på å utvikle oss som 
-                                    ledergruppe, som ledere og som team. <br/> <strong>NB! her er det forberedsler:</strong>  <i>Lag 
-                                    en 2 minutters pitch om en person du har i livet ditt, har hatt eller en kjent person, 
-                                        som du ser opp til og som du kan kalle en rollemodell for deg. 
-                                        Du velger selv hvilket format du presenterer i, men det er 
-                                        viktig at vi alle holder oss til 2 minutter per person. 
-                                        Si ifra til Linn om noen lurer på noe rundt oppgaven :)</i></p>
-                                <p className={style.initiator}>Fasilitering <strong>Linn</strong> </p>
-                                
-                                <p className={style.agendaItem}>Perspektiv</p>
-                                <p className={style.topic}>Hva skjer med Variant Utland? 
-                                Hvordan ser vårt fjellkart ut nå? Hvile småtopper har vi foran oss? Hvilke vekstambisjoner har vi og hvorfor?
-                                Perspektiv 2028 - i 2028 er vi 10 år. Skal vi fortsatt sponse langrennslaget? Hvordan ser vi ut da? 
-                                Kan vi i dag skrive en framtidig pressemelding?</p>
-                                <p className={style.initiator}>Innledning <strong>Anders</strong> og <strong>Odd Morten</strong> </p>
-                         </div>
-                    
-                        
+              <p className={style.agendaItem}>Min rollemodell</p>
+              <p className={style.topic}>
+                {' '}
+                Dette er noen øvelser som går på å utvikle oss som ledergruppe,
+                som ledere og som team. <br />{' '}
+                <strong>NB! her er det forberedsler:</strong>{' '}
+                <i>
+                  Lag en 2 minutters pitch om en person du har i livet ditt, har
+                  hatt eller en kjent person, som du ser opp til og som du kan
+                  kalle en rollemodell for deg. Du velger selv hvilket format du
+                  presenterer i, men det er viktig at vi alle holder oss til 2
+                  minutter per person. Si ifra til Linn om noen lurer på noe
+                  rundt oppgaven :)
+                </i>
+              </p>
+              <p className={style.initiator}>
+                Fasilitering <strong>Linn</strong>{' '}
+              </p>
 
-
-                    </div>
-
-                    <div>
-                        <h4 >Middag</h4>
-                        <p>
-                            Med dagens vidsyn som bakteppe spiser vi en bedre middag. Sammen med sosialt samvær og
-                            mulighet til å bli bedre kjent på tvers av kontor, er målet at en annen setting og 
-                            nytt fysisk perspektiv gir diskusjonene tidligere på dagen en ny dimensjon.
-                        </p>
-                    </div>
-
-                    <div>
-                        <h3 className="fancy">Lysebu</h3>
-                        <img
-                            className={and(style.right_image, style.image)}
-                            src="/images/lysebu.png"
-                            alt="Lysebu i vinterdrakt"
-                            />
-                        <p>
-                            Vidsyn 22 holdes på  <a href="https://lysebu.no/">Lysebu</a>.
-                            Lysebus historie er tuftet på verdier som generøsitet, takknemlighet 
-                            og omtanke. Disse verdiene sitter i veggene og inspirerer oss hver eneste dag.
-
-                        </p>
-                        <p>                            
-                        Under andre verdenskrig samlet det danske folk inn store summer for å sende mat til 
-                        Norge. Det ble delt ut flere tusentalls matpakker over hele landet - Norgeshjelpen sendte 
-                        daglig hele 22 tonn matvarer fra Danmark til Norge under krigen. I 1945 stod det igjen 13 
-                        millioner kroner fra. Disse pengene la grunnlaget for Fondet for dansk- norsk samarbeid. 
-                        Som takk for hjelpen under krigen, ga Norge Lysebu i gave til Fondet.
-
-                        </p>
-                    </div>
-                </section>
+              <p className={style.agendaItem}>Perspektiv</p>
+              <p className={style.topic}>
+                Hva skjer med Variant Utland? Hvordan ser vårt fjellkart ut nå?
+                Hvile småtopper har vi foran oss? Hvilke vekstambisjoner har vi
+                og hvorfor? Perspektiv 2028 - i 2028 er vi 10 år. Skal vi
+                fortsatt sponse langrennslaget? Hvordan ser vi ut da? Kan vi i
+                dag skrive en framtidig pressemelding?
+              </p>
+              <p className={style.initiator}>
+                Innledning <strong>Anders</strong> og{' '}
+                <strong>Odd Morten</strong>{' '}
+              </p>
             </div>
-        </Layout>
-    );
+          </div>
+
+          <div>
+            <h3>Middag</h3>
+            <p>
+              Med dagens vidsyn som bakteppe spiser vi en bedre middag. Sammen
+              med sosialt samvær og mulighet til å bli bedre kjent på tvers av
+              kontor, er målet at en annen setting og nytt fysisk perspektiv gir
+              diskusjonene tidligere på dagen en ny dimensjon.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="fancy">Lysebu</h2>
+            <img
+              className={and(style.right_image, style.image)}
+              src="/images/lysebu.png"
+              alt="Lysebu i vinterdrakt"
+            />
+            <p>
+              Vidsyn 22 holdes på <a href="https://lysebu.no/">Lysebu</a>.
+              Lysebus historie er tuftet på verdier som generøsitet,
+              takknemlighet og omtanke. Disse verdiene sitter i veggene og
+              inspirerer oss hver eneste dag.
+            </p>
+            <p>
+              Under andre verdenskrig samlet det danske folk inn store summer
+              for å sende mat til Norge. Det ble delt ut flere tusentalls
+              matpakker over hele landet - Norgeshjelpen sendte daglig hele 22
+              tonn matvarer fra Danmark til Norge under krigen. I 1945 stod det
+              igjen 13 millioner kroner fra. Disse pengene la grunnlaget for
+              Fondet for dansk- norsk samarbeid. Som takk for hjelpen under
+              krigen, ga Norge Lysebu i gave til Fondet.
+            </p>
+          </div>
+        </section>
+      </div>
+    </Layout>
+  );
 }

--- a/src/vidsyn/vidsyn.module.css
+++ b/src/vidsyn/vidsyn.module.css
@@ -11,26 +11,6 @@
   }
 }
 
-.omVariant__title {
-  font-weight: bold;
-  margin: 1.8rem 0;
-  font-size: 3.3rem;
-
-  background: linear-gradient(
-    to right,
-    var(--color-primary),
-    var(--color-secondary1),
-    var(--color-secondary2)
-  );
-  background-size: 200% 200%;
-  background-clip: text;
-  transition: color 0.2s ease-in-out;
-  color: rgba(0, 0, 0, 0);
-}
-.omVariant__title[data-no-animation='true'] {
-  animation: none;
-}
-
 .time {
   display: inline-block;
   width: 12rem;


### PR DESCRIPTION
Etter samtaler her: https://github.com/varianter/variant.no/pull/260#discussion_r959463484 begynte jeg å se litt over hvordan overskriftene var rundt omkring på variant.no. Nå er det litt inkonsekvent hvor det i enkelte steder blir brukt h1 2 ganger på en side.

Denne rydder opp i det og setter på konsekvent bruk:

1. På hovedsiden er h1 "Variant startside" (logo)
2. På undersider er det side-overskriften som er h1.
3. Forhåpentligvis ryddet opp i rett hierarki overalt.

Dette har noen konsekvenser for sizing her og der, men jeg tror i hovedsak det har blitt mer konsekvent. F.eks anelse større overskrift på mangfold (cc @Lotta-Linn @itzjacki )

Hvor det er verdt å sjekke over:

- Jobbannonser (spesielt nyutdanna)
- Ansattoversikten (her har jeg og lagt til egne overskrifter som er mer beskrivende)