### PR TITLE
fix: overflow scroll phone menu

### DIFF
--- a/src/summersplash2022/Content.tsx
+++ b/src/summersplash2022/Content.tsx
@@ -48,9 +48,9 @@ const Content = () => {
       <div className={style.scrollContainer} id="scrollContainer">
         <div>
           <section className={style.section1} id="forside">
-            <header className={style.header}>
+            <div className={style.header}>
               <Header white={false} />
-            </header>
+            </div>
             <span className={style.searchNewVariants}>
               <h3 className={style.bigHeading}>
                 Vi ser etter 14 sommervarianter i 2023!{' '}

--- a/src/summersplash2022/components/header/header.tsx
+++ b/src/summersplash2022/components/header/header.tsx
@@ -262,9 +262,9 @@ function useTogglableBurgerMenu<
 
     // Avoid scrolling when menu is visible.
     if (isMenuVisible) {
-      document.body.style.overflow = 'hidden';
+      document.body.classList.add('body-hidden');
     } else {
-      document.body.style.overflow = 'initial';
+      document.body.classList.remove('body-hidden');
     }
   }, [isMenuVisible, isNotHamburgerMode]);
 

--- a/src/summersplash2022/index.module.css
+++ b/src/summersplash2022/index.module.css
@@ -25,6 +25,10 @@
   scroll-behavior: smooth;
 }
 
+:global(.body-hidden) .scrollContainer {
+  overflow-y: hidden;
+}
+
 .section1,
 .section2,
 .section3,

--- a/src/summersplash2022/nyutdannet/nyutdannet.module.css
+++ b/src/summersplash2022/nyutdannet/nyutdannet.module.css
@@ -23,6 +23,10 @@
   scroll-behavior: smooth;
 }
 
+:global(.body-hidden) .scrollContainer {
+  overflow-y: hidden;
+}
+
 /* global var */
 :root {
   /* Heading */

--- a/src/summersplash2022/nyutdannet/sections/forside.tsx
+++ b/src/summersplash2022/nyutdannet/sections/forside.tsx
@@ -9,9 +9,9 @@ const LandingPage = () => {
   return (
     <>
       <section className={style.section1} id="jobForside">
-        <header className={style.header}>
+        <div className={style.header}>
           <Header white={true} />
-        </header>
+        </div>
         <span className={style.searchNewVariants}>
           <h3 className={style.bigHeading}>
             Vi ser etter 7 nyutdannede varianter i 2023!{' '}


### PR DESCRIPTION
Det er ikke pent eller elegant, men det funker for nå og for en måned som vi skal ha dette. Setter `overflow: hidden` på rett element (som har overflow scroll fra før).