### PR TITLE
v3 - singular form of company location id

### DIFF
--- a/studio/schema.ts
+++ b/studio/schema.ts
@@ -12,7 +12,7 @@ import posts from "./schemas/documents/post";
 import categories from "./schemas/fields/categories";
 import legalDocument from "./schemas/documents/legalDocuments";
 import benefit from "./schemas/documents/benefit";
-import companyLocations from "./schemas/documents/companyLocations";
+import companyLocation from "./schemas/documents/companyLocation";
 import compensations from "./schemas/documents/compensations";
 import siteSettings from "./schemas/documents/siteSettings";
 
@@ -33,6 +33,6 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     legalDocument,
     compensations,
     benefit,
-    companyLocations,
+    companyLocation,
   ],
 };

--- a/studio/schemas/deskStructure.ts
+++ b/studio/schemas/deskStructure.ts
@@ -17,7 +17,7 @@ import { soMeLinksID } from "./documents/socialMediaProfiles";
 import { companyInfoID } from "./documents/companyInfo";
 import { legalDocumentID } from "./documents/legalDocuments";
 import { compensationsId } from "./documents/compensations";
-import { companyLocationsID } from "./documents/companyLocations";
+import { companyLocationID } from "./documents/companyLocations";
 
 export default (S: StructureBuilder) =>
   S.list()
@@ -43,7 +43,7 @@ export default (S: StructureBuilder) =>
                 .title("Company Locations")
                 .icon(PinIcon)
                 .child(
-                  S.documentTypeList(companyLocationsID).title(
+                  S.documentTypeList(companyLocationID).title(
                     "Company Locations",
                   ),
                 ),

--- a/studio/schemas/deskStructure.ts
+++ b/studio/schemas/deskStructure.ts
@@ -17,7 +17,7 @@ import { soMeLinksID } from "./documents/socialMediaProfiles";
 import { companyInfoID } from "./documents/companyInfo";
 import { legalDocumentID } from "./documents/legalDocuments";
 import { compensationsId } from "./documents/compensations";
-import { companyLocationID } from "./documents/companyLocations";
+import { companyLocationID } from "./documents/companyLocation";
 
 export default (S: StructureBuilder) =>
   S.list()

--- a/studio/schemas/documents/companyLocation.ts
+++ b/studio/schemas/documents/companyLocation.ts
@@ -3,7 +3,7 @@ import { defineField, defineType } from "sanity";
 export const companyLocationID = "companyLocation";
 export const companyLocationNameID = "companyLocationName";
 
-const companyLocations = defineType({
+const companyLocation = defineType({
   name: companyLocationID,
   type: "document",
   title: "Location",
@@ -17,4 +17,4 @@ const companyLocations = defineType({
   ],
 });
 
-export default companyLocations;
+export default companyLocation;

--- a/studio/schemas/documents/companyLocations.ts
+++ b/studio/schemas/documents/companyLocations.ts
@@ -1,16 +1,16 @@
 import { defineField, defineType } from "sanity";
 
-export const companyLocationsID = "companyLocations";
 export const companyLocationID = "companyLocation";
+export const companyLocationNameID = "companyLocationName";
 
 const companyLocations = defineType({
-  name: companyLocationsID,
+  name: companyLocationID,
   type: "document",
   title: "Location",
   description: "Content related to an individual location within the company",
   fields: [
     defineField({
-      name: companyLocationID,
+      name: companyLocationNameID,
       type: "string",
       title: "Location",
     }),

--- a/studio/schemas/objects/compensations/bonusesByLocation.ts
+++ b/studio/schemas/objects/compensations/bonusesByLocation.ts
@@ -1,6 +1,6 @@
 import { defineField } from "sanity";
 import { location, locationID } from "../locations";
-import { companyLocationID } from "studio/schemas/documents/companyLocations";
+import { companyLocationNameID } from "studio/schemas/documents/companyLocations";
 
 export const bonusesByLocation = defineField({
   name: "bonusesByLocation",
@@ -37,7 +37,7 @@ export const bonusesByLocation = defineField({
       preview: {
         select: {
           averageBonus: "averageBonus",
-          location: `${locationID}.${companyLocationID}`,
+          location: `${locationID}.${companyLocationNameID}`,
         },
         prepare({ averageBonus, location }) {
           return {

--- a/studio/schemas/objects/compensations/bonusesByLocation.ts
+++ b/studio/schemas/objects/compensations/bonusesByLocation.ts
@@ -1,6 +1,6 @@
 import { defineField } from "sanity";
 import { location, locationID } from "../locations";
-import { companyLocationNameID } from "studio/schemas/documents/companyLocations";
+import { companyLocationNameID } from "studio/schemas/documents/companyLocation";
 
 export const bonusesByLocation = defineField({
   name: "bonusesByLocation",

--- a/studio/schemas/objects/locations.ts
+++ b/studio/schemas/objects/locations.ts
@@ -1,5 +1,5 @@
 import { defineField } from "sanity";
-import { companyLocationsID } from "../documents/companyLocations";
+import { companyLocationID } from "../documents/companyLocations";
 
 export const locationsID = "locations";
 export const locationID = "location";
@@ -10,7 +10,7 @@ export const location = defineField({
   title: "Select a location",
   description:
     "Select the office location this content applies to. If it applies to all locations, you can leave this field empty.",
-  to: [{ type: companyLocationsID }],
+  to: [{ type: companyLocationID }],
   options: {
     disableNew: true,
   },

--- a/studio/schemas/objects/locations.ts
+++ b/studio/schemas/objects/locations.ts
@@ -1,5 +1,5 @@
 import { defineField } from "sanity";
-import { companyLocationID } from "../documents/companyLocations";
+import { companyLocationID } from "../documents/companyLocation";
 
 export const locationsID = "locations";
 export const locationID = "location";


### PR DESCRIPTION
The id used for the company location document was in plural. This is confusing as there is also a field accepting multiple locations using the plural form. The location name of the location document has been given a separate id.

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?