### PR TITLE
v3 — add margin-top to main global for offset sticky header

### DIFF
--- a/src/app/(main)/layout.module.css
+++ b/src/app/(main)/layout.module.css
@@ -1,0 +1,3 @@
+.offsetForStickyHeader {
+  margin-top: 72px;
+}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -13,6 +13,7 @@ import { getDraftModeInfo } from "src/utils/draftmode";
 import SkipToMain from "src/components/skipToMain/SkipToMain";
 import { LEGAL_DOCUMENTS_QUERY } from "studio/lib/queries/legalDocuments";
 import { LegalDocument } from "studio/lib/payloads/legalDocuments";
+import styles from "./layout.module.css";
 
 export default async function Layout({
   children,

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -40,7 +40,7 @@ export default async function Layout({
 
   if (!hasNavigationData) {
     return (
-      <main id="main" tabIndex={-1}>
+      <main id="main" tabIndex={-1} className={styles.offsetForStickyHeader}>
         {children}
       </main>
     );


### PR DESCRIPTION
So we don't have to add margin top to every case where header is not rendered, we're adding offsetForStickyHeader to main 