### PR TITLE
42tte/feat perf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 80

--- a/next.config.js
+++ b/next.config.js
@@ -22,6 +22,7 @@ module.exports = withPlugins([withImages], {
       'img.youtube.com', // this
       'cdn-images-1.medium.com', // aaaaand this
     ],
+    formats: ['image/avif', 'image/webp'],
   },
 
   webpack: (config) => {

--- a/src/index/index.module.css
+++ b/src/index/index.module.css
@@ -334,7 +334,8 @@
 }
 
 .infoBlock__blob {
-  width: 60%;
+  --info-block__blob-width: 60%;
+  min-width: var(--info-block__blob-width);
 }
 
 @media (max-width: 650px) {
@@ -344,7 +345,7 @@
   }
 
   .infoBlock__blob {
-    width: 100%;
+    --info-block__blob-width: 100%;
   }
 
   .infoBlock__title {

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -366,11 +366,16 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
 function JobLandingpage() {
   return (
     <div className={style.infoBlock}>
-      <img
-        className={style.infoBlock__blob}
-        src={sommerjobbImg}
-        alt="Varianter under felles variantdag"
-      />
+      <div className={style.infoBlock__blob}>
+        <Image
+          src={sommerjobbImg}
+          alt="Varianter under felles variantdag"
+          width={774}
+          height={631}
+          loading="lazy"
+          decoding="async"
+        />
+      </div>
 
       <h2 className={style.infoBlock__title}>
         <Link href="/nyutdannet">

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -54,7 +54,12 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
             position: index % 2 === 1 ? 'bottom-middle' : 'bottom-left',
           }}
         >
-          <img src={caseItem.case_image} alt={caseItem.image_alt} />
+          <img
+              src={caseItem.case_image}
+              alt={caseItem.image_alt}
+              loading="lazy"
+              decoding="async"
+          />
         </DecorativeBoxes>
       </article>
     ));
@@ -85,12 +90,16 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
           className={style.omVariant_image1}
           src={require('./images/om-variant-1.png')}
           alt="Bilde av Kristin som sitter i en sofa"
+          loading="lazy"
+          decoding="async"
         />
 
         <img
           className={style.omVariant_image2}
           src={require('./images/om-variant-2.png')}
           alt="Bilde av Tonje og Odd Morten som sitter forran gamle Digs"
+          loading="lazy"
+          decoding="async"
         />
 
         <div className={style.omVariant__us}>
@@ -157,6 +166,8 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
             className={style.join_map}
             src={require('./images/blob-map.svg')}
             alt="Kart som viser hvor alle kontorene våre ligger"
+            loading="lazy"
+            decoding="async"
           />
         </div>
       </section>
@@ -166,6 +177,8 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
           className={style.services_image1}
           src={require('./images/bli-en-variant.png')}
           alt="Bilde av gladfisen Jacob"
+          loading="lazy"
+          decoding="async"
         />
 
         <article>
@@ -253,6 +266,8 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
             <img
               src="/images/tenk-sarah-marius.png"
               alt="Sarah og Marius som hjelper til med podcastlaging på TENK tech camp"
+              loading="lazy"
+              decoding="async"
             />
           </DecorativeBoxes>
         </article>
@@ -284,6 +299,8 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
             <img
               src="/images/lyttere-i-amfiet-500px.png"
               alt="personer i amfiet på Varianthuset lytter til en presentasjon"
+              loading="lazy"
+              decoding="async"
             />
           </DecorativeBoxes>
         </article>
@@ -328,6 +345,7 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
                 alt={`Bilde av ${randomEmployee.name}`}
                 src={randomEmployee.imageUrl}
                 loading="lazy"
+                decoding="async"
               />
             </div>
 

--- a/src/rss/feed/Blog.tsx
+++ b/src/rss/feed/Blog.tsx
@@ -17,6 +17,8 @@ export default function Blog({ item }: { item: BlogItem }) {
               src: item.imageCoverUrl,
               alt: '',
               className: style.cover,
+              loading: 'lazy',
+              decoding: 'async',
             }}
           />
         )}
@@ -44,7 +46,12 @@ export default function Blog({ item }: { item: BlogItem }) {
         </p>
         <div className={style.card__link}>
           <a href={item.url}>Les artikkel</a>
-          <img src="/images/arrow.svg" alt="Pil mot høyre" />
+          <img
+            src="/images/arrow.svg"
+            alt="Pil mot høyre"
+            loading="lazy"
+            decoding="async"
+          />
         </div>
       </div>
     </div>

--- a/src/rss/feed/Podcast.tsx
+++ b/src/rss/feed/Podcast.tsx
@@ -18,6 +18,8 @@ export default function Podcast({ item }: { item: PodcastItem }) {
             src: item.imageCoverUrl,
             alt: '',
             className: style.cover,
+            loading: 'lazy',
+            decoding: 'async',
           }}
         />
       </div>

--- a/src/rss/feed/YouTube.tsx
+++ b/src/rss/feed/YouTube.tsx
@@ -16,6 +16,8 @@ export default function YouTube({ item }: { item: YoutubeVideoItem }) {
             src: '/logo-512.png',
             alt: '',
             className: style.cover,
+            loading: 'lazy',
+            decoding: 'async',
           }}
         />
       </figure>
@@ -40,7 +42,12 @@ export default function YouTube({ item }: { item: YoutubeVideoItem }) {
         </p>
         <div className={style.card__link}>
           <a href={item.url}>Se video</a>
-          <img src="/images/arrow.svg" alt="Pil mot høyre" />
+          <img
+            src="/images/arrow.svg"
+            alt="Pil mot høyre"
+            loading="lazy"
+            decoding="async"
+          />
         </div>
       </div>
     </div>

--- a/src/summersplash2022/landingpage.module.css
+++ b/src/summersplash2022/landingpage.module.css
@@ -10,7 +10,8 @@
 }
 
 .infoBlock__blob {
-  width: 60%;
+  --info-block__blob-width: 60%;
+  min-width: var(--info-block__blob-width);
 }
 
 @media (max-width: 650px) {
@@ -20,7 +21,7 @@
   }
 
   .infoBlock__blob {
-    width: 100%;
+    --info-block__blob-width: 100%;
   }
 
   .infoBlock__title {


### PR DESCRIPTION
[feat(perf): lazy load images on home page](https://github.com/varianter/variant.no/commit/69228dcae4cb8f6fe3d44e759ee73196906de48f)
[feat(perf): use optimized image formats](https://github.com/varianter/variant.no/commit/c0c053a10d1d05a6c2fa0d31915108de98f22258)

**Before**
Initial load 6.3MB
<img width="890" alt="Screenshot 2022-10-12 at 10 02 03" src="https://user-images.githubusercontent.com/8436510/195286385-7a30332e-5d9e-451c-af79-64f8ec85c680.png">

2.9MB image size
<img width="493" alt="Screenshot 2022-10-12 at 10 04 21" src="https://user-images.githubusercontent.com/8436510/195285989-2a79c30f-b1cc-4b8f-81fd-ae64556a27a2.png">

**After**
Initial load 425kB
<img width="889" alt="Screenshot 2022-10-12 at 10 02 45" src="https://user-images.githubusercontent.com/8436510/195286321-d103e0fa-78a5-483e-9bd3-a2e27cf6f941.png">

2.9MB -> 48kB
<img width="584" alt="Screenshot 2022-10-12 at 10 04 01" src="https://user-images.githubusercontent.com/8436510/195286037-a22bf609-a6a8-4549-a6a1-a82240e1a518.png">

