### PR TITLE
fix(calculator): max height for mobile landscape

### DIFF
--- a/src/advanced-calculator/calculator.module.css
+++ b/src/advanced-calculator/calculator.module.css
@@ -108,6 +108,7 @@ input[type='number'] {
   grid-row: span 1;
   padding: 1.5rem;
 }
+
 .calculator-content {
   display: grid;
   grid-gap: 1rem;
@@ -173,6 +174,11 @@ input[type='number'] {
   .calculator-controls__summary {
     grid-column: 2 / 3;
     grid-row: 2 / 4;
+  }
+
+  .calculator-content-wrapper {
+    max-height: 70vh;
+    overflow: auto;
   }
 
   .calculator-content {

--- a/src/advanced-calculator/index.tsx
+++ b/src/advanced-calculator/index.tsx
@@ -100,6 +100,7 @@ export default function Calculator(props: SalaryCalculatorProps) {
               : style['calculator-controls--mobileHidden'],
           )}
         >
+          <div className={style['calculator-content-wrapper']}>
           {mobileVisible && (
             <motion.div
               id="controls-content"
@@ -266,6 +267,7 @@ export default function Calculator(props: SalaryCalculatorProps) {
             >
               {mobileVisible ? 'Skjul' : 'Endre'}
             </Button>
+          </div>
           </div>
         </div>
       </AnimatePresence>


### PR DESCRIPTION
On mobile landscape the [calculator](https://www.variant.no/kalkulator) fills the full viewport height and can't be closed unless you scroll to the page footer. Quick fix (that might need some designer loving ❤️ ) sets max height to 70% and add a second scrollbar to the calculator.

