### PR TITLE
v3 - more sections internal link

### DIFF
--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -15,7 +15,43 @@ const SECTIONS_FRAGMENT = groq`
           }
         }
       }
-    }
+    },
+    _type == "article" => {
+      ...,
+      link {
+        ...,
+        linkType == "internal" => {
+          ...,
+          "internalLink": internalLink->{
+            "_ref": slug.current
+          }
+        }
+      }
+    },
+    _type == "callout" => {
+      ...,
+      link {
+        ...,
+        linkType == "internal" => {
+          ...,
+          "internalLink": internalLink->{
+            "_ref": slug.current
+          }
+        }
+      }
+    },
+       _type == "ctaSection" => {
+      ...,
+      callToActions[] {
+        ...,
+        linkType == "internal" => {
+          ...,
+          "internalLink": internalLink->{
+            "_ref": slug.current
+          }
+        }
+      }
+    },
   }
 `;
 


### PR DESCRIPTION
## Short Description

When referencing another document, the _key is applied automatically, however we want to use slug as the indicator of what document we're linking do. That way we can have `www.variant.no/awesome-slug-here` and not `www.variant.no/1h2f7722bbfmvmjk893nncshkkiflp`

In order to achieve this, we need to adjust our query and specify that `internalLinks` should have the value `slug.current`

---

## Visual Overview (Image/Video)

Not applicable

---

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?
  - Please list the types of tests you've run (unit, integration, manual, etc.):
  Manual testing: I've made sure each section with an internal link does in fact render the right document

---