### PR TITLE
feat: adds tjenesteområder to header

### DIFF
--- a/src/components/page-header/index.tsx
+++ b/src/components/page-header/index.tsx
@@ -32,7 +32,7 @@ export default function PageHeader({
     closeRef,
     isNotHamburgerMode,
   );
-  
+
   useEffect(() => {
     onVisibleChange?.(isMenuVisible);
   }, [isMenuVisible, onVisibleChange]);
@@ -109,8 +109,8 @@ export default function PageHeader({
               ref={navRef}
             >
               <li>
-                <Link href="/jobs">
-                  <a>Bli en variant</a>
+                <Link href="/tjenesteomrader">
+                  <a>Tjenester</a>
                 </Link>
               </li>
               <li>
@@ -119,7 +119,7 @@ export default function PageHeader({
                 </a>
               </li>
               <li>
-                <a href="http://variant.blog" rel="noopener">
+                <a href="http://blog.variant.no" rel="noopener">
                   Blogg
                 </a>
               </li>
@@ -132,14 +132,6 @@ export default function PageHeader({
                 <Link href="/kalkulator">
                   <a>Lønnskalkulator</a>
                 </Link>
-              </li>
-              <li id="dont_show">
-                <a
-                  href="https://twitter.com/intent/tweet?screen_name=variant_as"
-                  rel="noopener"
-                >
-                  Si hallo!
-                </a>
               </li>
             </ul>
           </nav>

--- a/src/components/page-header/page-header.module.css
+++ b/src/components/page-header/page-header.module.css
@@ -26,10 +26,6 @@
   transition: 0.4s;
 }
 
-.header__nav__ul li:last-child {
-  display: none;
-}
-
 .header__nav a {
   display: block;
   color: var(--color-standard__white--text);

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -68,7 +68,7 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
   }, [randomCases]);
 
   return (
-    <Layout crazy homepage>
+    <Layout homepage>
       <Head>
         <meta
           property="og:description"
@@ -114,10 +114,6 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
             En variant av et konsulentselskap som er raust, åpent og læreglad.
           </p>
         </div>
-      </section>
-
-      <section className={style.bergen}>
-        <JobLandingpage />
       </section>
 
       <section className={style.join}>

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -9,8 +9,6 @@ import Layout from 'src/layout';
 import List from 'src/rss/feed/List';
 import style from './index.module.css';
 import PageTitle from '@components/page-title';
-import sommerjobbImg from './images/section1Blob.png';
-import Arrow from '@components/arrow';
 import { Heading3 } from '@components/heading';
 import Tjenesteomrader from 'src/tjenesteomrader';
 import { EmployeeItem } from 'src/employees/types';

--- a/src/index/index.tsx
+++ b/src/index/index.tsx
@@ -326,30 +326,4 @@ const Home = ({ randomEmployee, randomCases, feeds }: HomeProps) => {
   );
 };
 
-function JobLandingpage() {
-  return (
-    <div className={style.infoBlock}>
-      <Image
-        src={sommerjobbImg}
-        className={style.infoBlock__blob}
-        alt="Varianter under felles variantdag"
-        width={774}
-        height={631}
-        loading="lazy"
-        decoding="async"
-      />
-
-      <h2 className={style.infoBlock__title}>
-        <Link href="/nyutdannet">
-          <a className={style.infoBlock__link}>
-            <span className={style.infoBlock__text}>
-              Info om jobb for studenter
-            </span>
-            <Arrow className={style.infoBlock__arrow} color="standard__white" />
-          </a>
-        </Link>
-      </h2>
-    </div>
-  );
-}
 export default Home;

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -86,7 +86,7 @@ const Layout = ({
                 <a href="https://handbook.variant.no">Håndbok</a>
               </li>
               <li>
-                <a href="http://variant.blog" rel="noopener">
+                <a href="http://blog.variant.no" rel="noopener">
                   Blogg
                 </a>
               </li>

--- a/src/summersplash2022/components/header/header.tsx
+++ b/src/summersplash2022/components/header/header.tsx
@@ -98,8 +98,8 @@ const Header = (props: { white: boolean }) => {
                   ref={navRef}
                 >
                   <li>
-                    <Link href="/jobs">
-                      <a>Bli en variant</a>
+                    <Link href="/tjenesteomrader">
+                      <a>Tjenester</a>
                     </Link>
                   </li>
                   <li>
@@ -121,14 +121,6 @@ const Header = (props: { white: boolean }) => {
                     <Link href="/kalkulator">
                       <a>Lønnskalkulator</a>
                     </Link>
-                  </li>
-                  <li id="dont_show">
-                    <a
-                      href="https://twitter.com/intent/tweet?screen_name=variant_as"
-                      rel="noopener"
-                    >
-                      Si hallo!
-                    </a>
                   </li>
                 </ul>
               </nav>
@@ -205,8 +197,8 @@ const Header = (props: { white: boolean }) => {
                   ref={navRef}
                 >
                   <li>
-                    <Link href="/jobs">
-                      <a>Bli en variant</a>
+                    <Link href="/tjenesteomrader">
+                      <a>Tjenester</a>
                     </Link>
                   </li>
                   <li>
@@ -228,14 +220,6 @@ const Header = (props: { white: boolean }) => {
                     <Link href="/kalkulator">
                       <a>Lønnskalkulator</a>
                     </Link>
-                  </li>
-                  <li id="dont_show">
-                    <a
-                      href="https://twitter.com/intent/tweet?screen_name=variant_as"
-                      rel="noopener"
-                    >
-                      Si hallo!
-                    </a>
                   </li>
                 </ul>
               </nav>


### PR DESCRIPTION
Fjerner `Bli en variant` da dette er i stor fokus rett øverst på siden og er i footer. Prioriterer plassen til tjenesteområder som er vanskeligere å finne ut i fra tilbakemeldinger