### PR TITLE
v3 - pension in web calculator

### DIFF
--- a/src/compensations/Compensations.tsx
+++ b/src/compensations/Compensations.tsx
@@ -86,9 +86,12 @@ const Compensations = ({ compensations, locations }: CompensationsProps) => {
           {salary !== null ? (
             <div aria-live="polite">
               <Text> Du vil få en årlig lønn på {salary}</Text>
-              <Text>
-                Du vil få en årlig pensjon på omtrent {calculatePension(salary)}
-              </Text>
+              {compensations.pensionPercent && (
+                <Text>
+                  Du vil få en årlig pensjon på omtrent{" "}
+                  {calculatePension(salary, compensations.pensionPercent)}
+                </Text>
+              )}
             </div>
           ) : null}
         </>

--- a/src/compensations/utils/calculateSalary.ts
+++ b/src/compensations/utils/calculateSalary.ts
@@ -18,8 +18,11 @@ export function calculateSalary(
   return salaryPayscale[currentYear][adjustedYear];
 }
 
-export function calculatePension(salary: number): number {
-  return Math.round(salary * 0.07);
+export function calculatePension(
+  salary: number,
+  pensionPercent: number,
+): number {
+  return Math.round(salary * (pensionPercent / 100));
 }
 
 export function maxExperience(thisYear: number): number {

--- a/studio/lib/payloads/compensations.ts
+++ b/studio/lib/payloads/compensations.ts
@@ -30,6 +30,7 @@ export interface CompensationsPage {
   basicTitle: string;
   page: string;
   slug: Slug;
+  pensionPercent?: number;
   benefitsByLocation: BenefitsByLocation[];
   showSalaryCalculator: boolean;
 }

--- a/studio/schemas/objects/compensations/pension.ts
+++ b/studio/schemas/objects/compensations/pension.ts
@@ -1,7 +1,7 @@
 import { defineField } from "sanity";
 
 export const pension = defineField({
-  name: "pensionData",
+  name: "pensionPercent",
   title: "Pension Percentage",
   type: "number",
   initialValue: 7,


### PR DESCRIPTION
Closes #619 

Replaces the hardcoded pension percent with the pension data from Sanity.

## Visual Overview (Image/Video)

No visual changes

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?