### PR TITLE
v3 - preview api absolute redirect

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     visionTool({ defaultApiVersion: apiVersion }),
     presentationTool({
       previewUrl: {
-        draftMode: {
+        previewMode: {
           enable: "/api/draft",
         },
       },

--- a/src/app/api/disable-draft/route.ts
+++ b/src/app/api/disable-draft/route.ts
@@ -1,8 +1,8 @@
 import { draftMode } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import { absoluteUrlFromNextRequest } from "src/utils/url";
 
 export function GET(request: NextRequest) {
   draftMode().disable();
-  const url = new URL(request.nextUrl);
-  return NextResponse.redirect(new URL("/", url.origin));
+  return NextResponse.redirect(absoluteUrlFromNextRequest(request, "/"));
 }

--- a/src/app/api/draft/route.ts
+++ b/src/app/api/draft/route.ts
@@ -1,17 +1,18 @@
 import { validatePreviewUrl } from "@sanity/preview-url-secret";
 import { draftMode } from "next/headers";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 import { client } from "studio/lib/client";
 import { token } from "studio/lib/token";
+import { absoluteUrlFromNextRequest } from "src/utils/url";
 
 const clientWithToken = client.withConfig({ token });
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   try {
     const { isValid, redirectTo = "/" } = await validatePreviewUrl(
       clientWithToken,
-      request.url
+      request.url,
     );
 
     if (!isValid) {
@@ -20,7 +21,9 @@ export async function GET(request: Request) {
 
     draftMode().enable();
 
-    return NextResponse.redirect(redirectTo);
+    return NextResponse.redirect(
+      absoluteUrlFromNextRequest(request, redirectTo),
+    );
   } catch (error) {
     console.error("Error in /api/draft:", error);
     return new Response("Internal Server Error", { status: 500 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+
+export function absoluteUrlFromNextRequest(
+  request: NextRequest,
+  pathname?: string,
+) {
+  /**
+   * useful for middleware redirects where absolute url is required
+   * https://nextjs.org/docs/messages/middleware-relative-urls#possible-ways-to-fix-it
+   */
+  const absoluteUrl = request.nextUrl.clone();
+  if (pathname !== undefined) {
+    absoluteUrl.pathname = pathname;
+  }
+  return absoluteUrl;
+}


### PR DESCRIPTION
## Short Description

Since Next.js 12.1 the `NextResponse.redirect(...)` does not allow relative paths. The redirect url for `/api/draft` has therefore been made absolute with the [fix proposed by Next.js](https://nextjs.org/docs/messages/middleware-relative-urls#possible-ways-to-fix-it). The same utility function has been applied to `/api/disable-draft`.

Also, the deprecated `draftMode` property in the studio config has been replaced by `previewMode`.

---

## Visual Overview (Image/Video)

No visual changes.

---

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?
  - Please list the types of tests you've run (unit, integration, manual, etc.):
    - Manual testing in Studio Presentation tab