### PR TITLE
v3 - open graph image dimensions

### DIFF
--- a/src/app/api/openGraphImage/route.tsx
+++ b/src/app/api/openGraphImage/route.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { NextRequest } from "next/server";
 import OpenGraphImage from "./OpenGraphImage";
+import { OPEN_GRAPH_IMAGE_DIMENSIONS } from "../../../utils/seo";
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
@@ -9,8 +10,8 @@ export async function GET(request: NextRequest) {
   return new ImageResponse(
     <OpenGraphImage title={title} description={description ?? undefined} />,
     {
-      width: 1200,
-      height: 630,
+      width: OPEN_GRAPH_IMAGE_DIMENSIONS.width,
+      height: OPEN_GRAPH_IMAGE_DIMENSIONS.height,
     },
   );
 }

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -81,8 +81,12 @@ export async function generateMetadataFromSeo(
 ): Promise<Metadata> {
   const companyInfo = await fetchCompanyInfo();
 
-  const title = seo?.title || companyInfo?.siteMetadata?.siteName || "Variant";
-  const description = seo?.description;
+  const title =
+    seo?.title ||
+    companyInfo?.defaultSEO?.title ||
+    companyInfo?.siteMetadata?.siteName ||
+    "Variant";
+  const description = seo?.description || companyInfo?.defaultSEO?.description;
   const keywords = seo?.keywords || "";
 
   const favicon = companyInfo?.brandAssets?.favicon;
@@ -96,8 +100,17 @@ export async function generateMetadataFromSeo(
     title: title,
     ...(description ? { description: description } : {}),
   })}`;
-  const imageUrl =
-    seo?.imageUrl || companyInfo?.defaultSEO?.imageUrl || fallbackImageUrl;
+  const sanityImageUrl = seo?.imageUrl || companyInfo?.defaultSEO?.imageUrl;
+  const sanityImageParams = `?${new URLSearchParams({
+    w: "1200",
+    h: "630",
+    fit: "fill",
+    fm: "png", // required for transparent
+    bg: "00000000", // transparent
+  })}`;
+  const imageUrl = sanityImageUrl
+    ? `${sanityImageUrl}${sanityImageParams}`
+    : fallbackImageUrl;
 
   return {
     title: title,

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -29,6 +29,11 @@ type CompanyInfo = {
   defaultSEO: SeoData;
 };
 
+export const OPEN_GRAPH_IMAGE_DIMENSIONS = {
+  width: 1200,
+  height: 630,
+};
+
 export async function fetchSeoData(
   query: string,
   variables?: any,
@@ -102,8 +107,8 @@ export async function generateMetadataFromSeo(
   })}`;
   const sanityImageUrl = seo?.imageUrl || companyInfo?.defaultSEO?.imageUrl;
   const sanityImageParams = `?${new URLSearchParams({
-    w: "1200",
-    h: "630",
+    w: OPEN_GRAPH_IMAGE_DIMENSIONS.width.toString(),
+    h: OPEN_GRAPH_IMAGE_DIMENSIONS.height.toString(),
     fit: "fill",
     fm: "png", // required for transparent
     bg: "00000000", // transparent

--- a/studio/schemas/objects/seo.ts
+++ b/studio/schemas/objects/seo.ts
@@ -56,7 +56,7 @@ const seo = defineField({
       title: "Social Media Image",
       type: "image",
       description:
-        "A compelling image for social media can greatly improve conversion rates, even though it doesn't directly affect SEO.",
+        "A compelling image for social media can greatly improve conversion rates, even though it doesn't directly affect SEO. Recommended dimensions: 1200x630 (landscape).",
     }),
   ],
 });


### PR DESCRIPTION
Ensures that the OpenGraph image (`og:image`) has dimension 1200x630, independent of the original image. Any space not filled by the image is given a transparent background.

Also included the recommended dimensions in the field description.

## Visual Overview (Image/Video)

Using a [browser extension](https://addons.mozilla.org/en-US/firefox/addon/open-graph-preview-and-debug/) to preview the OpenGraph image

| Before | After |
| --- | --- |
| <img height="250" alt="image" src="https://github.com/user-attachments/assets/d411b70e-62ec-44ff-bdc2-7c24aa1fadea"> | <img height="250" alt="image" src="https://github.com/user-attachments/assets/bb52320b-54d7-4198-b001-6cce477c1897"> | 

---

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?