### PR TITLE
Endret lokasjon i Bergen fra Spaces til Vaskerelven 39

### DIFF
--- a/pages/bergen/index.tsx
+++ b/pages/bergen/index.tsx
@@ -11,10 +11,6 @@ export const getStaticProps = async () => {
       'andreas@variant.no',
       'tlh@variant.no',
       'vif@variant.no',
-      'haakon@variant.no',
-      'sh@variant.no',
-      'hss@variant.no',
-      'iki@variant.no',
     ]);
 
     return {

--- a/pages/bergen/index.tsx
+++ b/pages/bergen/index.tsx
@@ -11,6 +11,10 @@ export const getStaticProps = async () => {
       'andreas@variant.no',
       'tlh@variant.no',
       'vif@variant.no',
+      'haakon@variant.no',
+      'sh@variant.no',
+      'hss@variant.no',
+      'iki@variant.no',
     ]);
 
     return {

--- a/src/bergen/bergensvyer/index.tsx
+++ b/src/bergen/bergensvyer/index.tsx
@@ -194,7 +194,7 @@ export default function Home() {
             </p>
 
             <p>
-              Den første tiden leier Variant et kontor i Spaces Vaskerelven.
+              Den første tiden leier Variant et kontor i Vaskerelven 39.
               Antallet rom og arbeidsplasser utvides etter hvert som vi vokser.
               Konsernet stiller med struktur- og systemkapital. Konsernets
               ledelse jobber tett på en coachende måte med Bergens ledergruppe.

--- a/src/bergen/index.tsx
+++ b/src/bergen/index.tsx
@@ -86,14 +86,8 @@ const Bergen: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
 
             <p className="lead">
               På kort tid har vi sikret oss de aller første ansatte (hipp
-              hurra!), vi har fått kontorer hos{' '}
-              <a
-                href="https://www.spacesworks.com/bergen/vaskerelven/"
-                rel="external nofollow"
-              >
-                Spaces i Vaskerelven
-              </a>{' '}
-              og nå er vi klare for flere folk. Vil du være med å forme et
+              hurra!), vi har fått kontorer i kontorfellesskapet i Vaskerelven
+              39, og nå er vi klare for flere folk. Vil du være med å forme et
               annerledes konsulentselskap?
             </p>
             <p>

--- a/src/jobs/pages/prosjektleder-i-bergen.md
+++ b/src/jobs/pages/prosjektleder-i-bergen.md
@@ -59,7 +59,7 @@ Variant er menneskene som jobber her. Vi har kommet sammen for å være med å s
 
 Da er det helt selvsagt at vi må investere i kunnskap. Læreglede kommer i mange fasonger og vi prøver å tilrettelegge for at vi som varianter skal lære på den måten vi ønsker. Noen av oss driver podcasts ([her](http://bartjs.io/tag/podcast-episode/) og [her](https://kortslutning.fun/)), noen lager [kodevideoer](https://youtube.com/kodesnutt), noen underviser på NTNU og flere-enn-du-tror leder ymse meet-ups rundt om i landet. I tillegg samles vi hver måned til det vi [kaller en variantdag](https://blog.variant.no/tagged/variantdag); vår egen innedag for faglig påfyll. Og, ikke minst, for å møtes.
 
-Variant ble startet i 2018 og er 100 % eiet av de ansatte. Per desember 2022 er vi nærmere 80 ansatte i Norge – fordelt på våre kontorer i Oslo, Trondheim og Bergen. I Bergen har vi kontor på Spaces i Vaskerelven.
+Variant ble startet i 2018 og er 100 % eiet av de ansatte. Per desember 2022 er vi nærmere 80 ansatte i Norge – fordelt på våre kontorer i Oslo, Trondheim og Bergen. I Bergen har vi kontor i Vaskerelven 39.
 
 Konseptet og filosofien som er beskrevet over har vi behandlet i detalj, foråsidetsånn:
 

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -164,13 +164,13 @@ const Layout = ({
               >
                 Tollbugata 24
               </a>{' '}
-              i Oslo og på{' '}
+              i Oslo og i{' '}
               <a
                 href="https://g.page/Vaskerelven-39-5323"
                 rel="noopener"
                 target="_blank"
               >
-                Spaces Vaskerelven
+                Vaskerelven 39
               </a>{' '}
               i Bergen. Kom innom for en kopp kaffe eller bare en hyggelig prat.
             </p>
@@ -206,7 +206,6 @@ const Layout = ({
             <address>
               <strong>Variant Bergen AS</strong>
               <br />
-              C/O Spaces Vaskerelven <br />
               Vaskerelven 39
               <br />
               5014 Bergen


### PR DESCRIPTION
Spaces Vaskerelven finnes ikke lengre. Oppdaterte også en statisk liste over ansatte i Bergen, er det riktig?