### PR TITLE
v3 - read-only slug for published documents

### DIFF
--- a/studio/schemas/schemaTypes/slug.ts
+++ b/studio/schemas/schemaTypes/slug.ts
@@ -1,4 +1,5 @@
 import { defineField, SlugValidationContext } from "sanity";
+import { isPublished } from "../../utils/documentUtils";
 
 async function isSlugUniqueAcrossAllDocuments(
   slug: string,
@@ -51,6 +52,13 @@ function createSlugField(source: string) {
           "Slug can only consist of latin letters, digits, hyphen (-), underscore (_), full stop (.) and tilde (~)"
         );
       }),
+    readOnly: (ctx) => {
+      /*
+        make slugs read-only after initial publish
+        to avoid breaking shared links
+       */
+      return ctx.document !== undefined && isPublished(ctx.document);
+    },
   });
 }
 

--- a/studio/utils/documentUtils.ts
+++ b/studio/utils/documentUtils.ts
@@ -1,0 +1,9 @@
+import type { SanityDocument } from "@sanity/types";
+
+export function isPublished(document: SanityDocument) {
+  return !isDraft(document);
+}
+
+export function isDraft(document: SanityDocument) {
+  return document._id.startsWith("drafts.") || document._rev === undefined;
+}


### PR DESCRIPTION
Alternative solution to #560 

All slug fields have been made read-only when the related document is published.

---

## Visual Overview (Image/Video)

| Draft | Published |
| --- | --- |
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/9668a2be-0b2a-4e5b-9afc-a348b406e6c4"> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/4de29638-ae15-4511-89d2-ac3e4812f233">

---

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?