### PR TITLE
cleanup of deskstructure

### DIFF
--- a/studio/schemas/deskStructure.ts
+++ b/studio/schemas/deskStructure.ts
@@ -78,7 +78,7 @@ const siteSettingSection = (S: StructureBuilder) =>
               S.document().schemaType(soMeLinksID).documentId(soMeLinksID),
             ),
           S.listItem()
-            .title("SEO Redirects")
+            .title("Broken Links")
             .icon(DoubleChevronRightIcon)
             .child(S.documentTypeList(redirectId).title("Redirects")),
           //TODO: Add SEO Settings

--- a/studio/schemas/deskStructure.ts
+++ b/studio/schemas/deskStructure.ts
@@ -1,15 +1,14 @@
 import { StructureBuilder } from "sanity/structure";
 import { pageBuilderID } from "./builders/pageBuilder";
-import { blogId } from "./documents/blog";
+//import { blogId } from "./documents/blog";
 import {
   TransferIcon,
   UsersIcon,
   CogIcon,
-  ControlsIcon,
   ProjectsIcon,
-  StackCompactIcon,
   InfoOutlineIcon,
   HeartIcon,
+  SparkleIcon,
   CaseIcon,
   DoubleChevronRightIcon,
   PinIcon,
@@ -21,86 +20,116 @@ import { compensationsId } from "./documents/compensations";
 import { redirectId } from "./documents/redirect";
 import { companyLocationID } from "./documents/companyLocation";
 
+// Admin Section
+const adminSection = (S: StructureBuilder) =>
+  S.listItem()
+    .title("Admin")
+    .icon(CaseIcon)
+    .child(
+      S.list()
+        .title("Company Details")
+        .items([
+          S.listItem()
+            .title("Company Information")
+            .icon(InfoOutlineIcon)
+            .child(
+              S.document()
+                .schemaType(companyInfoID)
+                .documentId(companyInfoID)
+                .title("Company Information"),
+            ),
+          S.listItem()
+            .title("Company Locations")
+            .icon(PinIcon)
+            .child(
+              S.documentTypeList(companyLocationID).title("Company Locations"),
+            ),
+          S.listItem()
+            .title("Legal Documents")
+            .icon(CogIcon)
+            .child(
+              S.documentTypeList(legalDocumentID).title("Legal Documents"),
+            ),
+        ]),
+    );
+
+// Site Settings Section
+const siteSettingSection = (S: StructureBuilder) =>
+  S.listItem()
+    .title("Site Settings")
+    .icon(CogIcon)
+    .child(
+      S.list()
+        .title("Site Settings")
+        .items([
+          S.listItem()
+            .title("Navigation Manager")
+            .icon(TransferIcon)
+            .child(
+              S.document()
+                .schemaType("navigationManager")
+                .documentId("navigationManager")
+                .title("Navigation Manager"),
+            ),
+          S.listItem()
+            .title("Social Media Profiles")
+            .icon(UsersIcon)
+            .child(
+              S.document().schemaType(soMeLinksID).documentId(soMeLinksID),
+            ),
+          S.listItem()
+            .title("SEO Redirects")
+            .icon(DoubleChevronRightIcon)
+            .child(S.documentTypeList(redirectId).title("Redirects")),
+          //TODO: Add SEO Settings
+          //TODO: Add Language selector
+        ]),
+    );
+
+// Section for dynamic and customizable Pages
+const pagesSection = (S: StructureBuilder) =>
+  S.listItem()
+    .title("Pages")
+    .icon(ProjectsIcon)
+    .child(S.documentTypeList(pageBuilderID).title("Pages"));
+
+//Section for set pages
+const SpecialPagesSection = (S: StructureBuilder) =>
+  S.listItem()
+    .title("Special Pages")
+    .icon(SparkleIcon)
+    .child(
+      S.list()
+        .title("Special Pages")
+        .items([
+          // S.listItem()
+          //   .title("Blog Overview & Settings")
+          //   .icon(ControlsIcon)
+          //   .child(
+          //     S.document()
+          //       .schemaType(blogId)
+          //       .documentId(blogId)
+          //       .title("Blog Overview & Settings"),
+          //   ),
+          S.listItem()
+            .title("Compensations")
+            .icon(HeartIcon)
+            .child(
+              S.document()
+                .schemaType(compensationsId)
+                .documentId(compensationsId)
+                .title("Compensations"),
+            ),
+        ]),
+    );
+
+// Main export
 export default (S: StructureBuilder) =>
   S.list()
     .title("Content")
     .items([
-      S.listItem()
-        .title("Company Details")
-        .icon(CaseIcon)
-        .child(
-          S.list()
-            .title("Company Details")
-            .items([
-              S.listItem()
-                .title("Company Information")
-                .icon(InfoOutlineIcon)
-                .child(
-                  S.document()
-                    .schemaType(companyInfoID)
-                    .documentId(companyInfoID)
-                    .title("Company Information"),
-                ),
-              S.listItem()
-                .title("Company Locations")
-                .icon(PinIcon)
-                .child(
-                  S.documentTypeList(companyLocationID).title(
-                    "Company Locations",
-                  ),
-                ),
-            ]),
-        ),
-      S.listItem()
-        .title("Legal Documents")
-        .icon(CogIcon)
-        .child(S.documentTypeList(legalDocumentID).title("Legal Documents")),
-      S.listItem()
-        .title("Social Media Profiles")
-        .icon(UsersIcon)
-        .child(S.document().schemaType(soMeLinksID).documentId(soMeLinksID)),
-      S.listItem()
-        .title("Navigation Manager")
-        .icon(TransferIcon)
-        .child(
-          S.document()
-            .schemaType("navigationManager")
-            .documentId("navigationManager")
-            .title("Navigation Manager"),
-        ),
-      S.listItem()
-        .title("Dynamic Pages")
-        .icon(ProjectsIcon)
-        .child(S.documentTypeList(pageBuilderID).title("Dynamic Pages")),
-      S.listItem()
-        .title("Static Pages")
-        .icon(StackCompactIcon)
-        .child(
-          S.list()
-            .title("Static Pages")
-            .items([
-              S.listItem()
-                .title("Blog Overview & Settings")
-                .icon(ControlsIcon)
-                .child(
-                  S.document()
-                    .schemaType(blogId)
-                    .documentId(blogId)
-                    .title("Blog Overview & Settings"),
-                ),
-              S.listItem()
-                .title("Compensations")
-                .icon(HeartIcon)
-                .child(
-                  S.document()
-                    .schemaType(compensationsId)
-                    .documentId(compensationsId)
-                    .title("Compensations"),
-                ),
-            ]),
-        ),
-      S.listItem()
-        .title("Redirects")
-        .icon(DoubleChevronRightIcon)
-        .child(S.documentTypeList(redirectId).title("Redirects")),
+      adminSection(S),
+      siteSettingSection(S),
+      pagesSection(S),
+      SpecialPagesSection(S),
     ]);


### PR DESCRIPTION
## Short Description

I have updated the desk structure in /Studio to enhance the user experience. The layout is now more organized, focusing on roles and tasks related to content creation.

The blog overview has been temporarily commented out, as we don’t want to include it in tomorrow’s demo.

Remaining task that we should do in own PRs
- Add a field for SEO management.
- Add a field for language selection.

## Visual Overview (Image/Video)
<img width="1552" alt="Screenshot 2024-09-12 at 15 30 24" src="https://github.com/user-attachments/assets/dbe8bdd9-71ed-4052-b287-533e9c84552c">
<img width="1622" alt="Screenshot 2024-09-12 at 15 30 32" src="https://github.com/user-attachments/assets/0e2c377e-9fa6-4021-9ff5-23a8acd0ea70">
<img width="1673" alt="Screenshot 2024-09-12 at 15 30 40" src="https://github.com/user-attachments/assets/7eaae543-c10c-4836-b359-0d055194ca13">
<img width="1331" alt="Screenshot 2024-09-12 at 15 31 47" src="https://github.com/user-attachments/assets/5829ed90-2d8c-4c90-9e1a-84532ee81223">
