### PR TITLE
fix: sammenslåtte ord i kundereferansesider

### DIFF
--- a/src/kunde/assignments/index.tsx
+++ b/src/kunde/assignments/index.tsx
@@ -7,7 +7,7 @@ import { Interview } from 'src/kunde/utils/customerUtils';
 import { getStaticProps } from 'pages/kunde/[oppdrag]';
 import DecorativeBoxes from '@components/decorative-boxes';
 import MarkdownIt from 'markdown-it';
-import {Heading1} from "@components/heading";
+import { Heading1 } from '@components/heading';
 
 const createHtmlFromMetadata = () => {
   let html =
@@ -201,24 +201,22 @@ const Svv: NextPage<InferGetStaticPropsType<typeof getStaticProps>> =
                   )}
                 </div>
                 <div>
-                  <p>
-                    {assignment.meta_contribution_strategy === null ? (
-                      <></>
-                    ) : (
-                      <div className={style.contributionElements__text}>
-                        <img
-                          src="/images/customer/strategyDevelopment.png"
-                          alt="Blob med datamaskin"
-                        />
-                        <div>
-                          <p>
-                            <strong>Strategiutvikling</strong>
-                          </p>
-                          <p>{assignment.meta_contribution_strategy}</p>
-                        </div>
+                  {assignment.meta_contribution_strategy === null ? (
+                    <></>
+                  ) : (
+                    <div className={style.contributionElements__text}>
+                      <img
+                        src="/images/customer/strategyDevelopment.png"
+                        alt="Blob med datamaskin"
+                      />
+                      <div>
+                        <p>
+                          <strong>Strategiutvikling</strong>
+                        </p>
+                        <p>{assignment.meta_contribution_strategy}</p>
                       </div>
-                    )}
-                  </p>
+                    </div>
+                  )}
                 </div>
                 <div>
                   <p>

--- a/src/kunde/assignments/pages/fram.md
+++ b/src/kunde/assignments/pages/fram.md
@@ -30,7 +30,7 @@ meta_projects:
       project_title: App og nettbutikk,
       project_text:
         'FRAM skal benytte en Entur-basert plattform for blant annet billettering,
-        turplanlegging og sannuidsvisning. Men oppå der skal det lages egen nettbutikk og FRAM-app tilpasset Møre og Romsdal. Dette gjøres i samarbeid med flere andre fylkeskommuner,
+        turplanlegging og sanntidsvisning. Men oppå der skal det lages egen nettbutikk og FRAM-app tilpasset Møre og Romsdal. Dette gjøres i samarbeid med flere andre fylkeskommuner,
         blant annet Trøndelag.',
     },
   ]

--- a/src/kunde/assignments/pages/fram.md
+++ b/src/kunde/assignments/pages/fram.md
@@ -16,10 +16,8 @@ meta_projects:
         },
       project_title: Trygg overgang,
       project_text:
-        [
-          I en periode på nesten to år vil det finnes både gammelt og nytt utstyr på bussene. Ett av våre prosjekter handler om å sikre at reiseprodukter kjøpt på ny plattform vil fungere på gammel og vice versa. Dette er et spennede prosjekt som involverer både NFC-teknologi,
-          APP-utvikling og god gammeldags integrasjonsarbeid.,
-        ],
+        'I en periode på nesten to år vil det finnes både gammelt og nytt utstyr på bussene. Ett av våre prosjekter handler om å sikre at reiseprodukter kjøpt på ny plattform vil fungere på gammel og vice versa. Dette er et spennede prosjekt som involverer både NFC-teknologi,
+        APP-utvikling og god gammeldags integrasjonsarbeid.',
     },
     {
       project_image:
@@ -31,11 +29,9 @@ meta_projects:
         },
       project_title: App og nettbutikk,
       project_text:
-        [
-          FRAM skal benytte en Entur-basert plattform for blant annet billettering,
-          turplanlegging og sannuidsvisning. Men oppå der skal det lages egen nettbutikk og FRAM-app tilpasset Møre og Romsdal. Dette gjøres i samarbeid med flere andre fylkeskommuner,
-          blant annet Trøndelag.,
-        ],
+        'FRAM skal benytte en Entur-basert plattform for blant annet billettering,
+        turplanlegging og sannuidsvisning. Men oppå der skal det lages egen nettbutikk og FRAM-app tilpasset Møre og Romsdal. Dette gjøres i samarbeid med flere andre fylkeskommuner,
+        blant annet Trøndelag.',
     },
   ]
 meta_contribution_digital_productdevelopment: Variant bistår FRAM med å utvikle og tilpasse nye og kundeflater for reisende i Møre og Romsdal. Dette inkluderer ny mobilapp for reisesøk og billettering samt nettbutikk. I tillegg bistår vi kunden med integrasjon mellom gammel og ny plattform som gir reisende i fylket en sømløs opplevelse på trass av at  busser er utstyrt med enten nytt eller gammelt utstyr. Dette gir FRAM mulighet til en gradvis overgang og reduserer risikoen for at store kundegrupper ikke kan reise kollektivt i en overgangsperiode.

