### PR TITLE
v3 - benefit type field

### DIFF
--- a/studio/schemas/documents/benefit.ts
+++ b/studio/schemas/documents/benefit.ts
@@ -4,9 +4,9 @@ import { richText, title } from "../fields/text";
 export const benefitId = "benefit";
 export const benefitTypeId = "benefitType";
 
-const BENEFIT_TYPE_NONE_VALUE = "none";
+const BENEFIT_TYPE_BASIC_VALUE = "basic";
 const BENEFIT_TYPES = [
-  { title: "None", value: BENEFIT_TYPE_NONE_VALUE },
+  { title: "Basic", value: BENEFIT_TYPE_BASIC_VALUE },
   { title: "Gadgets", value: "gadgets" },
   { title: "Bonus", value: "bonus" },
   { title: "Pension", value: "pension" },
@@ -18,12 +18,12 @@ const benefitType = defineField({
   type: "string",
   title: "Benefit Type",
   description:
-    "Choose the type of benefit (use None for generic benefits). Some benefit types include visual graphs that will be displayed together with the text.",
+    "Choose the type of benefit. Some benefit types include visual graphs that will be displayed together with the text.",
   options: {
     list: BENEFIT_TYPES,
     layout: BENEFIT_TYPES.length > 5 ? "dropdown" : "radio",
   },
-  initialValue: BENEFIT_TYPE_NONE_VALUE,
+  initialValue: BENEFIT_TYPE_BASIC_VALUE,
   validation: (Rule) => Rule.required(),
 });
 

--- a/studio/schemas/documents/benefit.ts
+++ b/studio/schemas/documents/benefit.ts
@@ -4,7 +4,9 @@ import { richText, title } from "../fields/text";
 export const benefitId = "benefit";
 export const benefitTypeId = "benefitType";
 
+const BENEFIT_TYPE_NONE_VALUE = "none";
 const BENEFIT_TYPES = [
+  { title: "None", value: BENEFIT_TYPE_NONE_VALUE },
   { title: "Gadgets", value: "gadgets" },
   { title: "Bonus", value: "bonus" },
   { title: "Pension", value: "pension" },
@@ -16,11 +18,13 @@ const benefitType = defineField({
   type: "string",
   title: "Benefit Type",
   description:
-    "Choose the type of benefit, or leave blank for generic benefits. Some benefit types include visual graphs that will be displayed together with the text.",
+    "Choose the type of benefit (use None for generic benefits). Some benefit types include visual graphs that will be displayed together with the text.",
   options: {
     list: BENEFIT_TYPES,
-    layout: "dropdown",
+    layout: BENEFIT_TYPES.length > 5 ? "dropdown" : "radio",
   },
+  initialValue: BENEFIT_TYPE_NONE_VALUE,
+  validation: (Rule) => Rule.required(),
 });
 
 const benefit = defineType({

--- a/studio/schemas/documents/benefit.ts
+++ b/studio/schemas/documents/benefit.ts
@@ -1,27 +1,45 @@
-import { defineType } from 'sanity';
-import { richText, title } from '../fields/text';
+import { defineField, defineType } from "sanity";
+import { richText, title } from "../fields/text";
 
 export const benefitId = "benefit";
+export const benefitTypeId = "benefitType";
+
+const BENEFIT_TYPES = [
+  { title: "Gadgets", value: "gadgets" },
+  { title: "Bonus", value: "bonus" },
+  { title: "Pension", value: "pension" },
+  { title: "Salary Growth", value: "salaryGrowth" },
+];
+
+const benefitType = defineField({
+  name: benefitTypeId,
+  type: "string",
+  title: "Benefit Type",
+  description:
+    "Choose the type of benefit, or leave blank for generic benefits. Some benefit types include visual graphs that will be displayed together with the text.",
+  options: {
+    list: BENEFIT_TYPES,
+    layout: "dropdown",
+  },
+});
 
 const benefit = defineType({
   name: benefitId,
   type: "document",
   title: "Benefit",
-  fields: [
-    title,
-    richText
-  ],
+  fields: [benefitType, title, richText],
   preview: {
     select: {
       title: title.name,
+      type: benefitType.name,
     },
-    prepare({ title }) {
+    prepare({ title, type }) {
       return {
         title,
-        subtitle: "Benefit",
+        subtitle: `Benefit${type ? ` / ${BENEFIT_TYPES.find((o) => o.value === type)?.title ?? "Unknown benefit type"}` : ""}`,
       };
     },
   },
-})
+});
 
 export default benefit;

--- a/studio/schemas/documents/benefit.ts
+++ b/studio/schemas/documents/benefit.ts
@@ -38,9 +38,12 @@ const benefit = defineType({
       type: benefitType.name,
     },
     prepare({ title, type }) {
+      const subtitle =
+        BENEFIT_TYPES.find((o) => o.value === type)?.title ??
+        "Unknown benefit type";
       return {
         title,
-        subtitle: `Benefit${type ? ` / ${BENEFIT_TYPES.find((o) => o.value === type)?.title ?? "Unknown benefit type"}` : ""}`,
+        subtitle,
       };
     },
   },


### PR DESCRIPTION
Added field for type of benefit. "Basic" option for benefits not fitting any of the other types.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4b01d61d-83ad-492f-98d9-bab9bf3e3f7e">

List item preview includes benefit type
<img width="500" alt="image" src="https://github.com/user-attachments/assets/97504614-0b5b-4296-ad94-81e15940f0fe">
