### PR TITLE
v3 - yearly bonuses per location

### DIFF
--- a/studio/lib/payloads/compensations.ts
+++ b/studio/lib/payloads/compensations.ts
@@ -21,6 +21,13 @@ export interface SalariesPage {
   salaries: string;
 }
 
+export interface BonusPage {
+  _type: string;
+  _key: string;
+  year: number;
+  bonus: number;
+}
+
 export interface CompensationsPage {
   _createdAt: string;
   _id: string;

--- a/studio/schemas/objects/compensations/bonusesByLocation.ts
+++ b/studio/schemas/objects/compensations/bonusesByLocation.ts
@@ -11,20 +11,20 @@ export const bonusesByLocation = defineField({
   name: "bonusesByLocation",
   title: "Bonuses by Location",
   description:
-    "Yearly bonus data specific to a particular location. Each location should have a unique entry with the yearly bonuses given to employees.",
+    "Yearly bonus data specific to a particular company location. Each location should have a unique entry with the yearly bonuses given to their employees.",
   type: "array",
   of: [
     defineField({
       name: "bonusData",
-      title: "Location Bonuses",
+      title: "Bonus by location",
       description:
-        "Details of the bonus amount specific to a particular location. Each location should have a unique entry with the yearly bonuses given to employees.",
+        "Details of the bonus amount specific to a particular location. Each location should have a unique entry with the yearly bonus given to employees.",
       type: "object",
       fields: [
         {
           ...location,
           description:
-            "Select the company location for which you are entering the yearly bonuses data. Each location must be unique.",
+            "Select the company location for which you are entering the yearly bonus data. Each location must be unique.",
           validation: (Rule) => Rule.required(),
         },
         defineField({

--- a/studio/schemas/objects/compensations/bonusesByLocation.ts
+++ b/studio/schemas/objects/compensations/bonusesByLocation.ts
@@ -5,48 +5,91 @@ import {
   DocumentWithLocation,
   checkForDuplicateLocations,
 } from "./utils/validation";
+import { BonusPage } from "../../../lib/payloads/compensations";
 
 export const bonusesByLocation = defineField({
   name: "bonusesByLocation",
-  title: "Bonus by Location",
+  title: "Bonuses by Location",
   description:
-    "Enter the average bonus amount for each company location. Each location can have only one bonus entry, but you can assign the same bonus amount to multiple locations.",
+    "Yearly bonus data specific to a particular location. Each location should have a unique entry with the yearly bonuses given to employees.",
   type: "array",
   of: [
     defineField({
       name: "bonusData",
-      title: "Bonus Information",
+      title: "Location Bonuses",
       description:
-        "Details of the bonus amount specific to a particular location. Each location should have a unique entry with the average bonus calculated for that site.",
+        "Details of the bonus amount specific to a particular location. Each location should have a unique entry with the yearly bonuses given to employees.",
       type: "object",
       fields: [
         {
           ...location,
           description:
-            "Select the company location for which you are entering the average bonus information. Each location must be unique.",
+            "Select the company location for which you are entering the yearly bonuses data. Each location must be unique.",
           validation: (Rule) => Rule.required(),
         },
         defineField({
-          name: "averageBonus",
-          title: "Average Bonus",
+          name: "yearlyBonuses",
+          title: "Yearly Bonuses",
           description:
-            "Enter the average bonus amount for this location. Ensure the amount is positive and reflective of the compensation package for this location.",
-          type: "number",
-          validation: (Rule) =>
-            Rule.required()
-              .min(0)
-              .error("Please enter a positive bonus amount."),
+            "Bonus data reflecting the bonus given to employees for a given year.",
+          type: "array",
+          of: [
+            {
+              type: "object",
+              fields: [
+                defineField({
+                  name: "year",
+                  title: "Year",
+                  description:
+                    "The calendar year for which this bonus was given",
+                  type: "number",
+                  validation: (Rule) => Rule.required(),
+                }),
+                defineField({
+                  name: "bonus",
+                  title: "Bonus",
+                  description:
+                    "Enter the bonus amount for this year. Ensure the amount is positive and reflective of the compensation package for this location.",
+                  type: "number",
+                  validation: (Rule) =>
+                    Rule.required()
+                      .min(0)
+                      .error("Please enter a positive bonus amount."),
+                }),
+              ],
+              preview: {
+                select: {
+                  title: "year",
+                  subtitle: "bonus",
+                },
+              },
+            },
+          ],
         }),
       ],
       preview: {
         select: {
-          averageBonus: "averageBonus",
           location: `${locationID}.${companyLocationNameID}`,
+          yearlyBonuses: `yearlyBonuses`,
         },
-        prepare({ averageBonus, location }) {
+        prepare({ location, yearlyBonuses }) {
+          const latestBonus =
+            yearlyBonuses && yearlyBonuses.length > 0
+              ? yearlyBonuses.reduce(
+                  (latestBonus: BonusPage, bonus: BonusPage) => {
+                    if (bonus.year > latestBonus.year) {
+                      return bonus;
+                    }
+                    return latestBonus;
+                  },
+                  yearlyBonuses[0],
+                )
+              : undefined;
           return {
             title: location || "No location selected",
-            subtitle: averageBonus || "N/A",
+            subtitle: latestBonus
+              ? `Latest bonus (${latestBonus.year}): ${latestBonus.bonus}`
+              : "N/A",
           };
         },
       },

--- a/studio/schemas/objects/compensations/salariesByLocation.ts
+++ b/studio/schemas/objects/compensations/salariesByLocation.ts
@@ -42,7 +42,7 @@ export const salariesByLocation = defineField({
                   description:
                     "The calendar year for which these salaries were in effect",
                   type: "number",
-                  validation: (Rule) => Rule.required().min(2018),
+                  validation: (Rule) => Rule.required(),
                 }),
                 defineField({
                   name: "salaries",


### PR DESCRIPTION
Further explanation is found here: #607 

Updated schema for bonuses per location to support yearly bonuses instead of a single average. This is similar to the yearly salaries, but with only one number per year (since bonuses don't depend on experience).

This only changes the Sanity Studio schema, and no changes have been made to the compensations webpage (this is addressed in #612).

## Visual Overview (Image/Video)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e7677dd2-4dc5-4e9e-8535-da83a1f29bf8">

<img width="500" alt="image" src="https://github.com/user-attachments/assets/37799c5d-0a47-4e5c-8610-15af321c3ece">

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d9727250-b7a6-432b-ac5c-313cfef5cbad">


---

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?