--- a/src/kunde/assignments/pages/fram.md
+++ b/src/kunde/assignments/pages/fram.md
@@ -17,7 +17,7 @@ meta_projects:
       project_title: Trygg overgang,
       project_text:
         'I en periode på nesten to år vil det finnes både gammelt og nytt utstyr på bussene. Ett av våre prosjekter handler om å sikre at reiseprodukter kjøpt på ny plattform vil fungere på gammel og vice versa. Dette er et spennede prosjekt som involverer både NFC-teknologi,
-        APP-utvikling og god gammeldags integrasjonsarbeid.',
+        APP-utvikling og godt gammeldags integrasjonsarbeid.',
     },
     {
       project_image:

--- a/src/kunde/assignments/pages/sikt.md
+++ b/src/kunde/assignments/pages/sikt.md
@@ -16,11 +16,11 @@ meta_projects:
             { color: FFD0C9, vertical: bottom, horizontal: middle },
         },
       project_title: Designlaben,
-      project_text: [
-          Variant har sammen med Sikt utviklet Designlaben som innoverer og utvikler nye tjenester for fremtidens studenter og forskere. Designlaben er Sikts innovasjonssatsing hvor brukeren står i sentrum,
-          og består av et team av oss innleide og ansatte som bruker designmetodikk til å løse komplekse utfordringer.
-          Sikt og hele kunnskapssektoren er i stor endring. Spørsmål som hvordan studenter lærer best og hvordan undervisning bør foregå er noe som Sikt og sektoren må finne ut av. Det stilles økt krav til innsikt i brukerens hverdag. Det er også økt behov for innovasjon og nye tjenestetilbud for å møte fremtidens undervisnings- og forskningssituasjon. For å løse dette er det viktig at det interne maskineriet fungerer godt. Designlaben utvikler interne og eksterne arbeidsprosesser og tjenester for å sikre både fornøyde ansatte og kunder.,
-        ],
+      project_text:
+        'Variant har sammen med Sikt utviklet Designlaben som innoverer og utvikler nye tjenester for fremtidens studenter og forskere. Designlaben er Sikts innovasjonssatsing hvor brukeren står i sentrum,
+        og består av et team av oss innleide og ansatte som bruker designmetodikk til å løse komplekse utfordringer.
+
+        Sikt og hele kunnskapssektoren er i stor endring. Spørsmål som hvordan studenter lærer best og hvordan undervisning bør foregå er noe som Sikt og sektoren må finne ut av. Det stilles økt krav til innsikt i brukerens hverdag. Det er også økt behov for innovasjon og nye tjenestetilbud for å møte fremtidens undervisnings- og forskningssituasjon. For å løse dette er det viktig at det interne maskineriet fungerer godt. Designlaben utvikler interne og eksterne arbeidsprosesser og tjenester for å sikre både fornøyde ansatte og kunder.',
     },
     {
       project_image:
@@ -30,13 +30,10 @@ meta_projects:
           boxProperties2: { color: B7B4DE, vertical: bottom, horizontal: left },
         },
       project_title: Verdiskaping med offentlige data,
