### PR TITLE
v3 - fmt npm script for prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To get started with Sankitty, follow these steps:
 - `npm run dev`: Start the Next.js development server.
 - `npm run build`: Build the Next.js application for production.
 - `npm run start`: Start the Next.js application in production mode.
-- `npx prettier . --write`: Format the codebase using Prettier to ensure consistent code style across the project.
+- `npm run fmt`: Format the codebase using Prettier to ensure consistent code style across the project.
 - `npm run lint`: Lint the project using ESLint.
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To get started with Sankitty, follow these steps:
 - `npm run dev`: Start the Next.js development server.
 - `npm run build`: Build the Next.js application for production.
 - `npm run start`: Start the Next.js application in production mode.
-- `npm run fmt`: Format the codebase using Prettier to ensure consistent code style across the project.
+- `npm run format`: Format the codebase using Prettier to ensure consistent code style across the project.
 - `npm run lint`: Lint the project using ESLint.
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --fix",
+    "fmt": "prettier . --write",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --fix",
-    "fmt": "prettier . --write",
+    "format": "prettier . --write",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook"


### PR DESCRIPTION
Added a convenience npm script to be consistent with the rest of the scripts used during development.

`npm run fmt` can then be used instead of `npx prettier . --write`

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?