### PR TITLE
fix: contrast footer links comply AA/AAA

### DIFF
--- a/src/layout/layout.module.css
+++ b/src/layout/layout.module.css
@@ -254,12 +254,13 @@
   margin-bottom: 0.6rem;
 }
 .footer__item a {
-  color: var(--color-primary);
+  color: var(--color-secondary2);
   text-decoration: none;
-  border-bottom: 1px solid var(--color-primary);
+  border-bottom: 1px solid var(--color-secondary2);
   padding-bottom: 0.1rem;
   transition: border-bottom 200ms ease-out;
 }
 .footer__item a:hover {
-  border-bottom: 1px solid var(--color-secondary2);
+  color: var(--color-secondary2__shade1);
+  border-bottom: 1px solid var(--color-primary);
 }


### PR DESCRIPTION
Suggestion to change the colors of links in the footer to "secondary". This is the same as the underline from before and is the main color that is the easiest to make it comply to AA/AAA while still being somewhat "splashy".

Note: Hover state color is made somewhat darker to give an additional indication. This isn't AAA. Changing text color here could be a different color or simply not be done.

## Normal

<img width="1056" alt="Screenshot 2022-11-19 at 19 08 20" src="https://user-images.githubusercontent.com/606374/202865328-9d666b7b-7f17-452f-b662-d845931b6342.png">

## Hover state
<img width="1075" alt="Screenshot 2022-11-19 at 19 08 23" src="https://user-images.githubusercontent.com/606374/202865333-4ca377af-85db-44dc-9d47-e40d2583a18e.png">