-      project_text: [
-          De siste årene har Norges ledelse etterlyst økt verdiskaping med offentlige data som ressurs. Regjeringen vil at Norge skal utnytte mulighetene som ligger i data til økt verdiskaping,
-          flere nye arbeidsplasser i hele landet,
-          og en effektiv offentlig sektor (Meld. St. 22 (2020–2021)). Som svar på dette har Kunnskapsdepartementet,
-          alle underliggende direktorat og aktører i sektoren pekt på Sikt som en viktig tilrettelegger for at dette skal skje.
-          Variant hjelper Sikt og kunnskapssektoren med å finne ut hvordan data kan tilgjengeliggjøres og gi verdi gjennom flere ulike initiativ.,
-        ],
+      project_text:
+        'De siste årene har Norges ledelse etterlyst økt verdiskaping med offentlige data som ressurs. Regjeringen vil at Norge skal utnytte mulighetene som ligger i data til økt verdiskaping,
+        flere nye arbeidsplasser i hele landet, og en effektiv offentlig sektor (Meld. St. 22 (2020–2021)). Som svar på dette har Kunnskapsdepartementet, alle underliggende direktorat og aktører i sektoren pekt på Sikt som en viktig tilrettelegger for at dette skal skje.
+        Variant hjelper Sikt og kunnskapssektoren med å finne ut hvordan data kan tilgjengeliggjøres og gi verdi gjennom flere ulike initiativ.',
     },
   ]
 meta_contribution_digital_productdevelopment: Variant har bistått med kompetanse på design og utvikling over flere år. I tillegg til å bidra med innovasjon og utvikling av nye løsninger, har det vært mye fokus på blant annet testing, universell utforming og flerspråklig støtte.

--- a/src/kunde/assignments/pages/svv.md
+++ b/src/kunde/assignments/pages/svv.md
@@ -18,10 +18,10 @@ meta_projects:
           boxProperties2: { color: B7B4DE, vertical: bottom, horizontal: left },
         },
       project_title: Trygge tunneler,
-      project_text: I Norge har vi over 1100 tunneler som krever forvaltning og
+      project_text: 'I Norge har vi over 1100 tunneler som krever forvaltning og
         vedlikehold. Sammen med Statens vegvesen har vi utviklet
         løsninger som effektiviserer arbeidsprosessene rundt
-        inspeksjon og sikkerhetsgodkjenning av tunneler i henhold til,
+        inspeksjon og sikkerhetsgodkjenning av tunneler i henhold til',
     },
     {
       project_image:
@@ -32,11 +32,8 @@ meta_projects:
             { color: FFD0C9, vertical: bottom, horizontal: middle },
         },
       project_title: Økt trafikksikkerhet,
-      project_text:
-        [
-          Med kontinuerlig innsikt,
-          design og behovskartlegging bidrar vi til økt trafikksikkerhet ved å utvikle nye støtteverktøy for gjennomføring og oppfølging av Trafikksikkerhetsinspeksjoner.,
-        ],
+      project_text: 'Med kontinuerlig innsikt,
+        design og behovskartlegging bidrar vi til økt trafikksikkerhet ved å utvikle nye støtteverktøy for gjennomføring og oppfølging av Trafikksikkerhetsinspeksjoner.',
     },
     {
       project_image:
@@ -47,11 +44,9 @@ meta_projects:
         },
       project_title: Ledelse av digitaliseringsprogram,
       project_text:
-        [
-          I Statens vegvesen har de blant annet systemer for dataflyten vedrørende både veiene i seg selv,
-          og trafikken som benytter de. De siste 10 årene har kundefokuset økt kraftig både i samfunnet forøvrig og i Statens vegvesen,
-          noe som er en av driverne bak digitaliseringsprogrammet som Variant er involvert i. Vi bistår kunden med å se på nye teknologiske muligheter og krav i en verden hvor kjøretøyet i større grad er både konsument og leverandør av data. Utviklingen i førerstøtte i bil er forventet å bidra vesentlig til blant annet vegvesenets nullvisjon for drepte og hardt skadde i trafikken. Programmet som vi i Variant er med på å lede rammer inn en rekke utviklingstiltak som skal sette vegvesenet i bedre stand til å levere den digitale veien.,
-        ],
+        'I Statens vegvesen har de blant annet systemer for dataflyten vedrørende både veiene i seg selv,
+        og trafikken som benytter de. De siste 10 årene har kundefokuset økt kraftig både i samfunnet forøvrig og i Statens vegvesen,
+        noe som er en av driverne bak digitaliseringsprogrammet som Variant er involvert i. Vi bistår kunden med å se på nye teknologiske muligheter og krav i en verden hvor kjøretøyet i større grad er både konsument og leverandør av data. Utviklingen i førerstøtte i bil er forventet å bidra vesentlig til blant annet vegvesenets nullvisjon for drepte og hardt skadde i trafikken. Programmet som vi i Variant er med på å lede rammer inn en rekke utviklingstiltak som skal sette vegvesenet i bedre stand til å levere den digitale veien.',
     },
   ]
 meta_contribution_digital_productdevelopment:


### PR DESCRIPTION
Fix invalid syntax for YAML in gray-matter and fix incorrect HTML. 

Fixes https://variantas.slack.com/archives/CBFA8V536/p1672732067466909