### PR TITLE
fix: simplifies calculator for start salary

### DIFF
--- a/src/advanced-calculator/config.ts
+++ b/src/advanced-calculator/config.ts
@@ -12,8 +12,15 @@ export type PayscaleSingleYear = {
   [experienceYear: string]: string;
 };
 
+export type Degree = 'masters' | 'bachelor';
+
 export type HistoricalPayscaleData = {
   [payscaleYear: string]: PayscaleSingleYear;
+};
+
+export const startSalery: Record<Degree, number> = {
+  bachelor: 560000,
+  masters: 590000,
 };
 
 export const payscale = {

--- a/src/summersplash2022/nyutdannet/sections/lonn.tsx
+++ b/src/summersplash2022/nyutdannet/sections/lonn.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import style from 'src/summersplash2022/nyutdannet/nyutdannet.module.css';
 import PinkBlob from '../img/pinkBlob';
 import Calculator from '../utils/calculator';
@@ -21,10 +22,12 @@ const Payment = () => {
             antall års erfaring.
           </p>
           <p>
-            {' '}
-            I kalkulatoren til høyre kan du se hva du vil tjene ut ifra grad og
-            avgangsår. Du kan også ta en titt på denne siden om du vil vite mer
-            om lønn og andre goder i Variant.
+            I kalkulatoren til høyre kan du se hva du vil tjene som nyutdannet.
+            Du kan også ta en titt på{' '}
+            <Link href="/kalkulator">
+              <a>lønnskalkulatoren</a>
+            </Link>{' '}
+            om du vil vite mer om lønn og andre goder i Variant.
           </p>
         </div>
         <div className={style.calculator}>

--- a/src/summersplash2022/nyutdannet/utils/calculator.tsx
+++ b/src/summersplash2022/nyutdannet/utils/calculator.tsx
@@ -1,56 +1,19 @@
 import { useEffect, useState } from 'react';
-import Counter from 'src/advanced-calculator/Counter';
-import { firstDayOfTheYear } from 'src/advanced-calculator/helpers/daysUntilNewSalary';
-import { getAverageBonus } from 'src/advanced-calculator/helpers/getHistoricBonus';
-import getPayscale from 'src/advanced-calculator/helpers/getPayscale';
-import {
-  formatCurrencyFromNumber,
-  getMaxYear,
-} from 'src/advanced-calculator/helpers/utils';
 import style from 'src/advanced-calculator/calculator.module.css';
+import { Degree, startSalery } from 'src/advanced-calculator/config';
+import Counter from 'src/advanced-calculator/Counter';
+import { getAverageBonus } from 'src/advanced-calculator/helpers/getHistoricBonus';
+import { formatCurrencyFromNumber } from 'src/advanced-calculator/helpers/utils';
 
 const Calculator = () => {
-  const [selectedYear, setSelectedYear] = useState(2021);
-  const [selectedValidYear, setSelectedValidYear] = useState(2021);
-  const [degree, setDegree] = useState('bachelor');
-  const year = selectedValidYear + (degree === 'bachelor' ? 1 : 0);
-  const payscale = getPayscale(year);
-
-  const MIN_YEAR = 1990;
-  const MAX_YEAR = getMaxYear();
-
-  const DEGREE: { [key: string]: string } = {
-    bachelor: 'bachelor',
-    master: 'master',
-  };
+  const [degree, setDegree] = useState<Degree>('masters');
+  const totalSalary = startSalery[degree];
 
   const [isMobile, setIsMobile] = useState(false);
 
-  const yearsOfExperience =
-    firstDayOfTheYear(MAX_YEAR).getFullYear() - selectedValidYear;
-
-  const totalExperience =
-    yearsOfExperience === 0
-      ? `Nyutdannet ${DEGREE[degree]}`
-      : `${yearsOfExperience} år + ${DEGREE[degree]}`;
-
-  function isValidYear(year: number) {
-    return MIN_YEAR <= year && year <= MAX_YEAR;
-  }
-
   function onDegreeChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const value = event.target.value;
+    const value = event.target.value as Degree;
     setDegree(value);
-  }
-
-  function handleOnChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const value = event.target.value;
-    if (value) onSelectedYearChange(parseInt(value, 10));
-  }
-
-  function onSelectedYearChange(value: number) {
-    setSelectedYear(value);
-    if (isValidYear(value)) setSelectedValidYear(value);
   }
 
   const handleResize = () => {
@@ -102,6 +65,7 @@ const Calculator = () => {
                 id="Bachelor"
                 name="education"
                 value="bachelor"
+                checked={degree == 'bachelor'}
                 onChange={onDegreeChange}
                 defaultChecked
               />
@@ -120,7 +84,8 @@ const Calculator = () => {
                 type="radio"
                 id="Master"
                 name="education"
-                value="master"
+                value="masters"
+                checked={degree == 'masters'}
                 onChange={onDegreeChange}
               />
               <label id="masterLabel" htmlFor="Master">
@@ -128,71 +93,6 @@ const Calculator = () => {
               </label>
             </div>
           </div>
-          <label htmlFor="experience" className={style['form-row']}>
-            <div className={style['form-label']}>
-              Når ble eller blir du ferdig med studiene?
-            </div>
-
-            <div className={style['range-input-wrapper']}>
-              <div
-                style={{ backgroundColor: '#FFDCD7' }}
-                className={style['range-input']}
-              >
-                <input
-                  aria-label={`range slider for ${'experience'} ${'År'}`}
-                  type="range"
-                  name={'År'}
-                  className={style.inputRange}
-                  min={MIN_YEAR}
-                  max={2023}
-                  value={selectedYear}
-                  step={1}
-                  onChange={handleOnChange}
-                  /* onBlur={handleOnBlur} */
-                  disabled={false}
-                />
-              </div>
-              <input
-                aria-label={`number input for ${'experience'} ${'År'}`}
-                id={'experience'}
-                className={style.inputNumber}
-                name={'År'}
-                type="number"
-                size={MAX_YEAR.toString().length}
-                maxLength={MAX_YEAR.toString().length}
-                min={MIN_YEAR}
-                max={MAX_YEAR}
-                value={selectedYear}
-                onChange={handleOnChange}
-                /* onBlur={handleOnBlur} */
-                disabled={false}
-              />
-            </div>
-            <span
-              className={style['form-error']}
-              style={
-                isValidYear(selectedYear)
-                  ? { opacity: 0, height: 0 }
-                  : {
-                      opacity: 1,
-                      backgroundColor: '#FFF3F2',
-                      padding: '5%',
-                    }
-              }
-            >
-              Årslønnen for nyutdannede i 2023 oppdateres basert på Teknas
-              lønnsstatistikk for 2022, som tilgjengeliggjøres i november.{' '}
-            </span>
-          </label>
-        </div>
-        <div
-          style={{ marginTop: '5%' }}
-          className={style['calculator-controls__label']}
-        >
-          Vi baserer lønn på erfaring
-        </div>
-        <div className={style['calculator-controls__value']}>
-          {totalExperience}
         </div>
       </div>
 
@@ -201,10 +101,7 @@ const Calculator = () => {
           Det vil gi en årslønn på
         </div>
         <div className={style['calculator-controls__value']}>
-          <Counter
-            num={payscale.current}
-            formatter={formatCurrencyFromNumber}
-          />
+          <Counter num={totalSalary} formatter={formatCurrencyFromNumber} />
         </div>
       </div>
 
@@ -214,7 +111,7 @@ const Calculator = () => {
         </div>
         <div className={style['calculator-controls__value']}>
           <Counter
-            num={payscale.current + getAverageBonus()}
+            num={totalSalary + getAverageBonus()}
             formatter={formatCurrencyFromNumber}
           />
         </div>
@@ -226,7 +123,7 @@ const Calculator = () => {
         </div>
         <div className={style['calculator-controls__value']}>
           <Counter
-            num={payscale.current * 0.07}
+            num={totalSalary * 0.07}
             formatter={formatCurrencyFromNumber}
           />
         </div>


### PR DESCRIPTION
Forenkler kalkulatoren for nyutdannet på student takeover. Trenger ikke se lønn for andre år da vi vet de er nyutdannet. Tall er basert på det @Krakels nevnte tidligere. Oppdaterte tekst til å reflektere endringer og lenke til full lønnskalkulator.

<img width="1099" alt="Screenshot 2022-09-05 at 20 35 22" src="https://user-images.githubusercontent.com/606374/188501019-576bb129-eab9-4c3d-8d90-1cc082692198.png">
<img width="1136" alt="Screenshot 2022-09-05 at 20 35 17" src="https://user-images.githubusercontent.com/606374/188501024-3fc1aab2-e109-4ae8-9664-3473ddb35df7.png">
