### PR TITLE
v3 - compensations consistent field naming

### DIFF
--- a/src/compensations/Compensations.tsx
+++ b/src/compensations/Compensations.tsx
@@ -47,9 +47,9 @@ const Compensations = ({ compensations, locations }: CompensationsProps) => {
       salariesFromLocation(
         currentYear,
         selectedLocation,
-        compensations.salaries,
+        compensations.salariesByLocation,
       ),
-    [currentYear, selectedLocation, compensations.salaries],
+    [currentYear, selectedLocation, compensations.salariesByLocation],
   );
 
   const updateSelectedDegree = (newDegree: Degree) => {

--- a/studio/lib/payloads/compensations.ts
+++ b/studio/lib/payloads/compensations.ts
@@ -54,6 +54,6 @@ export interface CompensationsPage {
   pensionPercent?: number;
   benefitsByLocation: BenefitsByLocation[];
   bonusesByLocation: BonusesByLocationPage[];
-  salaries: SalariesByLocation[];
+  salariesByLocation: SalariesByLocation[];
   showSalaryCalculator: boolean;
 }

--- a/studio/schemas/documents/compensations.ts
+++ b/studio/schemas/documents/compensations.ts
@@ -3,7 +3,7 @@ import { titleSlug } from "../schemaTypes/slug";
 import seo from "../objects/seo";
 import { title } from "../fields/text";
 import { bonusesByLocation } from "../objects/compensations/bonusesByLocation";
-import { pension } from "../objects/compensations/pension";
+import { pensionPercent } from "../objects/compensations/pension";
 import { benefitsByLocation } from "../objects/compensations/benefitsByLocation";
 import { salariesByLocation } from "../objects/compensations/salariesByLocation";
 
@@ -29,7 +29,7 @@ const compensations = defineType({
       type: "boolean",
       initialValue: true,
     }),
-    pension,
+    pensionPercent,
     bonusesByLocation,
     benefitsByLocation,
     salariesByLocation,

--- a/studio/schemas/objects/compensations/pension.ts
+++ b/studio/schemas/objects/compensations/pension.ts
@@ -1,6 +1,6 @@
 import { defineField } from "sanity";
 
-export const pension = defineField({
+export const pensionPercent = defineField({
   name: "pensionPercent",
   title: "Pension Percentage",
   type: "number",

--- a/studio/schemas/objects/compensations/salariesByLocation.ts
+++ b/studio/schemas/objects/compensations/salariesByLocation.ts
@@ -9,7 +9,7 @@ import { SalariesInput } from "../../../components/salariesInput/SalariesInput";
 import { SalariesPage } from "../../../lib/payloads/compensations";
 
 export const salariesByLocation = defineField({
-  name: "salaries",
+  name: "salariesByLocation",
   title: "Salaries by Location",
   description:
     "Yearly salary data specific to a particular location. Each location should have a unique entry with the yearly salaries for that location.",


### PR DESCRIPTION
See https://github.com/varianter/variant.no/pull/617#discussion_r1756610991

Renamed  salaries → salariesByLocation to be consistent with the other location-dependant compensations.

## Visual Overview (Image/Video)

No visual changes

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?