### PR TITLE
fix: wider layout to fit long email

### DIFF
--- a/src/employees/employees.module.css
+++ b/src/employees/employees.module.css
@@ -35,7 +35,7 @@
 
   max-width: calc(var(--total-images-width) + var(--total-margin) + 5rem);
   display: flex;
-  justify-content: center;
+  justify-content: space-evenly;
   flex-wrap: wrap;
   padding-top: 4rem;
   padding-bottom: 10rem;

--- a/src/employees/employees.module.css
+++ b/src/employees/employees.module.css
@@ -33,8 +33,9 @@
   --total-margin: calc(var(--column-margin) * 2 * var(--columns));
   --total-images-width: calc(var(--image-width) * var(--columns));
 
-  max-width: calc(var(--total-images-width) + var(--total-margin));
+  max-width: calc(var(--total-images-width) + var(--total-margin) + 5rem);
   display: flex;
+  justify-content: center;
   flex-wrap: wrap;
   padding-top: 4rem;
   padding-bottom: 10rem;

--- a/src/employees/utils/getEmployeesList.ts
+++ b/src/employees/utils/getEmployeesList.ts
@@ -1,6 +1,7 @@
 import { Office } from 'src/office-selector';
 import { EmployeeItem } from '../types';
 import { requestByEmails, requestEmployees } from './request';
+import { offices } from 'src/office-selector';
 
 export const getEmployeesList = async (): Promise<EmployeeItem[] | false> => {
   const employees = await requestEmployees();
@@ -10,7 +11,9 @@ export const getEmployeesList = async (): Promise<EmployeeItem[] | false> => {
   }
 
   // Make images
-  return employees;
+  return employees.filter((employee) =>
+    offices.includes(employee.officeName.toLowerCase() as Office),
+  );
 };
 
 export const getEmployeesByOffice = async (


### PR DESCRIPTION
Forsøk på å fikse en bug hvor den lange emailen forskjøv resten av blobbene

TODO
- [x] justify content start på nederste rad
- [x] Smart måte å filtrere ut basert på kontorene