### PR TITLE
v3 - fix(SoMeInputs): remove useEffects and use proper form patches

### DIFF
--- a/studio/components/SoMeInputs.tsx
+++ b/studio/components/SoMeInputs.tsx
@@ -45,12 +45,19 @@ const SoMeInputs: React.FC<ObjectInputProps<Record<string, any>>> = ({
     onChange(set(newPlatform, ["platform"]));
   };
 
+  const urlInputName = "social-url-input";
+  const platformInputName = "social-platform-input";
+
   return (
     <Stack space={6}>
       <Box>
         <Stack space={3}>
-          <Label>URL</Label>
+          <Label htmlFor={urlInputName} as={"label"}>
+            URL
+          </Label>
           <TextInput
+            id={urlInputName}
+            name={urlInputName}
             value={value.url}
             onChange={handleUrlChange}
             placeholder="Enter URL"
@@ -59,8 +66,15 @@ const SoMeInputs: React.FC<ObjectInputProps<Record<string, any>>> = ({
       </Box>
       <Box>
         <Stack space={3}>
-          <Label>Platform</Label>
-          <Select value={value.platform} onChange={handlePlatformChange}>
+          <Label htmlFor={platformInputName} as={"label"}>
+            Platform
+          </Label>
+          <Select
+            id={platformInputName}
+            name={platformInputName}
+            value={value.platform}
+            onChange={handlePlatformChange}
+          >
             <option value="">Select Platform</option>
             {Object.values(SoMePlatforms).map((platform) => (
               <option key={platform} value={platform}>

--- a/studio/components/SoMeInputs.tsx
+++ b/studio/components/SoMeInputs.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { ObjectInputProps, PatchEvent, set } from "sanity";
+import React from "react";
+import { ObjectInputProps, set } from "sanity";
 import { Box, TextInput, Select, Stack, Label } from "@sanity/ui";
 
 export const SoMePlatforms: { [key: string]: string } = {
@@ -14,44 +14,35 @@ export const SoMePlatforms: { [key: string]: string } = {
   tikTok: "Tiktok",
 };
 
+const detectPlatformFromUrl = (url: string): string | null => {
+  for (const key in SoMePlatforms) {
+    if (url.includes(key)) {
+      return SoMePlatforms[key];
+    }
+  }
+  return null;
+};
+
 const SoMeInputs: React.FC<ObjectInputProps<Record<string, any>>> = ({
   value = {},
   onChange,
 }) => {
-  const [url, setUrl] = useState(value.url || "");
-  const [platform, setPlatform] = useState(value.platform || "");
-
-  useEffect(() => {
-    let detectedPlatform = "";
-    for (const key in SoMePlatforms) {
-      if (url.includes(key)) {
-        detectedPlatform = SoMePlatforms[key];
-        break;
-      }
-    }
-    setPlatform(detectedPlatform);
-    if (onChange) {
-      onChange(
-        PatchEvent.from([set({ ...value, url, platform: detectedPlatform })]),
-      );
-    }
-  }, [url, onChange]);
-
   const handleUrlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!onChange) return;
     const newUrl = event.target.value;
-    setUrl(newUrl);
+    onChange(set(newUrl, ["url"]));
+    const detectedPlatform = detectPlatformFromUrl(newUrl);
+    if (detectedPlatform !== null) {
+      onChange(set(detectedPlatform, ["platform"]));
+    }
   };
 
   const handlePlatformChange = (
     event: React.ChangeEvent<HTMLSelectElement>,
   ) => {
+    if (!onChange) return;
     const newPlatform = event.target.value;
-    setPlatform(newPlatform);
-    if (onChange) {
-      onChange(
-        PatchEvent.from([set({ ...value, url, platform: newPlatform })]),
-      );
-    }
+    onChange(set(newPlatform, ["platform"]));
   };
 
   return (
@@ -60,7 +51,7 @@ const SoMeInputs: React.FC<ObjectInputProps<Record<string, any>>> = ({
         <Stack space={3}>
           <Label>URL</Label>
           <TextInput
-            value={url}
+            value={value.url}
             onChange={handleUrlChange}
             placeholder="Enter URL"
           />
@@ -69,7 +60,7 @@ const SoMeInputs: React.FC<ObjectInputProps<Record<string, any>>> = ({
       <Box>
         <Stack space={3}>
           <Label>Platform</Label>
-          <Select value={platform} onChange={handlePlatformChange}>
+          <Select value={value.platform} onChange={handlePlatformChange}>
             <option value="">Select Platform</option>
             {Object.values(SoMePlatforms).map((platform) => (
               <option key={platform} value={platform}>


### PR DESCRIPTION
## Short Description

Refactored `SoMeInputs` to not rely on `useEffect`s, and used proper `set` patches to avoid updating the whole object when changing url and platform.

This change was motivated by an ESLint warning about a missing dependency in one of the `useEffect`s. Naturally, this warning has now been adressed.

---

## Visual Overview (Image/Video)

No visual changes.

---

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?
  - Please list the types of tests you've run (unit, integration, manual, etc.):