### PR TITLE
feat: adds support for 2023 in calc

### DIFF
--- a/src/advanced-calculator/helpers/daysUntilNewSalary.ts
+++ b/src/advanced-calculator/helpers/daysUntilNewSalary.ts
@@ -6,12 +6,15 @@ export function gradDateOfTheYear(year: number): Date {
   return new Date(year, 5, 30, 0, 0); // 30. jul
 }
 
-export function calculateYearsSince(calcDate: Date) :number {  
+export function calculateYearsSince(calcDate: Date): number {
+  if (Date.now() < calcDate.getTime()) {
+    return -1;
+  }
+
   let diffInMs = Date.now() - calcDate.getTime();
   let diffInDate = new Date(diffInMs); // miliseconds from epoch
   return Math.abs(diffInDate.getUTCFullYear() - 1970);
 }
-
 
 export function daysBetweenDates(startDate: Date, endDate: Date) {
   const dayInMs = 1000 * 60 * 60 * 24;
@@ -19,12 +22,12 @@ export function daysBetweenDates(startDate: Date, endDate: Date) {
   const start = Date.UTC(
     endDate.getFullYear(),
     endDate.getMonth(),
-    endDate.getDate()
+    endDate.getDate(),
   );
   const end = Date.UTC(
     startDate.getFullYear(),
     startDate.getMonth(),
-    startDate.getDate()
+    startDate.getDate(),
   );
 
   return (start - end) / dayInMs;

--- a/src/advanced-calculator/helpers/getPayscale.ts
+++ b/src/advanced-calculator/helpers/getPayscale.ts
@@ -13,7 +13,7 @@ export type PayscaleEntry = {
 
 export type Payscale = {
   current: number;
-  diffSinceLast: number;
+  diffSinceLast?: number;
   historic: PayscaleEntry[];
   prognosis: PayscaleEntry[];
 };
@@ -54,9 +54,9 @@ export default function getPayscale(selectedYear: number): Payscale {
   const latestPayscale = payscale[latestYearInPayscaleArray];
   const payForSelectedYear = parseInt(latestPayscale[selectedYear], 10);
 
-  const historic = availablePayscaleYears.map(
-    getHistoricPayscale(selectedYear),
-  );
+  const historic = availablePayscaleYears
+    .map(getHistoricPayscale(selectedYear))
+    .filter((i) => !Number.isNaN(i.pay));
 
   const prognosis = createPrognosisPayscale(
     selectedYear,
@@ -65,10 +65,12 @@ export default function getPayscale(selectedYear: number): Payscale {
     2,
   );
 
+  const prev = historic[historic.length - 2];
+
   return {
     current: payForSelectedYear,
     historic,
-    diffSinceLast: payForSelectedYear - historic[historic.length - 2].pay,
+    diffSinceLast: prev ? payForSelectedYear - prev.pay : undefined,
     prognosis,
   };
 }

--- a/src/advanced-calculator/helpers/utils.ts
+++ b/src/advanced-calculator/helpers/utils.ts
@@ -22,7 +22,7 @@ export function calculateEstimatedSalary(
 
 export function getMaxYear(): number {
   const keys = Object.keys(data);
-  return parseInt(keys[keys.length - 1], 10) - 2;
+  return parseInt(keys[keys.length - 1], 10) - 1;
 }
 
 export const formatCurrencyFromNumber = (pay: number | undefined) => {

--- a/src/advanced-calculator/index.tsx
+++ b/src/advanced-calculator/index.tsx
@@ -333,12 +333,17 @@ export default function Calculator() {
               </p>
               <p>
                 Grafen her viser en indikasjon på lønnsvekst i Variant gitt en
-                erfaring av {totalExperience}. Fra i fjor ville du fått en{' '}
-                <strong>
-                  økning på {formatCurrencyFromNumber(payscale.diffSinceLast)}{' '}
-                  kr
-                </strong>
-                .
+                erfaring av {totalExperience}.{' '}
+                {payscale.diffSinceLast && (
+                  <>
+                    Fra i fjor ville du fått en{' '}
+                    <strong>
+                      økning på{' '}
+                      {formatCurrencyFromNumber(payscale.diffSinceLast)} kr
+                    </strong>
+                    .
+                  </>
+                )}
               </p>
             </div>
           </InView>

--- a/src/advanced-calculator/index.tsx
+++ b/src/advanced-calculator/index.tsx
@@ -58,7 +58,7 @@ export default function Calculator() {
   );
 
   const totalExperience =
-    yearsOfExperience === 0
+    yearsOfExperience < 0
       ? `Nyutdannet ${DEGREE[degree]}`
       : `${yearsOfExperience} år + ${DEGREE[degree]}`;
 


### PR DESCRIPTION
Gjør slik at mellom 2022 og nå så er det 0 år erfaring, 2023 er nyutdannet og ellers som før.