### PR TITLE
v3 - hotfix customer case document type list

### DIFF
--- a/studioShared/deskStructure.ts
+++ b/studioShared/deskStructure.ts
@@ -9,7 +9,7 @@ export const deskStructure: StructureResolver = (S) =>
       S.listItem()
         .title("Customer cases")
         .child(
-          S.documentList()
+          S.documentTypeList(customerCaseID)
             .title("Customer cases")
             .filter("_type == $type && language == $lang")
             .params({ type: customerCaseID, lang: i18n.base }),


### PR DESCRIPTION
Using `documentList` instead of `documentTypeList` (by [suggestion from me](https://github.com/varianter/variant.no/pull/552#discussion_r1754013118)...) removed the plus icon for creating a new document. This has now been changed back to `documentTypeList`.

## Visual Overview (Image/Video)

| Before | After |
| --- | --- |
| <img width="664" alt="image" src="https://github.com/user-attachments/assets/94c10d20-0ac2-4e91-9b7a-213d7d29384a"> | <img width="672" alt="image" src="https://github.com/user-attachments/assets/b1e1493f-1beb-45e6-8cb7-1226e064a816"> |


## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?