### PR TITLE
add temporary calculator link for splash

### DIFF
--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -164,6 +164,11 @@ const Layout: React.FC<LayoutProps> = ({
                       <a tabIndex={tabIndex}>Alle varianter</a>
                     </Link>
                   </li>
+                  <li>
+                    <Link href="/kalkulator">
+                      <a tabIndex={tabIndex}>Lønnskalkulator</a>
+                    </Link>
+                  </li>
                   <li id="dont_show">
                     <a
                       href="https://twitter.com/intent/tweet?screen_name=variant_as"

--- a/src/layout/layout.module.css
+++ b/src/layout/layout.module.css
@@ -19,7 +19,7 @@
 .header {
   display: flex;
   flex-wrap: wrap;
-  padding-right: 7.4rem;
+  /* padding-right: 7.4rem Commented out when adding temporary calculator url */
   max-width: 50rem;
   margin: 0 auto;
 }

--- a/src/summersplash2022/components/header/header.tsx
+++ b/src/summersplash2022/components/header/header.tsx
@@ -117,6 +117,11 @@ const Header = (props: { white: boolean }) => {
                       <a tabIndex={tabIndex}>Alle varianter</a>
                     </Link>
                   </li>
+                  <li>
+                    <Link href="/kalkulator">
+                      <a tabIndex={tabIndex}>Lønnskalkulator</a>
+                    </Link>
+                  </li>
                   <li id="dont_show">
                     <a
                       href="https://twitter.com/intent/tweet?screen_name=variant_as"
@@ -220,6 +225,11 @@ const Header = (props: { white: boolean }) => {
                   <li>
                     <Link href="/ansatte">
                       <a tabIndex={tabIndex}>Alle varianter</a>
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/kalkulator">
+                      <a tabIndex={tabIndex}>Lønnskalkulator</a>
                     </Link>
                   </li>
                   <li id="dont_show">

--- a/src/summersplash2022/components/header/headerBlack.module.css
+++ b/src/summersplash2022/components/header/headerBlack.module.css
@@ -20,7 +20,7 @@
 .header {
   display: flex;
   flex-wrap: wrap;
-  padding-right: 7.4rem;
+  /* padding-right: 7.4rem Commented out when adding temporary calculator url */
   max-width: 50rem;
   margin: 0 auto;
 }


### PR DESCRIPTION
Adds calculator url while summersplash exists, must be removed manually if we want that afterwards.

<img width="1444" alt="image" src="https://user-images.githubusercontent.com/21310942/192746223-9ba3f543-c9cd-47b5-807a-d89e06378a42.png">

<img width="653" alt="image" src="https://user-images.githubusercontent.com/21310942/192746284-1530c0ed-3732-46d3-9b62-d1620486bc91.png">
