### PR TITLE
v3 - migrate default seo

### DIFF
--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -4,8 +4,8 @@ import { urlFor } from "studio/lib/image";
 import { COMPANY_INFO_QUERY } from "studio/lib/queries/companyDetails";
 import { loadQuery } from "studio/lib/store";
 import { PortableTextBlock } from "src/components/richText/RichText";
-import { FALLBACK_SEO_QUERY } from "../../studio/lib/queries/seo";
-import { SeoFallback } from "../../studio/lib/payloads/seoFallback";
+import { DEFAULT_SEO_QUERY } from "../../studio/lib/queries/seo";
+import { DefaultSeo } from "../../studio/lib/payloads/defaultSeo";
 
 type SeoData = {
   title: string;
@@ -85,8 +85,9 @@ export async function fetchCompanyInfo(): Promise<CompanyInfo | null> {
 export async function generateMetadataFromSeo(
   seo: SeoData | null,
 ): Promise<Metadata> {
-  const { data: fallbackSeo } =
-    await loadQuery<SeoFallback>(FALLBACK_SEO_QUERY);
+  const { data: fallbackSeo } = await loadQuery<DefaultSeo | null>(
+    DEFAULT_SEO_QUERY,
+  );
   const companyInfo = await fetchCompanyInfo();
 
   const title =
@@ -94,7 +95,7 @@ export async function generateMetadataFromSeo(
     fallbackSeo?.seo?.seoTitle ||
     companyInfo?.siteMetadata?.siteName ||
     "Variant";
-  const description = seo?.description || fallbackSeo.seo?.seoDescription;
+  const description = seo?.description || fallbackSeo?.seo?.seoDescription;
   const keywords = seo?.keywords || "";
 
   const favicon = companyInfo?.brandAssets?.favicon;
@@ -108,7 +109,7 @@ export async function generateMetadataFromSeo(
     title: title,
     ...(description ? { description: description } : {}),
   })}`;
-  const sanityImageUrl = seo?.imageUrl || fallbackSeo.seo?.seoImageUrl;
+  const sanityImageUrl = seo?.imageUrl || fallbackSeo?.seo?.seoImageUrl;
   const sanityImageParams = `?${new URLSearchParams({
     w: OPEN_GRAPH_IMAGE_DIMENSIONS.width.toString(),
     h: OPEN_GRAPH_IMAGE_DIMENSIONS.height.toString(),

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -4,6 +4,8 @@ import { urlFor } from "studio/lib/image";
 import { COMPANY_INFO_QUERY } from "studio/lib/queries/companyDetails";
 import { loadQuery } from "studio/lib/store";
 import { PortableTextBlock } from "src/components/richText/RichText";
+import { FALLBACK_SEO_QUERY } from "../../studio/lib/queries/seo";
+import { SeoFallback } from "../../studio/lib/payloads/seoFallback";
 
 type SeoData = {
   title: string;
@@ -26,7 +28,6 @@ type CompanyInfo = {
   brandAssets: {
     favicon: string;
   };
-  defaultSEO: SeoData;
 };
 
 export const OPEN_GRAPH_IMAGE_DIMENSIONS = {
@@ -84,14 +85,16 @@ export async function fetchCompanyInfo(): Promise<CompanyInfo | null> {
 export async function generateMetadataFromSeo(
   seo: SeoData | null,
 ): Promise<Metadata> {
+  const { data: fallbackSeo } =
+    await loadQuery<SeoFallback>(FALLBACK_SEO_QUERY);
   const companyInfo = await fetchCompanyInfo();
 
   const title =
     seo?.title ||
-    companyInfo?.defaultSEO?.title ||
+    fallbackSeo?.seo?.seoTitle ||
     companyInfo?.siteMetadata?.siteName ||
     "Variant";
-  const description = seo?.description || companyInfo?.defaultSEO?.description;
+  const description = seo?.description || fallbackSeo.seo?.seoDescription;
   const keywords = seo?.keywords || "";
 
   const favicon = companyInfo?.brandAssets?.favicon;
@@ -105,7 +108,7 @@ export async function generateMetadataFromSeo(
     title: title,
     ...(description ? { description: description } : {}),
   })}`;
-  const sanityImageUrl = seo?.imageUrl || companyInfo?.defaultSEO?.imageUrl;
+  const sanityImageUrl = seo?.imageUrl || fallbackSeo.seo?.seoImageUrl;
   const sanityImageParams = `?${new URLSearchParams({
     w: OPEN_GRAPH_IMAGE_DIMENSIONS.width.toString(),
     h: OPEN_GRAPH_IMAGE_DIMENSIONS.height.toString(),

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -85,17 +85,17 @@ export async function fetchCompanyInfo(): Promise<CompanyInfo | null> {
 export async function generateMetadataFromSeo(
   seo: SeoData | null,
 ): Promise<Metadata> {
-  const { data: fallbackSeo } = await loadQuery<DefaultSeo | null>(
+  const { data: defaultSeo } = await loadQuery<DefaultSeo | null>(
     DEFAULT_SEO_QUERY,
   );
   const companyInfo = await fetchCompanyInfo();
 
   const title =
     seo?.title ||
-    fallbackSeo?.seo?.seoTitle ||
+    defaultSeo?.seo?.seoTitle ||
     companyInfo?.siteMetadata?.siteName ||
     "Variant";
-  const description = seo?.description || fallbackSeo?.seo?.seoDescription;
+  const description = seo?.description || defaultSeo?.seo?.seoDescription;
   const keywords = seo?.keywords || "";
 
   const favicon = companyInfo?.brandAssets?.favicon;
@@ -109,7 +109,7 @@ export async function generateMetadataFromSeo(
     title: title,
     ...(description ? { description: description } : {}),
   })}`;
-  const sanityImageUrl = seo?.imageUrl || fallbackSeo?.seo?.seoImageUrl;
+  const sanityImageUrl = seo?.imageUrl || defaultSeo?.seo?.seoImageUrl;
   const sanityImageParams = `?${new URLSearchParams({
     w: OPEN_GRAPH_IMAGE_DIMENSIONS.width.toString(),
     h: OPEN_GRAPH_IMAGE_DIMENSIONS.height.toString(),

--- a/studio/lib/payloads/defaultSeo.ts
+++ b/studio/lib/payloads/defaultSeo.ts
@@ -1,4 +1,4 @@
-export type SeoFallback = {
+export type DefaultSeo = {
   _id: string;
   _type: "seoFallback";
   _createdAt: string;

--- a/studio/lib/payloads/seoFallback.ts
+++ b/studio/lib/payloads/seoFallback.ts
@@ -1,0 +1,13 @@
+export type SeoFallback = {
+  _id: string;
+  _type: "seoFallback";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  seo?: {
+    seoTitle?: string;
+    seoDescription?: string;
+    seoKeywords?: string;
+    seoImageUrl?: string;
+  };
+};

--- a/studio/lib/queries/companyDetails.ts
+++ b/studio/lib/queries/companyDetails.ts
@@ -3,12 +3,6 @@ import { groq } from "next-sanity";
 export const COMPANY_INFO_QUERY = groq`*[_type == "companyInfo"]{
     brandAssets,
     siteMetadata,
-    defaultSEO {
-        "title": seoTitle,
-        "description": seoDescription,
-        "keywords": seoKeywords,
-        "imageUrl": seoImage.asset->url
-    },
     legalPages,
 }[0]`;
 

--- a/studio/lib/queries/seo.ts
+++ b/studio/lib/queries/seo.ts
@@ -1,0 +1,10 @@
+import { groq } from "next-sanity";
+
+export const FALLBACK_SEO_QUERY = groq`*[_type == "seoFallback"]{
+  seo {
+    seoTitle,
+    seoDescription,
+    seoKeywords,
+    "seoImageUrl": seoImage.asset->url
+  }
+}[0]`;

--- a/studio/lib/queries/seo.ts
+++ b/studio/lib/queries/seo.ts
@@ -1,6 +1,6 @@
 import { groq } from "next-sanity";
 
-export const FALLBACK_SEO_QUERY = groq`*[_type == "seoFallback"]{
+export const DEFAULT_SEO_QUERY = groq`*[_type == "seoFallback"]{
   seo {
     seoTitle,
     seoDescription,

--- a/studio/schema.ts
+++ b/studio/schema.ts
@@ -15,7 +15,7 @@ import companyLocation from "./schemas/documents/companyLocation";
 import compensations from "./schemas/documents/compensations";
 import redirect from "./schemas/documents/redirect";
 import benefitsByLocation from "./schemas/objects/compensations/benefitsByLocation";
-import seoFallback from "./schemas/documents/admin/fallbackSeo";
+import defaultSeo from "./schemas/documents/admin/defaultSeo";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
@@ -35,6 +35,6 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     redirect,
     benefitsByLocation,
     companyLocation,
-    seoFallback,
+    defaultSeo,
   ],
 };

--- a/studio/schemas/deskStructure.ts
+++ b/studio/schemas/deskStructure.ts
@@ -20,7 +20,7 @@ import { legalDocumentID } from "./documents/legalDocuments";
 import { compensationsId } from "./documents/compensations";
 import { redirectId } from "./documents/redirect";
 import { companyLocationID } from "./documents/companyLocation";
-import { seoFallbackID } from "./documents/admin/fallbackSeo";
+import { defaultSeoID } from "./documents/admin/defaultSeo";
 
 // Admin Section
 const adminSection = (S: StructureBuilder) =>
@@ -80,21 +80,13 @@ const siteSettingSection = (S: StructureBuilder) =>
               S.document().schemaType(soMeLinksID).documentId(soMeLinksID),
             ),
           S.listItem()
-            .title("SEO Configurations")
+            .title("Default SEO")
             .icon(SearchIcon)
             .child(
-              S.list()
-                .title("SEO Configurations")
-                .items([
-                  S.listItem()
-                    .title("Fallback SEO")
-                    .child(
-                      S.document()
-                        .schemaType(seoFallbackID)
-                        .documentId(seoFallbackID)
-                        .title("Fallback SEO"),
-                    ),
-                ]),
+              S.document()
+                .schemaType(defaultSeoID)
+                .documentId(defaultSeoID)
+                .title("Default SEO"),
             ),
           S.listItem()
             .title("Broken Links")

--- a/studio/schemas/documents/admin/defaultSeo.ts
+++ b/studio/schemas/documents/admin/defaultSeo.ts
@@ -1,10 +1,10 @@
 import { defineField, defineType } from "sanity";
 import seo from "studio/schemas/objects/seo";
 
-export const seoFallbackID = "seoFallback";
+export const defaultSeoID = "seoFallback";
 
-const seoFallback = defineType({
-  name: seoFallbackID,
+const defaultSeo = defineType({
+  name: defaultSeoID,
   type: "document",
   title: "SEO Configurations",
   description:
@@ -29,4 +29,4 @@ const seoFallback = defineType({
   },
 });
 
-export default seoFallback;
+export default defaultSeo;

--- a/studio/schemas/documents/companyInfo.ts
+++ b/studio/schemas/documents/companyInfo.ts
@@ -79,14 +79,6 @@ const companyInfo = defineType({
         }),
       ],
     },
-    {
-      name: "defaultSEO",
-      type: "object",
-      title: "Default SEO Settings",
-      description:
-        "If page-specific SEO settings are not provided, these settings will be applied as default.",
-      fields: seo.fields,
-    },
   ],
   preview: {
     prepare() {


### PR DESCRIPTION
Continuation of #642, which added a separate page for fallback seo content.

The corresponding migration has now been performed in web to use the new source of fallback SEO metadata. This also allowed us to delete the default SEO section from companyInfo.

The SEO Configuration parent item in deskStructure has been removed and Fallback SEO renamed to Default SEO.

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?