### PR TITLE
Initial calculator page

### DIFF
--- a/src/app/(main)/kalkulator/page.tsx
+++ b/src/app/(main)/kalkulator/page.tsx
@@ -1,0 +1,5 @@
+import { Calculator } from 'src/calculator/Calculator';
+
+export default async function Page() {
+  return <Calculator />;
+}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -29,15 +29,23 @@ export default async function Layout({
     ]);
 
   const hasNavigationData = Boolean(
-    initialNav.data.main ||
+    initialNav.data &&
+    (initialNav.data.main ||
       initialNav.data.sidebar ||
       initialNav.data.footer ||
-      siteSettings.data?.brandAssets
+      siteSettings.data?.brandAssets)
   );
+
+  if (!hasNavigationData) {
+    return <main id="main" tabIndex={-1}>
+      {children}
+    </main>;
+  }
+
   return (
     <>
       <SkipToMain />
-      {hasNavigationData && isDraftMode ? (
+      {isDraftMode ? (
         <HeaderPreview
           initialNav={initialNav}
           initialSiteSetting={siteSettings}
@@ -48,7 +56,7 @@ export default async function Layout({
       <main id="main" tabIndex={-1}>
         {children}
       </main>
-      {hasNavigationData && isDraftMode ? (
+      {isDraftMode ? (
         <FooterPreview
           initialNav={initialNav}
           initialSiteSetting={siteSettings}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -6,6 +6,7 @@ import SectionRenderer from "src/utils/renderSection";
 import { loadQuery } from "studio/lib/store";
 import { Metadata, ResolvingMetadata } from "next";
 import { fetchSeoData, generateMetadataFromSeo } from "src/utils/seo";
+import { MissingData } from 'src/components/missingData/MissingData';
 
 export async function generateMetadata(
   parent: ResolvingMetadata
@@ -26,7 +27,7 @@ const Home = async () => {
   );
 
   if (!landingId) {
-    throw new Error("Landing page ID not found");
+    return <MissingData description={"Landing page id"} />
   }
 
   const initialLandingPage = await loadQuery<PageBuilder>(
@@ -36,7 +37,11 @@ const Home = async () => {
   );
 
   if (!initialLandingPage) {
-    throw new Error("Page not found");
+    return <MissingData description={`Page for id '${landingId}'`} />
+  }
+
+  if (!initialLandingPage.data.sections) {
+    return <MissingData description={`Sections for landing page`} />
   }
 
   return initialLandingPage.data.sections.map((section, index) => {

--- a/src/calculator/Calculator.tsx
+++ b/src/calculator/Calculator.tsx
@@ -3,7 +3,7 @@ import Text from 'src/components/text/Text';
 
 export const Calculator = () => {
   return (
-    <div className={styles.container}>
+    <div className={styles.content}>
       <Text>🤖 Beep boop, I&apos;m a calculator</Text>
       <Text type={"small"}>1 + 1 = {1 + 1}</Text>
     </div>

--- a/src/calculator/Calculator.tsx
+++ b/src/calculator/Calculator.tsx
@@ -1,11 +1,11 @@
 import styles from './calculator.module.css';
-import textStyles from 'src/components/text/text.module.css';
+import Text from 'src/components/text/Text';
 
 export const Calculator = () => {
   return (
     <div className={styles.container}>
-      <p className={textStyles.body}>🤖 Beep boop, I&apos;m a calculator</p>
-      <p className={textStyles.small}>1 + 1 = {1 + 1}</p>
+      <Text>🤖 Beep boop, I&apos;m a calculator</Text>
+      <Text type={"small"}>1 + 1 = {1 + 1}</Text>
     </div>
   );
 };

--- a/src/calculator/Calculator.tsx
+++ b/src/calculator/Calculator.tsx
@@ -1,0 +1,11 @@
+import styles from './calculator.module.css';
+import textStyles from 'src/components/text/text.module.css';
+
+export const Calculator = () => {
+  return (
+    <div className={styles.container}>
+      <p className={textStyles.body}>🤖 Beep boop, I&apos;m a calculator</p>
+      <p className={textStyles.small}>1 + 1 = {1 + 1}</p>
+    </div>
+  );
+};

--- a/src/calculator/calculator.module.css
+++ b/src/calculator/calculator.module.css
@@ -1,4 +1,4 @@
-.container {
+.content {
     margin-top: calc(5rem + 72px); /* TODO: remove extra pixels when .main -72px is handled */
     width: 100%;
     display: flex;

--- a/src/calculator/calculator.module.css
+++ b/src/calculator/calculator.module.css
@@ -1,0 +1,8 @@
+.container {
+    margin-top: calc(5rem + 72px); /* TODO: remove extra pixels when .main -72px is handled */
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+}

--- a/src/components/missingData/MissingData.tsx
+++ b/src/components/missingData/MissingData.tsx
@@ -1,7 +1,8 @@
 import LinkButton from '../linkButton/LinkButton';
 import { LinkType } from '../../../studio/lib/payloads/navigation';
+import Text from "src/components/text/Text";
 import styles from './missingData.module.css';
-import textStyles from "src/components/text/text.module.css";
+
 
 const studioLink = {
   _key: "go-to-sanity-studio",
@@ -16,12 +17,10 @@ const studioLink = {
 export const MissingData = ({ description }: { description: string }) => {
   return (
     <div className={styles.wrapper}>
-      <div className={`${textStyles.small} ${styles.container}`}>
-        <h3>Missing Content</h3>
-        <p>Navigate to Sanity Studio to add the following:</p>
-        <strong>
-          <pre>{description}</pre>
-        </strong>
+      <div className={`${styles.container}`}>
+        <Text type={"h3"}>Missing Content</Text>
+        <Text type={"small"}>Navigate to Sanity Studio to add the following:</Text>
+        <p className={styles.description}>{description}</p>
         <LinkButton link={studioLink} />
       </div>
     </div>

--- a/src/components/missingData/MissingData.tsx
+++ b/src/components/missingData/MissingData.tsx
@@ -17,7 +17,7 @@ const studioLink = {
 export const MissingData = ({ description }: { description: string }) => {
   return (
     <div className={styles.wrapper}>
-      <div className={`${styles.container}`}>
+      <div className={`${styles.content}`}>
         <Text type={"h3"}>Missing Content</Text>
         <Text type={"small"}>Navigate to Sanity Studio to add the following:</Text>
         <p className={styles.description}>{description}</p>

--- a/src/components/missingData/MissingData.tsx
+++ b/src/components/missingData/MissingData.tsx
@@ -1,0 +1,29 @@
+import LinkButton from '../linkButton/LinkButton';
+import { LinkType } from '../../../studio/lib/payloads/navigation';
+import styles from './missingData.module.css';
+import textStyles from "src/components/text/text.module.css";
+
+const studioLink = {
+  _key: "go-to-sanity-studio",
+  _type: "link",
+  linkTitle: "Go to Studio",
+  linkType: LinkType.Internal,
+  internalLink: {
+    _ref: "studio",
+  },
+};
+
+export const MissingData = ({ description }: { description: string }) => {
+  return (
+    <div className={styles.wrapper}>
+      <div className={`${textStyles.small} ${styles.container}`}>
+        <h3>Missing Content</h3>
+        <p>Navigate to Sanity Studio to add the following:</p>
+        <strong>
+          <pre>{description}</pre>
+        </strong>
+        <LinkButton link={studioLink} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/missingData/missingData.module.css
+++ b/src/components/missingData/missingData.module.css
@@ -11,7 +11,16 @@
     margin: calc(2rem + 72px) auto 0; /* TODO: remove extra pixels when .main -72px is handled */
     padding: 2.5rem;
     background: #FFEBEE;
-    border: 0.25rem solid #F44336;
+    border: 0.25rem solid var(--primary-red-error);
     border-radius: 8px;
     gap: 1.5rem;
+}
+
+.description {
+    font-family: monospace;
+    font-size: 1rem;
+    margin: 0.5rem 0;
+    background: var(--primary-white);
+    border-radius: 8px;
+    padding: 0.75rem;
 }

--- a/src/components/missingData/missingData.module.css
+++ b/src/components/missingData/missingData.module.css
@@ -1,0 +1,17 @@
+.wrapper {
+    width: 100%;
+    display: flex;
+    align-items: center;
+}
+
+.container {
+    display: inline-flex;
+    align-self: center;
+    flex-direction: column;
+    margin: calc(72px + 2rem) auto 0;
+    padding: 2.5rem;
+    background: #FFEBEE;
+    border: 0.25rem solid #F44336;
+    border-radius: 8px;
+    gap: 1.5rem;
+}

--- a/src/components/missingData/missingData.module.css
+++ b/src/components/missingData/missingData.module.css
@@ -8,7 +8,7 @@
     display: inline-flex;
     align-self: center;
     flex-direction: column;
-    margin: calc(72px + 2rem) auto 0;
+    margin: calc(2rem + 72px) auto 0; /* TODO: remove extra pixels when .main -72px is handled */
     padding: 2.5rem;
     background: #FFEBEE;
     border: 0.25rem solid #F44336;

--- a/src/components/missingData/missingData.module.css
+++ b/src/components/missingData/missingData.module.css
@@ -4,7 +4,7 @@
     align-items: center;
 }
 
-.container {
+.content {
     display: inline-flex;
     align-self: center;
     flex-direction: column;

--- a/src/components/missingData/missingData.module.css
+++ b/src/components/missingData/missingData.module.css
@@ -10,7 +10,7 @@
     flex-direction: column;
     margin: calc(2rem + 72px) auto 0; /* TODO: remove extra pixels when .main -72px is handled */
     padding: 2.5rem;
-    background: #FFEBEE;
+    background: var(--primary-red-error-light);
     border: 0.25rem solid var(--primary-red-error);
     border-radius: 8px;
     gap: 1.5rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,6 +12,7 @@ html {
   --primary-green-dark: #206a6f;
   --primary-green-light: #a9db91;
   --primary-red-error: #b30b0b;
+  --primary-red-error-light: #ffebee;
 
   /* secondary colors */
   --secondary-yellow1: #f5f3e5;

--- a/studio/components/CustomCallToActions.tsx
+++ b/studio/components/CustomCallToActions.tsx
@@ -19,7 +19,7 @@ const CustomCallToActions = (props: CustomCallToActionsProps) => {
   useEffect(() => {
     const checkIfCurrentPageIsLandingPage = async () => {
       const navigationManager = await client.fetch(
-        `*[_type == "navigationManager"][1]{
+        `*[_type == "navigationManager" && _id == "navigationManager"][0]{
         setLanding
       }`
       );

--- a/studio/lib/queries/navigation.ts
+++ b/studio/lib/queries/navigation.ts
@@ -39,5 +39,5 @@ export const NAV_QUERY = groq`
 `;
 
 export const LANDING_QUERY = groq`
-  *[_type == "navigationManager"][1].setLanding._ref
+  *[_type == "navigationManager" && _id == "navigationManager"][0].setLanding._ref
 `;

--- a/studio/lib/queries/navigation.ts
+++ b/studio/lib/queries/navigation.ts
@@ -1,7 +1,7 @@
 import { groq } from "next-sanity";
 
 export const NAV_QUERY = groq`
-  *[_type == "navigationManager"]{
+  *[_type == "navigationManager" && _id == "navigationManager"]{
     "main": main[] {
       ...,
       linkType == "internal" => {
@@ -35,7 +35,7 @@ export const NAV_QUERY = groq`
         }
       }
     }
-  }[1]
+  }[0]
 `;
 
 export const LANDING_QUERY = groq`


### PR DESCRIPTION
Added dummy `Calculator` component in a new page at `/kalkulator`.

<img width="710" alt="image" src="https://github.com/user-attachments/assets/2f729cec-2287-473e-b8ef-89f98bae2854">

Also added an error message component for missing Sanity data.

<img width="556" alt="image" src="https://github.com/user-attachments/assets/5143a2b6-61fd-4780-bae6-a3630da756f9">

Finally fixed some minor issues encountered when using a fresh dataset.

