### PR TITLE
v3 - hotfix: force dynamic sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,6 +10,9 @@ interface SitemapDocument {
 
 const clientWithToken = client.withConfig({ token });
 
+export const dynamic = "force-dynamic";
+export const fetchCache = "default-no-store";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const documents =
     await clientWithToken.fetch<SitemapDocument[]>(`*[defined(slug)]`);


### PR DESCRIPTION
Opting out of any caching to keep the sitemap fresh. This should be improved later to only update when content actually changes (not for every request to `/sitemap.xml`)

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?