### PR TITLE
dependabot for v3 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "v3"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
See #618 

This will only affect the `v3` branch, but the configuration file must be placed in the default branch (aka `main`) to take effect.