### PR TITLE
fix: apply minor changes that fix css issues

### DIFF
--- a/src/components/decorative-boxes/style.module.css
+++ b/src/components/decorative-boxes/style.module.css
@@ -1,5 +1,4 @@
 .main-container {
-  padding: 8%;
   position: relative;
   height: fit-content;
   max-height: 100%;
@@ -21,6 +20,7 @@
 }
 
 .child-container {
+  padding: 8%;
   display: grid;
   place-items: center;
 }

--- a/src/index/index.module.css
+++ b/src/index/index.module.css
@@ -83,6 +83,10 @@
   font-size: 1.5rem;
 }
 
+.join {
+  margin: 0 1rem;
+}
+
 .join_title {
   text-align: center;
   margin: 2rem auto;
@@ -112,7 +116,6 @@
 
 @media (max-width: 500px) {
   .join {
-    margin: 0 1rem;
     text-align: center;
   }
   .join > p {
@@ -179,9 +182,9 @@
 }
 .cases__case {
   display: grid;
-  gap: 2rem 2rem;
+  gap: 2rem;
   padding: 2rem 0;
-  grid-template-columns: minmax(20rem, 2fr) minmax(23rem, 1fr);
+  grid-template-columns: minmax(15rem, 2fr) minmax(20rem, 1fr);
 }
 @media (max-width: 600px) {
   .cases__case {
@@ -213,7 +216,7 @@
   position: relative;
   z-index: 2;
 
-  margin: 8.25rem 0 4.25rem;
+  margin: 8.25rem 1rem 4.25rem;
 }
 
 .employees a {


### PR DESCRIPTION
Hadde litt ekstra tid så fikk sett på noen bittesmå css issues som har plaga meg på forsida. Changelist:

- Padding rundt bilder i decorative boxes (plassen utenfor bildene, der kun boksene er synlig) var basert på fraksjon av bredden til parent element (oops), nå skal det være basert på komponentens egen bredde. Har ikke noe særlig effekt i praksis de stedene boksene brukes nå, men ser for meg at det kan hindre frustrasjon og debuggingstid i framtida.
- Justerte minmax-verdier på case-list ("variantarbeid") på forsida. På bredder rett over mobil-breakpointet overflowa teksten utover kanten av siden, da min-verdiene var litt høye. Nå er min-verdiene så lave at overflow ikke blir et problem før vi har gått over i mobilmodus, og da brukes ikke disse verdiene uansett.
![image](https://user-images.githubusercontent.com/31799931/188815793-7663ba1e-e596-409e-bca3-4247f079d105.png)
- La inn 1 rem horizontal padding på "Bli en Variant!"-bolken og elementet som viser fram en tilfeldig ansatt (begge på forsida). De manglet dette i desktop mode, men skal nå matche resten av forsida i at innholdet ikke går _helt_ ut til kanten.

Husk at forsida nå ligger på `/original`, dersom man vil inn og se på changesa mine.