### PR TITLE
v3 - manual Sanity-controlled redirects

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,14 +6,13 @@ export async function middleware(request: NextRequest) {
   const slug = request.nextUrl.pathname;
   const redirect = await client.fetch<RedirectSparsePage | null>(
     `*[_type == "redirect" && source.current == "${slug}"][0]{
-        "destination":destination.current,
-        permanent
+        "destination":destination.current
       }`,
   );
   if (redirect !== null) {
     return NextResponse.redirect(
       new URL(redirect.destination, request.url),
-      redirect.permanent ? 308 : 307,
+      307,
     );
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,20 +1,37 @@
 import { NextRequest, NextResponse } from "next/server";
-import { client } from "../studio/lib/client";
-import { RedirectSparsePage } from "../studio/lib/payloads/redirect";
 import { HTTP_STATUSES } from "./utils/http";
+import { RedirectDestinationSlugPage } from "studio/lib/payloads/redirect";
+import { REDIRECT_BY_SOURCE_SLUG_QUERY } from "../studio/lib/queries/redirects";
 
 export async function middleware(request: NextRequest) {
   const slug = request.nextUrl.pathname;
-  const redirect = await client.fetch<RedirectSparsePage | null>(
-    `*[_type == "redirect" && source.current == "${slug}"][0]{
-        "destination":destination.current
-      }`,
+  const slugQueryParam = slug.replace(/^\/+/, "");
+  /*
+   fetching redirect data via API route to avoid token leaking to client
+   (middleware should run on server, but `experimental_taintUniqueValue` begs to differ...)
+  */
+  const redirectRes = await fetch(
+    new URL("/api/fetchData", process.env.NEXT_PUBLIC_URL),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: REDIRECT_BY_SOURCE_SLUG_QUERY,
+        params: { slug: slugQueryParam },
+      }),
+    },
   );
-  if (redirect !== null) {
-    return NextResponse.redirect(
-      new URL(redirect.destination, request.url),
-      HTTP_STATUSES.TEMPORARY_REDIRECT,
-    );
+  if (redirectRes.ok) {
+    const redirect: RedirectDestinationSlugPage | null =
+      await redirectRes.json();
+    if (redirect?.destinationSlug) {
+      return NextResponse.redirect(
+        new URL(redirect.destinationSlug, request.url),
+        HTTP_STATUSES.TEMPORARY_REDIRECT,
+      );
+    }
   }
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { client } from "../studio/lib/client";
+import { RedirectSparsePage } from "../studio/lib/payloads/redirect";
+
+export async function middleware(request: NextRequest) {
+  const slug = request.nextUrl.pathname;
+  const redirect = await client.fetch<RedirectSparsePage | null>(
+    `*[_type == "redirect" && source.current == "${slug}"][0]{
+        "destination":destination.current,
+        permanent
+      }`,
+  );
+  if (redirect !== null) {
+    return NextResponse.redirect(
+      new URL(redirect.destination, request.url),
+      redirect.permanent ? 308 : 307,
+    );
+  }
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+  ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,9 +26,9 @@ export async function middleware(request: NextRequest) {
   if (redirectRes.ok) {
     const redirect: RedirectDestinationSlugPage | null =
       await redirectRes.json();
-    if (redirect?.destinationSlug) {
+    if (redirect?.destination) {
       return NextResponse.redirect(
-        new URL(redirect.destinationSlug, request.url),
+        new URL(redirect.destination, request.url),
         HTTP_STATUSES.TEMPORARY_REDIRECT,
       );
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { client } from "../studio/lib/client";
 import { RedirectSparsePage } from "../studio/lib/payloads/redirect";
+import { HTTP_STATUSES } from "./utils/http";
 
 export async function middleware(request: NextRequest) {
   const slug = request.nextUrl.pathname;
@@ -12,7 +13,7 @@ export async function middleware(request: NextRequest) {
   if (redirect !== null) {
     return NextResponse.redirect(
       new URL(redirect.destination, request.url),
-      307,
+      HTTP_STATUSES.TEMPORARY_REDIRECT,
     );
   }
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,3 @@
+export const HTTP_STATUSES = {
+  TEMPORARY_REDIRECT: 307,
+};

--- a/studio/components/PrefixedSlugInput.tsx
+++ b/studio/components/PrefixedSlugInput.tsx
@@ -1,0 +1,21 @@
+import { SlugInputProps } from "sanity";
+import styles from "./prefixedSlugInput.module.css";
+import { useTheme } from "@sanity/ui";
+
+type PrefixedSlugInputProps = SlugInputProps & {
+  prefix: string;
+};
+
+const PrefixedSlugInput = ({ prefix, ...props }: PrefixedSlugInputProps) => {
+  const theme = useTheme();
+  const prefersDark = theme.sanity.v2?.color._dark ?? false;
+
+  return (
+    <div className={`${prefersDark ? `${styles.dark} ` : ""}${styles.wrapper}`}>
+      <span className={styles.prefixWrapper}>{prefix}</span>
+      {props.renderDefault(props)}
+    </div>
+  );
+};
+
+export default PrefixedSlugInput;

--- a/studio/components/RedirectThumbnail.tsx
+++ b/studio/components/RedirectThumbnail.tsx
@@ -1,0 +1,5 @@
+const RedirectThumbnail = ({ permanent }: { permanent: boolean }) => {
+  return <span style={{ fontSize: "1.5rem" }}>{permanent ? "⮕" : "⇢"}</span>;
+};
+
+export default RedirectThumbnail;

--- a/studio/components/RedirectThumbnail.tsx
+++ b/studio/components/RedirectThumbnail.tsx
@@ -1,5 +1,0 @@
-const RedirectThumbnail = ({ permanent }: { permanent: boolean }) => {
-  return <span style={{ fontSize: "1.5rem" }}>{permanent ? "⮕" : "⇢"}</span>;
-};
-
-export default RedirectThumbnail;

--- a/studio/components/prefixedSlugInput.module.css
+++ b/studio/components/prefixedSlugInput.module.css
@@ -1,0 +1,28 @@
+.wrapper {
+  display: flex;
+}
+
+.wrapper input {
+  padding-left: 0.5rem;
+  border-left: none;
+}
+
+.prefixWrapper + * * {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.prefixWrapper {
+  background-color: rgb(246, 246, 248);
+  border-radius: 4px 0 0 4px;
+  padding: 0.375rem 0.5rem 0.375rem 0.5rem;
+  border: 1px solid rgb(225, 226, 230);
+  border-right: none;
+}
+
+[data-scheme="dark"] .prefixWrapper {
+  background-color: rgb(25, 26, 36);
+  border: 1px solid rgb(41, 44, 61);
+  border-right: none;
+  color: white;
+}

--- a/studio/lib/payloads/redirect.ts
+++ b/studio/lib/payloads/redirect.ts
@@ -1,7 +1,3 @@
-export interface RedirectPage extends RedirectSparsePage {
-  source: string;
-}
-
-export interface RedirectSparsePage {
-  destination: string;
+export interface RedirectDestinationSlugPage {
+  destinationSlug: string;
 }

--- a/studio/lib/payloads/redirect.ts
+++ b/studio/lib/payloads/redirect.ts
@@ -1,0 +1,8 @@
+export interface RedirectPage extends RedirectSparsePage {
+  source: string;
+}
+
+export interface RedirectSparsePage {
+  destination: string;
+  permanent: boolean;
+}

--- a/studio/lib/payloads/redirect.ts
+++ b/studio/lib/payloads/redirect.ts
@@ -4,5 +4,4 @@ export interface RedirectPage extends RedirectSparsePage {
 
 export interface RedirectSparsePage {
   destination: string;
-  permanent: boolean;
 }

--- a/studio/lib/payloads/redirect.ts
+++ b/studio/lib/payloads/redirect.ts
@@ -1,3 +1,3 @@
 export interface RedirectDestinationSlugPage {
-  destinationSlug: string;
+  destination: string;
 }

--- a/studio/lib/queries/redirects.ts
+++ b/studio/lib/queries/redirects.ts
@@ -1,0 +1,10 @@
+import { groq } from "next-sanity";
+
+export const REDIRECT_BY_SOURCE_SLUG_QUERY = groq`
+  *[_type == "redirect" && source.current == $slug][0]{
+    "destinationSlug": select(
+      destination.type == "slug" => destination.slug.current,
+      destination.type == "reference" => destination.reference->slug.current
+    )
+  }
+`;

--- a/studio/lib/queries/redirects.ts
+++ b/studio/lib/queries/redirects.ts
@@ -3,7 +3,6 @@ import { groq } from "next-sanity";
 export const REDIRECT_BY_SOURCE_SLUG_QUERY = groq`
   *[_type == "redirect" && source.current == $slug][0]{
     "destination": select(
-      destination.type == "slug" => destination.slug.current,
       destination.type == "reference" => destination.reference->slug.current,
       destination.type == "external" => destination.external
     )

--- a/studio/lib/queries/redirects.ts
+++ b/studio/lib/queries/redirects.ts
@@ -2,9 +2,10 @@ import { groq } from "next-sanity";
 
 export const REDIRECT_BY_SOURCE_SLUG_QUERY = groq`
   *[_type == "redirect" && source.current == $slug][0]{
-    "destinationSlug": select(
+    "destination": select(
       destination.type == "slug" => destination.slug.current,
-      destination.type == "reference" => destination.reference->slug.current
+      destination.type == "reference" => destination.reference->slug.current,
+      destination.type == "external" => destination.external
     )
   }
 `;

--- a/studio/schema.ts
+++ b/studio/schema.ts
@@ -15,6 +15,7 @@ import benefit from "./schemas/documents/benefit";
 import companyLocation from "./schemas/documents/companyLocation";
 import compensations from "./schemas/documents/compensations";
 import siteSettings from "./schemas/documents/siteSettings";
+import redirect from "./schemas/documents/redirect";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
@@ -33,6 +34,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     legalDocument,
     compensations,
     benefit,
+    redirect,
     companyLocation,
   ],
 };

--- a/studio/schemas/deskStructure.ts
+++ b/studio/schemas/deskStructure.ts
@@ -11,12 +11,14 @@ import {
   InfoOutlineIcon,
   HeartIcon,
   CaseIcon,
+  DoubleChevronRightIcon,
   PinIcon,
 } from "@sanity/icons";
 import { soMeLinksID } from "./documents/socialMediaProfiles";
 import { companyInfoID } from "./documents/companyInfo";
 import { legalDocumentID } from "./documents/legalDocuments";
 import { compensationsId } from "./documents/compensations";
+import { redirectId } from "./documents/redirect";
 import { companyLocationID } from "./documents/companyLocation";
 
 export default (S: StructureBuilder) =>
@@ -97,4 +99,8 @@ export default (S: StructureBuilder) =>
                 ),
             ]),
         ),
+      S.listItem()
+        .title("Redirects")
+        .icon(DoubleChevronRightIcon)
+        .child(S.documentTypeList(redirectId).title("Redirects")),
     ]);

--- a/studio/schemas/documents/redirect.ts
+++ b/studio/schemas/documents/redirect.ts
@@ -4,13 +4,11 @@ import RedirectThumbnail from "../../components/RedirectThumbnail";
 import { pageBuilderID } from "../builders/pageBuilder";
 import { blogId } from "./blog";
 import { compensationsId } from "./compensations";
+import PrefixedSlugInput from "../../components/PrefixedSlugInput";
 
 const slugValidator = (rule: SlugRule) =>
   rule.required().custom((value: Slug | undefined) => {
     if (!value || !value.current) return "Can't be blank";
-    if (!value.current.startsWith("/")) {
-      return "The path must start with a forward slash ('/')";
-    }
     return true;
   });
 
@@ -37,6 +35,9 @@ const redirect = defineType({
       description: "Which url should this redirect apply for",
       type: "slug",
       validation: slugValidator,
+      components: {
+        input: (props) => PrefixedSlugInput({ prefix: "/", ...props }),
+      },
     }),
     defineField({
       name: "destination",
@@ -85,6 +86,9 @@ const redirect = defineType({
               return true;
             },
           },
+          components: {
+            input: (props) => PrefixedSlugInput({ prefix: "/", ...props }),
+          },
         }),
       ],
     }),
@@ -116,7 +120,7 @@ const redirect = defineType({
         destinationType === "slug" ? destinationSlug : destinationReferenceSlug;
       const title =
         source && destination
-          ? `${source.current} → ${destination}`
+          ? `/${source.current} → /${destination}`
           : undefined;
       return {
         title,

--- a/studio/schemas/documents/redirect.ts
+++ b/studio/schemas/documents/redirect.ts
@@ -1,6 +1,5 @@
 import { defineField, defineType, type Slug } from "sanity";
 import { SlugRule } from "@sanity/types";
-import RedirectThumbnail from "../../components/RedirectThumbnail";
 import { pageBuilderID } from "../builders/pageBuilder";
 import { blogId } from "./blog";
 import { compensationsId } from "./compensations";
@@ -18,16 +17,6 @@ const redirect = defineType({
   name: redirectId,
   title: "Redirect",
   type: "document",
-  readOnly: (ctx) => {
-    /*
-      make permanent redirects read-only after initial publish
-      this is a soft guardrail that is possible to bypass
-     */
-    return (
-      (ctx.document?.permanent ?? false) &&
-      !ctx.document?._id.startsWith("drafts.")
-    );
-  },
   fields: [
     defineField({
       name: "source",
@@ -92,14 +81,6 @@ const redirect = defineType({
         }),
       ],
     }),
-    defineField({
-      name: "permanent",
-      title: "Permanent",
-      description:
-        "Will this redirect exist throughout the foreseeable future?",
-      type: "boolean",
-      initialValue: false,
-    }),
   ],
   preview: {
     select: {
@@ -107,14 +88,12 @@ const redirect = defineType({
       destinationType: "destination.type",
       destinationSlug: "destination.slug.current",
       destinationReferenceSlug: "destination.reference.slug.current",
-      permanent: "permanent",
     },
     prepare({
       source,
       destinationType,
       destinationSlug,
       destinationReferenceSlug,
-      permanent,
     }) {
       const destination =
         destinationType === "slug" ? destinationSlug : destinationReferenceSlug;
@@ -124,8 +103,7 @@ const redirect = defineType({
           : undefined;
       return {
         title,
-        subtitle: permanent ? "Permanent" : "Temporary",
-        media: RedirectThumbnail({ permanent }),
+        subtitle: "type: " + destinationType,
       };
     },
   },

--- a/studio/schemas/documents/redirect.ts
+++ b/studio/schemas/documents/redirect.ts
@@ -110,8 +110,10 @@ const redirect = defineType({
       if (
         typeof sourceSlug !== "string" ||
         typeof destinationType !== "string" ||
-        typeof destinationReferenceSlug !== "string" ||
-        typeof destinationExternalURL !== "string"
+        (destinationType === "reference" &&
+          typeof destinationReferenceSlug !== "string") ||
+        (destinationType === "external" &&
+          typeof destinationExternalURL !== "string")
       ) {
         return {};
       }

--- a/studio/schemas/documents/redirect.ts
+++ b/studio/schemas/documents/redirect.ts
@@ -1,6 +1,9 @@
 import { defineField, defineType, type Slug } from "sanity";
 import { SlugRule } from "@sanity/types";
 import RedirectThumbnail from "../../components/RedirectThumbnail";
+import { pageBuilderID } from "../builders/pageBuilder";
+import { blogId } from "./blog";
+import { compensationsId } from "./compensations";
 
 const slugValidator = (rule: SlugRule) =>
   rule.required().custom((value: Slug | undefined) => {
@@ -30,45 +33,90 @@ const redirect = defineType({
   fields: [
     defineField({
       name: "source",
+      title: "Source",
       description: "Which url should this redirect apply for",
       type: "slug",
       validation: slugValidator,
     }),
     defineField({
       name: "destination",
-      description: "Where should the user be redirected?",
-      type: "slug",
-      validation: slugValidator,
-      options: {
-        isUnique: () => {
-          /*
-           does not need to be unique since multiple source paths
-           can point to the same destination path
-          */
-          return true;
-        },
-      },
+      title: "Destination",
+      type: "object",
+      fields: [
+        defineField({
+          name: "type",
+          title: "Type",
+          description: "Choose between an internal page or a static slug",
+          type: "string",
+          initialValue: "reference",
+          options: {
+            layout: "radio",
+            list: [
+              { value: "reference", title: "Internal Page" },
+              { value: "slug", title: "Slug" },
+            ],
+          },
+        }),
+        defineField({
+          name: "reference",
+          title: "Internal Page",
+          description: "Where should the user be redirected?",
+          type: "reference",
+          to: [
+            { type: pageBuilderID },
+            { type: blogId },
+            { type: compensationsId },
+          ],
+          hidden: ({ parent }) => parent?.type !== "reference",
+        }),
+        defineField({
+          name: "slug",
+          title: "Slug",
+          description: "Where should the user be redirected?",
+          type: "slug",
+          hidden: ({ parent }) => parent?.type !== "slug",
+          validation: slugValidator,
+          options: {
+            isUnique: () => {
+              /*
+               does not need to be unique since multiple source paths
+               can point to the same destination path
+              */
+              return true;
+            },
+          },
+        }),
+      ],
     }),
     defineField({
       name: "permanent",
+      title: "Permanent",
       description:
         "Will this redirect exist throughout the foreseeable future?",
       type: "boolean",
+      initialValue: false,
     }),
   ],
-  initialValue: {
-    permanent: false,
-  },
   preview: {
     select: {
       source: "source",
-      destination: "destination",
+      destinationType: "destination.type",
+      destinationSlug: "destination.slug.current",
+      destinationReferenceSlug: "destination.reference.slug.current",
       permanent: "permanent",
     },
-    prepare({ source, destination, permanent }) {
+    prepare({
+      source,
+      destinationType,
+      destinationSlug,
+      destinationReferenceSlug,
+      permanent,
+    }) {
+      const destination =
+        destinationType === "slug" ? destinationSlug : destinationReferenceSlug;
       const title =
         source && destination
-          ? `${source.current} → ${destination.current}`
+          ? `${source.current} → ${destination}`
           : undefined;
       return {
         title,

--- a/studio/schemas/documents/redirect.ts
+++ b/studio/schemas/documents/redirect.ts
@@ -61,7 +61,6 @@ const redirect = defineType({
             list: [
               { value: "reference", title: "Internal Page" },
               { value: "external", title: "External URL" },
-              { value: "slug", title: "Slug" },
             ],
           },
         }),
@@ -92,29 +91,6 @@ const redirect = defineType({
               requiredIfDestinationType("external", document, value),
             ),
         }),
-        defineField({
-          name: "slug",
-          title: "Slug",
-          description: "Where should the user be redirected?",
-          type: "slug",
-          hidden: ({ parent }) => parent?.type !== "slug",
-          validation: (rule) =>
-            rule.custom((value, { document }) =>
-              requiredIfDestinationType("slug", document, value),
-            ),
-          options: {
-            isUnique: () => {
-              /*
-               does not need to be unique since multiple source paths
-               can point to the same destination path
-              */
-              return true;
-            },
-          },
-          components: {
-            input: (props) => PrefixedSlugInput({ prefix: "/", ...props }),
-          },
-        }),
       ],
     }),
   ],
@@ -122,36 +98,37 @@ const redirect = defineType({
     select: {
       sourceSlug: "source.current",
       destinationType: "destination.type",
-      destinationSlug: "destination.slug.current",
       destinationReferenceSlug: "destination.reference.slug.current",
       destinationExternalURL: "destination.external",
     },
     prepare({
       sourceSlug,
       destinationType,
-      destinationSlug,
       destinationReferenceSlug,
       destinationExternalURL,
-    }: {
-      sourceSlug: string;
-      destinationType: string;
-      destinationSlug: string;
-      destinationReferenceSlug: string;
-      destinationExternalURL: string;
     }) {
+      if (
+        typeof sourceSlug !== "string" ||
+        typeof destinationType !== "string" ||
+        typeof destinationReferenceSlug !== "string" ||
+        typeof destinationExternalURL !== "string"
+      ) {
+        return {};
+      }
       const destination = {
-        slug: `/${destinationSlug}`,
         reference: `/${destinationReferenceSlug}`,
         external: destinationExternalURL,
       }[destinationType];
-      console.log(destination);
       const title =
         sourceSlug && destination
           ? `/${sourceSlug} → ${destination}`
           : undefined;
       return {
         title,
-        subtitle: "type: " + destinationType,
+        subtitle: {
+          reference: "Internal",
+          external: "External",
+        }[destinationType],
       };
     },
   },

--- a/studio/schemas/documents/redirect.ts
+++ b/studio/schemas/documents/redirect.ts
@@ -1,0 +1,82 @@
+import { defineField, defineType, type Slug } from "sanity";
+import { SlugRule } from "@sanity/types";
+import RedirectThumbnail from "../../components/RedirectThumbnail";
+
+const slugValidator = (rule: SlugRule) =>
+  rule.required().custom((value: Slug | undefined) => {
+    if (!value || !value.current) return "Can't be blank";
+    if (!value.current.startsWith("/")) {
+      return "The path must start with a forward slash ('/')";
+    }
+    return true;
+  });
+
+export const redirectId = "redirect";
+
+const redirect = defineType({
+  name: redirectId,
+  title: "Redirect",
+  type: "document",
+  readOnly: (ctx) => {
+    /*
+      make permanent redirects read-only after initial publish
+      this is a soft guardrail that is possible to bypass
+     */
+    return (
+      (ctx.document?.permanent ?? false) &&
+      !ctx.document?._id.startsWith("drafts.")
+    );
+  },
+  fields: [
+    defineField({
+      name: "source",
+      description: "Which url should this redirect apply for",
+      type: "slug",
+      validation: slugValidator,
+    }),
+    defineField({
+      name: "destination",
+      description: "Where should the user be redirected?",
+      type: "slug",
+      validation: slugValidator,
+      options: {
+        isUnique: () => {
+          /*
+           does not need to be unique since multiple source paths
+           can point to the same destination path
+          */
+          return true;
+        },
+      },
+    }),
+    defineField({
+      name: "permanent",
+      description:
+        "Will this redirect exist throughout the foreseeable future?",
+      type: "boolean",
+    }),
+  ],
+  initialValue: {
+    permanent: false,
+  },
+  preview: {
+    select: {
+      source: "source",
+      destination: "destination",
+      permanent: "permanent",
+    },
+    prepare({ source, destination, permanent }) {
+      const title =
+        source && destination
+          ? `${source.current} → ${destination.current}`
+          : undefined;
+      return {
+        title,
+        subtitle: permanent ? "Permanent" : "Temporary",
+        media: RedirectThumbnail({ permanent }),
+      };
+    },
+  },
+});
+
+export default redirect;

--- a/studio/schemas/schemaTypes/slug.ts
+++ b/studio/schemas/schemaTypes/slug.ts
@@ -28,7 +28,10 @@ function createSlugField(source: string) {
     name: "slug",
     title: "URL Path (slug)",
     description:
-      "Enter a unique URL path for the page. This path will be used in the website's address bar. A URL path, also known as a slug, is a URL-friendly version of the page title, used to create a human-readable and search engine optimized URL for the content. Legal characters include latin letters, digits, hyphen (-), underscore (_), full stop (.) and tilde (~)",
+      "Enter a unique URL path for the page. This path will be used in the website's address bar. " +
+      "A URL path, also known as a slug, is a URL-friendly version of the page title, used to create " +
+      "a human-readable and search engine optimized URL for the content. " +
+      "Note that the slug can not be changed after publication, but alternative slugs can be defined via Redirects.",
     options: {
       source,
       maxLength: SLUG_MAX_LENGTH,
@@ -49,7 +52,7 @@ function createSlugField(source: string) {
         if (value?.current === undefined) return true;
         return (
           encodeURIComponent(value.current) === value.current ||
-          "Slug can only consist of latin letters, digits, hyphen (-), underscore (_), full stop (.) and tilde (~)"
+          "Slug can only consist of latin letters (a-z, A-Z), digits (0-9), hyphen (-), underscore (_), full stop (.) and tilde (~)"
         );
       }),
     readOnly: (ctx) => {

--- a/studio/schemas/schemaTypes/slug.ts
+++ b/studio/schemas/schemaTypes/slug.ts
@@ -56,6 +56,8 @@ function createSlugField(source: string) {
       /*
         make slugs read-only after initial publish
         to avoid breaking shared links
+
+        if new slugs are needed, redirects can be used instead
        */
       return ctx.document !== undefined && isPublished(ctx.document);
     },


### PR DESCRIPTION
Further explanation is found here: #561 

Added support for defining temporary redirects from Sanity Studio. Redirect destination can be either a reference to a page defined in Sanity, or an external URL. Support for a static internal slug has not been added, but might be introduced in the future.

Redirects are performed in a Next.js middleware. Using a middleware ensures that all redirects are up-to-date, but will likely reduce performance. The alternative is a [redirects list](https://nextjs.org/docs/pages/api-reference/next-config-js/redirects) generated at build-time. This will likely improve performance, but has the disadvantage of outdated redirects between builds. This could be adressed by adding some type of [hook that would trigger a rebuild](https://www.sanity.io/guides/nextjs-automatic-redirects#12513fa8acbe) when new slugs are published. 

---

## Visual Overview (Image/Video)

Page reference:

<img width="1481" alt="image" src="https://github.com/user-attachments/assets/2ab80858-c199-4f97-8681-f7fd40695ce4">


External URL:

<img width="1478" alt="image" src="https://github.com/user-attachments/assets/b6f9bf93-d04a-4d4c-bd1f-7d3e9759da44">



---

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?