### PR TITLE
v3 - Fix/hero styling for firefox

### DIFF
--- a/src/components/linkButton/linkButton.module.css
+++ b/src/components/linkButton/linkButton.module.css
@@ -1,9 +1,11 @@
 .button {
-  width: -webkit-fill-available;
+  width: 100%;
+  box-sizing: border-box;
   max-width: 360px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
+  align-self: stretch;
   justify-content: space-between;
   gap: 0.6rem;
   border-radius: 1.5625rem;
@@ -15,7 +17,6 @@
   padding: 0.5rem 1.25rem;
   font-size: 1.25rem;
   font-weight: 400;
-
 
   @media (min-width: 1024px) {
     font-size: 1.5rem;
@@ -35,7 +36,6 @@
 }
 
 .small {
-
   @media (min-width: 1024px) {
     font-size: 1.25rem;
     padding: 0.375rem 1.25rem;

--- a/src/components/sections/hero/Hero.tsx
+++ b/src/components/sections/hero/Hero.tsx
@@ -19,7 +19,9 @@ export const Hero = ({ hero, isLanding = false }: HeroProps) => {
     >
       {isLanding ? (
         <div className={styles.secondary}>
-          <Text type="display">{hero.basicTitle}</Text>
+          <Text type="display" className={styles.title}>
+            {hero.basicTitle}
+          </Text>
           {hero.description && (
             <div className={styles.description}>
               <Text type="bodyLarge">{hero.description}</Text>

--- a/src/components/sections/hero/hero.module.css
+++ b/src/components/sections/hero/hero.module.css
@@ -51,6 +51,10 @@
   align-items: flex-start;
 }
 
+.title {
+  text-align: center;
+}
+
 .description {
   margin: auto;
   align-self: stretch;
@@ -59,7 +63,7 @@
 .cta {
   margin: 0;
   padding: 0;
-  width: -webkit-fill-available;
+  width: 100%;
   list-style-type: none;
   display: flex;
   flex-direction: column;
@@ -75,7 +79,7 @@
 
   & > li {
     @media (max-width: 640px) {
-      width: -webkit-fill-available;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
This fixes render of styling on firefox of CTAs in Hero section. 

Firefox:
<img width="452" alt="Screenshot 2024-08-16 at 13 14 26" src="https://github.com/user-attachments/assets/ca7482fb-ce68-4bc0-b227-22b4f2388715">

Safari: (buttons, from design, has a max-width. Safari doesnt scale smaller than this) 
<img width="686" alt="Screenshot 2024-08-16 at 13 14 45" src="https://github.com/user-attachments/assets/06efd999-1f48-492c-b2a5-3fcf7fae3c7e">

Chrome (same case here as with Safari, buttons have a max-width prop)
<img width="612" alt="Screenshot 2024-08-16 at 13 15 53" src="https://github.com/user-attachments/assets/fcaf1db5-7cec-4f52-affa-b3d3e7ee687a">
