### PR TITLE
v3 - organize imports with eslint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,71 @@
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    projectService: true,
+    tsconfigRootDir: __dirname,
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:storybook/recommended",
+    "plugin:@typescript-eslint/recommended",
+    // "plugin:@typescript-eslint/recommended-type-checked",  // TODO
+    // "plugin:@typescript-eslint/stylistic-type-checked",  // TODO
+    "plugin:import/recommended",
+    "plugin:import/typescript",
+    "plugin:prettier/recommended",
+    "next/core-web-vitals",
+  ],
+  plugins: [
+    "@typescript-eslint",
+    "unused-imports",
+    "no-relative-import-paths",
+    "import",
+    "prettier",
+  ],
+  ignorePatterns: ["dist", "node_modules", ".sanity"],
+  settings: {
+    "import/resolver": {
+      typescript: {
+        project: "./tsconfig.json",
+      },
+    },
+  },
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off", // TODO
+    "unused-imports/no-unused-imports": "error",
+    "import/no-named-as-default": "off",
+    "import/no-unresolved": "error",
+    "no-relative-import-paths/no-relative-import-paths": [
+      "warn",
+      { allowSameFolder: true },
+    ],
+    "import/order": [
+      "error",
+      {
+        groups: [
+          "builtin", // from NodeJS native
+          "external",
+          "internal",
+          ["sibling", "parent"], // sibling and parent types they can be mingled together
+          "index",
+          "unknown",
+        ],
+        "newlines-between": "always",
+        alphabetize: {
+          order: "asc",
+          caseInsensitive: true,
+        },
+      },
+    ],
+    "sort-imports": [
+      "error",
+      {
+        ignoreCase: false,
+        ignoreDeclarationSort: true, // handled by eslint-plugin-import
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ["none", "all", "multiple", "single"],
+        allowSeparatedGroups: true,
+      },
+    ],
+  },
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,0 @@
-{
-  "extends": [
-    "next/core-web-vitals",
-    "plugin:storybook/recommended",
-    "plugin:storybook/recommended"
-  ],
-  "plugins": ["prettier", "simple-import-sort", "eslint-plugin-import"],
-  "ignorePatterns": ["dist", "node_modules", ".sanity"]
-}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,11 +1,11 @@
-name: Prettier Check
+name: Code Quality Checks
 
 on:
   pull_request:
     branches: [main, v3]
 
 jobs:
-  prettier:
+  code_quality:
     runs-on: ubuntu-latest
 
     steps:
@@ -16,9 +16,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/workflows/prettier.yml') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/workflows/code-quality.yml') }}
           restore-keys: |
             ${{ runner.os }}-npm-
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Prettier Check
         run: npx prettier --check .
+
+      - name: ESLint Check
+        run: npx eslint .

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ To get started with Sankitty, follow these steps:
 - `npm run start`: Start the Next.js application in production mode.
 - `npm run format`: Format the codebase using Prettier to ensure consistent code style across the project.
 - `npm run lint`: Lint the project using ESLint.
+- `npm run fix`: Format and lint in one command.
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,15 +38,21 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "eslint": "^8",
+        "@typescript-eslint/eslint-plugin": "^8.6.0",
+        "@typescript-eslint/parser": "^8.6.0",
+        "eslint": "^8.57.1",
         "eslint-config-next": "14.2.3",
-        "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-prettier": "^5.1.3",
-        "eslint-plugin-simple-import-sort": "^12.1.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-import-resolver-typescript": "^3.6.3",
+        "eslint-plugin-import": "^2.30.0",
+        "eslint-plugin-no-relative-import-paths": "^1.5.5",
+        "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-storybook": "^0.8.0",
+        "eslint-plugin-unused-imports": "^4.1.4",
+        "npm-run-all": "^4.1.5",
         "prettier": "^3.2.5",
         "storybook": "^8.2.5",
-        "typescript": "^5"
+        "typescript": "^5.6.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2780,69 +2786,6 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
@@ -2995,14 +2938,14 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -4823,6 +4766,13 @@
         "react": "^18",
         "react-dom": "^18"
       }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.10.4",
@@ -8089,28 +8039,85 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
-      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
+      "integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.2.0",
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/typescript-estree": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
-        "debug": "^4.3.4"
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/type-utils": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.56.0"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
+      "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
+      "integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -8119,31 +8126,79 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
-      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
+      "integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0"
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
+      "integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
+      "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
+      "integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8151,23 +8206,23 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
-      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
+      "integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "@typescript-eslint/visitor-keys": "7.2.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8190,9 +8245,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8361,17 +8416,17 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
-      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
+      "integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "7.2.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "8.6.0",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9477,13 +9532,13 @@
       }
     },
     "node_modules/axobject-query": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
-      "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "deep-equal": "^2.0.5"
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/b4a": {
@@ -13058,17 +13113,17 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -13140,6 +13195,166 @@
         }
       }
     },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
+      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.2.0",
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/typescript-estree": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
+      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
+      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
+      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -13199,9 +13414,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.2.tgz",
-      "integrity": "sha512-3XnC5fDyc8M4J2E8pt8pmSVRX2M+5yWMCfI/kDZwauQeFgzQOuhcRBFKjTeJagqgk4sFKxe1mvNVnaWwImx/Tg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.11.0.tgz",
+      "integrity": "sha512-gbBE5Hitek/oG6MUVj6sFuzEjA/ClzNflVrLovHi/JgLdC7fiN5gLAY1WIPW1a0V5I999MnsrvVrCOGmmVqDBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13227,27 +13442,28 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
-      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
+      "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.7",
-        "array.prototype.findlastindex": "^1.2.3",
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlastindex": "^1.2.5",
         "array.prototype.flat": "^1.3.2",
         "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.8.0",
-        "hasown": "^2.0.0",
-        "is-core-module": "^2.13.1",
+        "eslint-module-utils": "^2.9.0",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.15.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.7",
-        "object.groupby": "^1.0.1",
-        "object.values": "^1.1.7",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.0",
         "semver": "^6.3.1",
         "tsconfig-paths": "^3.15.0"
       },
@@ -13318,9 +13534,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.9.0.tgz",
-      "integrity": "sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
+      "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13328,8 +13544,8 @@
         "array-includes": "^3.1.8",
         "array.prototype.flatmap": "^1.3.2",
         "ast-types-flow": "^0.0.8",
-        "axe-core": "^4.9.1",
-        "axobject-query": "~3.1.1",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
         "damerau-levenshtein": "^1.0.8",
         "emoji-regex": "^9.2.2",
         "es-iterator-helpers": "^1.0.19",
@@ -13345,7 +13561,7 @@
         "node": ">=4.0"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
@@ -13357,6 +13573,13 @@
       "dependencies": {
         "deep-equal": "^2.0.5"
       }
+    },
+    "node_modules/eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.5.tgz",
+      "integrity": "sha512-UjudFFdBbv93v0CsVdEKcMLbBzRIjeK2PubTctX57tgnHxZcMj1Jm8lDBWoETnPxk0S5g5QLSltEM+511yL4+w==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.2.1",
@@ -13390,9 +13613,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.35.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.0.tgz",
-      "integrity": "sha512-v501SSMOWv8gerHkk+IIQBkcGRGrO2nfybfj5pLxuJNFTPxxA3PSryhXTK+9pNbtkggheDdsC0E9Q8CuPk6JKA==",
+      "version": "7.36.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.36.1.tgz",
+      "integrity": "sha512-/qwbqNXZoq+VP30s1d4Nc1C5GTxjJQjk4Jzs4Wq2qzxFM7dSmuG2UkIjg2USMLh3A/aVcUNrK7v0J5U1XEGGwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13466,16 +13689,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/eslint-plugin-simple-import-sort": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
-      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
-      }
-    },
     "node_modules/eslint-plugin-storybook": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.8.0.tgz",
@@ -13503,6 +13716,22 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {
@@ -13533,6 +13762,40 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
@@ -19408,6 +19671,13 @@
       "integrity": "sha512-7otpx5UPFeSELoF8nkZPHCfywg86wOsJV0WNOaysuO7mfWj1QFp2vlqESRRCeJKBXr+tqDgHh4HgqUFKTLcifQ==",
       "license": "ISC"
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -19638,6 +19908,56 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
+    },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
@@ -19917,6 +20237,15 @@
       "license": "MIT",
       "dependencies": {
         "map-or-similar": "^1.5.0"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/mendoza": {
@@ -20476,6 +20805,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -20749,6 +21085,163 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/npm-run-all/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/npm-run-path": {
@@ -22062,6 +22555,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pify": {
@@ -25091,6 +25597,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -25801,6 +26317,25 @@
         "regexp.prototype.flags": "^1.5.2",
         "set-function-name": "^2.0.2",
         "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -27185,9 +27720,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint . --fix",
     "format": "prettier . --write",
+    "fix": "run-s lint format",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook"
@@ -43,14 +44,20 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "eslint": "^8",
+    "@typescript-eslint/eslint-plugin": "^8.6.0",
+    "@typescript-eslint/parser": "^8.6.0",
+    "eslint": "^8.57.1",
     "eslint-config-next": "14.2.3",
-    "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-prettier": "^5.1.3",
-    "eslint-plugin-simple-import-sort": "^12.1.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-import-resolver-typescript": "^3.6.3",
+    "eslint-plugin-import": "^2.30.0",
+    "eslint-plugin-no-relative-import-paths": "^1.5.5",
+    "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-storybook": "^0.8.0",
+    "eslint-plugin-unused-imports": "^4.1.4",
+    "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
     "storybook": "^8.2.5",
-    "typescript": "^5"
+    "typescript": "^5.6.2"
   }
 }

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -5,7 +5,8 @@
  */
 
 import { defineConfig } from "sanity";
-import sharedStudioConfig from "./studioShared/studioConfig";
+
 import studioConfig from "./studio/studioConfig";
+import sharedStudioConfig from "./studioShared/studioConfig";
 
 export default defineConfig([studioConfig, sharedStudioConfig]);

--- a/src/app/(main)/[slug]/[id]/page.tsx
+++ b/src/app/(main)/[slug]/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { loadQuery } from "@sanity/react-loader";
 import { Metadata } from "next";
+
 import PostPage from "src/post/PostPage";
 import PostPagePreview from "src/post/PostPagePreview";
 import { getDraftModeInfo } from "src/utils/draftmode";

--- a/src/app/(main)/[slug]/page.tsx
+++ b/src/app/(main)/[slug]/page.tsx
@@ -1,25 +1,26 @@
 import { Metadata } from "next";
+
 import { Blog } from "src/blog/Blog";
 import BlogPreview from "src/blog/BlogPreview";
+import CustomErrorMessage from "src/blog/components/customErrorMessage/CustomErrorMessage";
+import { homeLink } from "src/blog/components/utils/linkTypes";
 import Compensations from "src/compensations/Compensations";
+import CompensationsPreview from "src/compensations/CompensationsPreview";
 import { getDraftModeInfo } from "src/utils/draftmode";
 import SectionRenderer from "src/utils/renderSection";
 import { fetchSeoData, generateMetadataFromSeo } from "src/utils/seo";
-import { BlogPage, PageBuilder, Post } from "studio/lib/interfaces/pages";
+import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
 import { CompensationsPage } from "studio/lib/interfaces/compensations";
+import { BlogPage, PageBuilder, Post } from "studio/lib/interfaces/pages";
+import { COMPANY_LOCATIONS_QUERY } from "studio/lib/queries/companyDetails";
 import {
   BLOG_PAGE_QUERY,
-  POSTS_QUERY,
   COMPENSATIONS_PAGE_QUERY,
+  POSTS_QUERY,
   SEO_SLUG_QUERY,
   SLUG_QUERY,
 } from "studio/lib/queries/pages";
 import { loadQuery } from "studio/lib/store";
-import CompensationsPreview from "src/compensations/CompensationsPreview";
-import { homeLink } from "../../../blog/components/utils/linkTypes";
-import CustomErrorMessage from "../../../blog/components/customErrorMessage/CustomErrorMessage";
-import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
-import { COMPANY_LOCATIONS_QUERY } from "studio/lib/queries/companyDetails";
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,21 +1,22 @@
 import Footer from "src/components/navigation/footer/Footer";
-import { NAV_QUERY } from "studio/lib/queries/navigation";
-import { COMPANY_INFO_QUERY } from "studio/lib/queries/companyDetails";
-import { Header } from "src/components/navigation/header/Header";
-import { Navigation } from "studio/lib/interfaces/navigation";
-import { CompanyInfo } from "studio/lib/interfaces/companyDetails";
-import { loadQuery } from "studio/lib/store";
-import HeaderPreview from "src/components/navigation/header/HeaderPreview";
 import FooterPreview from "src/components/navigation/footer/FooterPreview";
-import { SOMEPROFILES_QUERY } from "studio/lib/queries/socialMediaProfiles";
-import { SocialMediaProfiles } from "studio/lib/interfaces/socialMedia";
-import { getDraftModeInfo } from "src/utils/draftmode";
+import { Header } from "src/components/navigation/header/Header";
+import HeaderPreview from "src/components/navigation/header/HeaderPreview";
 import SkipToMain from "src/components/skipToMain/SkipToMain";
-import { LEGAL_DOCUMENTS_QUERY } from "studio/lib/queries/legalDocuments";
+import { getDraftModeInfo } from "src/utils/draftmode";
+import { BrandAssets } from "studio/lib/interfaces/brandAssets";
+import { CompanyInfo } from "studio/lib/interfaces/companyDetails";
 import { LegalDocument } from "studio/lib/interfaces/legalDocuments";
+import { Navigation } from "studio/lib/interfaces/navigation";
+import { SocialMediaProfiles } from "studio/lib/interfaces/socialMedia";
+import { BRAND_ASSETS_QUERY } from "studio/lib/queries/brandAssets";
+import { COMPANY_INFO_QUERY } from "studio/lib/queries/companyDetails";
+import { LEGAL_DOCUMENTS_QUERY } from "studio/lib/queries/legalDocuments";
+import { NAV_QUERY } from "studio/lib/queries/navigation";
+import { SOMEPROFILES_QUERY } from "studio/lib/queries/socialMediaProfiles";
+import { loadQuery } from "studio/lib/store";
+
 import styles from "./layout.module.css";
-import { BRAND_ASSETS_QUERY } from "../../../studio/lib/queries/brandAssets";
-import { BrandAssets } from "../../../studio/lib/interfaces/brandAssets";
 
 const hasValidData = (data: any) => data && Object.keys(data).length > 0;
 

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,13 +1,14 @@
+import { Metadata } from "next";
+
+import InformationSection from "src/blog/components/informationSection/InformationSection";
 import { getDraftModeInfo } from "src/utils/draftmode";
+import SectionRenderer from "src/utils/renderSection";
+import { fetchSeoData, generateMetadataFromSeo } from "src/utils/seo";
+import { LinkType } from "studio/lib/interfaces/navigation";
+import { PageBuilder } from "studio/lib/interfaces/pages";
 import { LANDING_QUERY } from "studio/lib/queries/navigation";
 import { PAGE_QUERY, SEO_PAGE_QUERY } from "studio/lib/queries/pages";
-import { PageBuilder } from "studio/lib/interfaces/pages";
-import SectionRenderer from "src/utils/renderSection";
 import { loadQuery } from "studio/lib/store";
-import { Metadata } from "next";
-import { fetchSeoData, generateMetadataFromSeo } from "src/utils/seo";
-import InformationSection from "src/blog/components/informationSection/InformationSection";
-import { LinkType } from "studio/lib/interfaces/navigation";
 
 export async function generateMetadata(): Promise<Metadata> {
   const { data: landingId } = await loadQuery<string>(LANDING_QUERY);

--- a/src/app/api/contactForm/route.ts
+++ b/src/app/api/contactForm/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { PubSub } from "@google-cloud/pubsub";
+import { NextResponse } from "next/server";
 
 export interface ContactData {
   name: string;

--- a/src/app/api/disable-draft/route.ts
+++ b/src/app/api/disable-draft/route.ts
@@ -1,5 +1,6 @@
 import { draftMode } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+
 import { absoluteUrlFromNextRequest } from "src/utils/url";
 
 export function GET(request: NextRequest) {

--- a/src/app/api/draft/route.ts
+++ b/src/app/api/draft/route.ts
@@ -2,9 +2,9 @@ import { validatePreviewUrl } from "@sanity/preview-url-secret";
 import { draftMode } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
+import { absoluteUrlFromNextRequest } from "src/utils/url";
 import { client } from "studio/lib/client";
 import { token } from "studio/lib/token";
-import { absoluteUrlFromNextRequest } from "src/utils/url";
 
 const clientWithToken = client.withConfig({ token });
 

--- a/src/app/api/fetchData/route.ts
+++ b/src/app/api/fetchData/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+
 import { client } from "studio/lib/client";
 import { token } from "studio/lib/token";
 

--- a/src/app/api/openGraphImage/route.tsx
+++ b/src/app/api/openGraphImage/route.tsx
@@ -1,7 +1,9 @@
 import { ImageResponse } from "next/og";
 import { NextRequest } from "next/server";
+
+import { OPEN_GRAPH_IMAGE_DIMENSIONS } from "src/utils/seo";
+
 import OpenGraphImage from "./OpenGraphImage";
-import { OPEN_GRAPH_IMAGE_DIMENSIONS } from "../../../utils/seo";
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,11 +2,13 @@ import { Metadata } from "next";
 import { Darker_Grotesque, Figtree } from "next/font/google";
 import { draftMode } from "next/headers";
 
-import LiveVisualEditing from "studio/lib/loaders/AutomaticVisualEditing";
-import { loadQuery } from "studio/lib/store";
-import "src/styles/global.css";
 import { generateMetadataFromSeo } from "src/utils/seo";
+import { DefaultLanguageObject } from "studio/lib/interfaces/languages";
+import LiveVisualEditing from "studio/lib/loaders/AutomaticVisualEditing";
 import { DEFAULT_LANGUAGE_QUERY } from "studio/lib/queries/languages";
+import { loadQuery } from "studio/lib/store";
+
+import "src/styles/global.css";
 
 const darkerGrotesque = Darker_Grotesque({
   subsets: ["latin"],

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,12 @@
+import { Metadata } from "next";
 import { Darker_Grotesque, Figtree } from "next/font/google";
 import { draftMode } from "next/headers";
+
 import LiveVisualEditing from "studio/lib/loaders/AutomaticVisualEditing";
-import { Metadata } from "next";
 import { loadQuery } from "studio/lib/store";
 import "src/styles/global.css";
 import { generateMetadataFromSeo } from "src/utils/seo";
-import { DEFAULT_LANGUAGE_QUERY } from "../../studio/lib/queries/languages";
+import { DEFAULT_LANGUAGE_QUERY } from "studio/lib/queries/languages";
 
 const darkerGrotesque = Darker_Grotesque({
   subsets: ["latin"],

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from "next";
-import { client } from "../../studio/lib/client";
-import { Slug } from "../../studio/lib/interfaces/global";
-import { token } from "../../studio/lib/token";
+
+import { client } from "studio/lib/client";
+import { Slug } from "studio/lib/interfaces/global";
+import { token } from "studio/lib/token";
 
 interface SitemapDocument {
   slug: Slug;

--- a/src/blog/Blog.tsx
+++ b/src/blog/Blog.tsx
@@ -1,14 +1,16 @@
 "use client";
-import { useEffect, useCallback } from "react";
+import { useCallback, useEffect } from "react";
+
+import PostPreview from "src/blog/components/postPreview/PostPreview";
+import { useFetchPosts } from "src/utils/hooks/useFetchPosts";
 import useTabs from "src/utils/hooks/useTabs";
 import { BlogPage, Post } from "studio/lib/interfaces/pages";
+
 import styles from "./blog.module.css";
-import { useFetchPosts } from "src/utils/hooks/useFetchPosts";
-import BlogHero from "./components/hero/BlogHero";
-import PostPreview from "src/blog/components/postPreview/PostPreview";
-import PostPreviewGrid from "./components/postPreviewGrid/PostPreviewGrid";
-import LoadingNews from "./components/loadingNews/LoadingNews";
 import CustomErrorMessage from "./components/customErrorMessage/CustomErrorMessage";
+import BlogHero from "./components/hero/BlogHero";
+import LoadingNews from "./components/loadingNews/LoadingNews";
+import PostPreviewGrid from "./components/postPreviewGrid/PostPreviewGrid";
 import { homeLink } from "./components/utils/linkTypes";
 
 interface BlogProps {

--- a/src/blog/BlogPreview.tsx
+++ b/src/blog/BlogPreview.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
+import { Suspense } from "react";
+
 import { BlogPage, Post } from "studio/lib/interfaces/pages";
 import { BLOG_PAGE_QUERY } from "studio/lib/queries/pages";
-import { Suspense } from "react";
+
 import { Blog } from "./Blog";
 
 interface BlogPreviewProps {

--- a/src/blog/components/customErrorMessage/CustomErrorMessage.tsx
+++ b/src/blog/components/customErrorMessage/CustomErrorMessage.tsx
@@ -2,6 +2,7 @@ import Button from "src/components/buttons/Button";
 import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
 import { ILink } from "studio/lib/interfaces/navigation";
+
 import styles from "./customErrorMessage.module.css";
 
 interface CustomErrorMessageProps {

--- a/src/blog/components/hero/BlogHero.stories.tsx
+++ b/src/blog/components/hero/BlogHero.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+
 import BlogHero from "./BlogHero";
 
 const meta: Meta<typeof BlogHero> = {

--- a/src/blog/components/hero/BlogHero.tsx
+++ b/src/blog/components/hero/BlogHero.tsx
@@ -1,7 +1,9 @@
-import Text from "src/components/text/Text";
-import styles from "./blogHero.module.css";
-import { Category } from "studio/lib/interfaces/pages";
 import { LegacyRef } from "react";
+
+import Text from "src/components/text/Text";
+import { Category } from "studio/lib/interfaces/pages";
+
+import styles from "./blogHero.module.css";
 
 const BlogHero = ({
   title,

--- a/src/blog/components/informationSection/InformationSection.tsx
+++ b/src/blog/components/informationSection/InformationSection.tsx
@@ -1,8 +1,10 @@
+import React from "react";
+
 import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
 import { ILink } from "studio/lib/interfaces/navigation";
+
 import styles from "./informationSection.module.css";
-import React from "react";
 
 interface InformationSectionProps {
   title: string;

--- a/src/blog/components/legal/Legal.tsx
+++ b/src/blog/components/legal/Legal.tsx
@@ -1,8 +1,10 @@
-import Text from "src/components/text/Text";
-import styles from "./legal.module.css";
-import { LegalDocument } from "studio/lib/interfaces/legalDocuments";
-import { RichText, PortableTextBlock } from "src/components/richText/RichText";
 import Link from "next/link";
+
+import { PortableTextBlock, RichText } from "src/components/richText/RichText";
+import Text from "src/components/text/Text";
+import { LegalDocument } from "studio/lib/interfaces/legalDocuments";
+
+import styles from "./legal.module.css";
 
 const extractHeadings = (blocks: PortableTextBlock[]) => {
   return blocks

--- a/src/blog/components/legal/LegalPreview.tsx
+++ b/src/blog/components/legal/LegalPreview.tsx
@@ -1,7 +1,9 @@
 "use client";
 import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
-import { NAV_QUERY } from "studio/lib/queries/navigation";
+
 import { LegalDocument } from "studio/lib/interfaces/legalDocuments";
+import { NAV_QUERY } from "studio/lib/queries/navigation";
+
 import Legal from "./Legal";
 
 export default function LegalPreview({

--- a/src/blog/components/loadingNews/LoadingNews.tsx
+++ b/src/blog/components/loadingNews/LoadingNews.tsx
@@ -1,4 +1,5 @@
 import Text from "src/components/text/Text";
+
 import styles from "./loadingNews.module.css";
 
 const LoadingNews = () => {

--- a/src/blog/components/postCard/PostCard.tsx
+++ b/src/blog/components/postCard/PostCard.tsx
@@ -2,6 +2,7 @@
 import Text from "src/components/text/Text";
 import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
 import { Post } from "studio/lib/interfaces/pages";
+
 import styles from "./postCard.module.css";
 
 export const PostCard = ({

--- a/src/blog/components/postPreview/PostPreview.tsx
+++ b/src/blog/components/postPreview/PostPreview.tsx
@@ -1,11 +1,12 @@
 "use client";
-import { RichText, PortableTextBlock } from "src/components/richText/RichText";
-import Text from "src/components/text/Text";
-import { Post } from "studio/lib/interfaces/pages";
-import styles from "./postPreview.module.css";
 import CustomLink from "src/components/link/CustomLink";
-import { LinkType } from "studio/lib/interfaces/navigation";
+import { PortableTextBlock, RichText } from "src/components/richText/RichText";
+import Text from "src/components/text/Text";
 import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
+import { LinkType } from "studio/lib/interfaces/navigation";
+import { Post } from "studio/lib/interfaces/pages";
+
+import styles from "./postPreview.module.css";
 
 export interface PostPreviewProps {
   post: Post;

--- a/src/blog/components/postPreview/PostReview.stories.tsx
+++ b/src/blog/components/postPreview/PostReview.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
-import PostPreview from "./PostPreview";
+
 import { postMock } from "./mockData";
+import PostPreview from "./PostPreview";
 
 const meta: Meta<typeof PostPreview> = {
   title: "Blog/PostPreview",

--- a/src/blog/components/postPreview/mockData.ts
+++ b/src/blog/components/postPreview/mockData.ts
@@ -1,5 +1,5 @@
-import placeholder from "src/stories/assets/image-placeholder.png";
 import { PortableTextBlock } from "src/components/richText/RichText";
+import placeholder from "src/stories/assets/image-placeholder.png";
 
 // Common rich text for lead and main content
 const leadRichText: PortableTextBlock[] = [

--- a/src/blog/components/postPreviewGrid/PostPreviewGrid.tsx
+++ b/src/blog/components/postPreviewGrid/PostPreviewGrid.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useRef, useState, useCallback } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+import { PostCard } from "src/blog/components/postCard/PostCard";
+import Button from "src/components/buttons/Button";
 import Text from "src/components/text/Text";
 import { Post } from "studio/lib/interfaces/pages";
+
 import styles from "./postPreviewGrid.module.css";
-import Button from "src/components/buttons/Button";
-import { PostCard } from "../postCard/PostCard";
 
 const PostPreviewGrid = ({
   posts,

--- a/src/compensations/Compensations.tsx
+++ b/src/compensations/Compensations.tsx
@@ -1,11 +1,20 @@
 "use client";
-import styles from "./compensations.module.css";
+import { useMemo, useState } from "react";
+
+import {
+  IOption,
+  RadioButtonGroup,
+} from "src/components/forms/radioButtonGroup/RadioButtonGroup";
 import Text from "src/components/text/Text";
+import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
 import { CompensationsPage } from "studio/lib/interfaces/compensations";
+
+import styles from "./compensations.module.css";
+import BenefitsByLocation from "./components/benefitsByLocation/BenefitsByLocation";
 import SalaryCalculator, {
   Degree,
 } from "./components/salaryCalculator/SalaryCalculator";
-import { useMemo, useState } from "react";
+import YearlyBonuses from "./components/yearlyBonuses/YearlyBonuses";
 import {
   calculatePension,
   calculateSalary,
@@ -13,13 +22,6 @@ import {
   minSalariesExaminationYear,
   salariesFromLocation,
 } from "./utils/salary";
-import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
-import {
-  IOption,
-  RadioButtonGroup,
-} from "src/components/forms/radioButtonGroup/RadioButtonGroup";
-import YearlyBonuses from "./components/yearlyBonuses/YearlyBonuses";
-import BenefitsByLocation from "./components/benefitsByLocation/BenefitsByLocation";
 
 interface CompensationsProps {
   compensations: CompensationsPage;

--- a/src/compensations/CompensationsPreview.tsx
+++ b/src/compensations/CompensationsPreview.tsx
@@ -1,11 +1,13 @@
 "use client";
-import { Suspense } from "react";
-import Compensations from "./Compensations";
 import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
-import { CompensationsPage } from "studio/lib/interfaces/compensations";
+import { Suspense } from "react";
+
 import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
+import { CompensationsPage } from "studio/lib/interfaces/compensations";
 import { COMPANY_LOCATIONS_QUERY } from "studio/lib/queries/companyDetails";
 import { COMPENSATIONS_PAGE_QUERY } from "studio/lib/queries/pages";
+
+import Compensations from "./Compensations";
 
 interface CompensationsPreviewProps {
   initialCompensations: QueryResponseInitial<CompensationsPage>;

--- a/src/compensations/components/benefitsByLocation/BenefitsByLocation.tsx
+++ b/src/compensations/components/benefitsByLocation/BenefitsByLocation.tsx
@@ -1,7 +1,8 @@
-import Text from "src/components/text/Text";
 import { RichText } from "src/components/richText/RichText";
-import styles from "./benefitsByLocation.module.css";
+import Text from "src/components/text/Text";
 import { Benefit } from "studio/lib/interfaces/compensations";
+
+import styles from "./benefitsByLocation.module.css";
 
 interface BenefitsByLocationProps {
   benefits: Benefit[];

--- a/src/compensations/components/salaryCalculator/SalaryCalculator.tsx
+++ b/src/compensations/components/salaryCalculator/SalaryCalculator.tsx
@@ -1,10 +1,11 @@
-import styles from "./salaryCalculator.module.css";
+import Button from "src/components/buttons/Button";
 import InputField from "src/components/forms/inputField/InputField";
 import {
   IOption,
   RadioButtonGroup,
 } from "src/components/forms/radioButtonGroup/RadioButtonGroup";
-import Button from "src/components/buttons/Button";
+
+import styles from "./salaryCalculator.module.css";
 
 export type Degree = "bachelor" | "master";
 

--- a/src/compensations/components/yearlyBonuses/YearlyBonuses.tsx
+++ b/src/compensations/components/yearlyBonuses/YearlyBonuses.tsx
@@ -1,5 +1,6 @@
+import Text from "src/components/text/Text";
 import { BonusPage } from "studio/lib/interfaces/compensations";
-import Text from "../../../components/text/Text";
+
 import styles from "./yearlyBonuses.module.css";
 
 interface YearlyBonusesProps {

--- a/src/compensations/utils/salary.ts
+++ b/src/compensations/utils/salary.ts
@@ -1,9 +1,9 @@
 import {
-  isSalariesType,
   Salaries,
+  isSalariesType,
 } from "studio/components/salariesInput/utils/parseSalaries";
-import { SalariesByLocation } from "../../../studio/lib/interfaces/compensations";
-import { Result, ResultError, ResultOk } from "../../../studio/utils/result";
+import { SalariesByLocation } from "studio/lib/interfaces/compensations";
+import { Result, ResultError, ResultOk } from "studio/utils/result";
 
 export function calculateSalary(
   examinationYear: number,

--- a/src/components/buttons/BackButton.stories.tsx
+++ b/src/components/buttons/BackButton.stories.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
+
 import BackButton from "./BackButton";
 
 const meta: Meta<typeof BackButton> = {

--- a/src/components/buttons/BackButton.tsx
+++ b/src/components/buttons/BackButton.tsx
@@ -1,7 +1,8 @@
 "use client";
-import React from "react";
-import styles from "./button.module.css";
 import { useRouter } from "next/navigation";
+import React from "react";
+
+import styles from "./button.module.css";
 
 type ButtonSize = "large" | "small";
 

--- a/src/components/buttons/Button.stories.tsx
+++ b/src/components/buttons/Button.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+
 import Button from "./Button";
 
 const meta: Meta<typeof Button> = {

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import styles from "./button.module.css";
 
 type ButtonType = "primary" | "secondary";

--- a/src/components/forms/checkbox/Checkbox.tsx
+++ b/src/components/forms/checkbox/Checkbox.tsx
@@ -1,8 +1,10 @@
-import Text from "src/components/text/Text";
-import styles from "./checkbox.module.css";
-import textStyles from "src/components/text/text.module.css";
-import { PortableTextBlock } from "src/components/richText/RichText";
 import { PortableText } from "@portabletext/react";
+
+import { PortableTextBlock } from "src/components/richText/RichText";
+import Text from "src/components/text/Text";
+import textStyles from "src/components/text/text.module.css";
+
+import styles from "./checkbox.module.css";
 
 interface CheckboxProps {
   label: string | PortableTextBlock[];

--- a/src/components/forms/inputField/InputField.tsx
+++ b/src/components/forms/inputField/InputField.tsx
@@ -1,7 +1,9 @@
-import Text from "src/components/text/Text";
-import styles from "./inputField.module.css";
-import textStyles from "src/components/text/text.module.css";
 import { HTMLInputAutoCompleteAttribute, HTMLInputTypeAttribute } from "react";
+
+import Text from "src/components/text/Text";
+import textStyles from "src/components/text/text.module.css";
+
+import styles from "./inputField.module.css";
 
 interface InputFieldProps {
   label: string;

--- a/src/components/forms/inputTextArea/InputTextArea.tsx
+++ b/src/components/forms/inputTextArea/InputTextArea.tsx
@@ -1,6 +1,7 @@
 import Text from "src/components/text/Text";
-import styles from "./inputTextArea.module.css";
 import textStyles from "src/components/text/text.module.css";
+
+import styles from "./inputTextArea.module.css";
 
 interface InputTextAreaProps {
   label: string;

--- a/src/components/forms/radioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/forms/radioButtonGroup/RadioButtonGroup.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import styles from "src/components/forms/radioButtonGroup/radioButtonGroup.module.css";
 import textStyles from "src/components/text/text.module.css";
 

--- a/src/components/link/CustomLink.stories.tsx
+++ b/src/components/link/CustomLink.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import CustomLink from "./CustomLink";
+
 import { LinkType } from "studio/lib/interfaces/navigation";
+
+import CustomLink from "./CustomLink";
 
 const meta: Meta<typeof CustomLink> = {
   title: "Components/Links/CustomLink",

--- a/src/components/link/CustomLink.tsx
+++ b/src/components/link/CustomLink.tsx
@@ -1,8 +1,10 @@
-import React from "react";
-import styles from "./link.module.css";
 import Link from "next/link";
-import { ILink } from "studio/lib/interfaces/navigation";
+import React from "react";
+
 import { getHref } from "src/utils/get";
+import { ILink } from "studio/lib/interfaces/navigation";
+
+import styles from "./link.module.css";
 
 type ComponentLinkType = "link" | "headerLink" | "footerLink";
 

--- a/src/components/link/SoMeLink.tsx
+++ b/src/components/link/SoMeLink.tsx
@@ -1,7 +1,9 @@
-import React from "react";
-import styles from "./link.module.css";
 import Link from "next/link";
+import React from "react";
+
 import { SocialMediaLink } from "studio/lib/interfaces/socialMedia";
+
+import styles from "./link.module.css";
 
 interface ISoMeLink {
   link: SocialMediaLink;

--- a/src/components/linkButton/LinkButton.stories.tsx
+++ b/src/components/linkButton/LinkButton.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import LinkButton from "./LinkButton";
+
 import { LinkType } from "studio/lib/interfaces/navigation";
+
+import LinkButton from "./LinkButton";
 
 const meta: Meta<typeof LinkButton> = {
   title: "Components/Links/LinkButton",

--- a/src/components/linkButton/LinkButton.tsx
+++ b/src/components/linkButton/LinkButton.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import styles from "./linkButton.module.css";
-import { ILink } from "studio/lib/interfaces/navigation";
+
 import { getHref } from "src/utils/get";
+import { ILink } from "studio/lib/interfaces/navigation";
+
+import styles from "./linkButton.module.css";
 
 type LinkButtonType = "primary" | "secondary";
 

--- a/src/components/navigation/footer/Footer.stories.tsx
+++ b/src/components/navigation/footer/Footer.stories.tsx
@@ -1,10 +1,12 @@
 import { Meta, StoryObj } from "@storybook/react";
-import Footer from "./Footer";
+
 import {
+  mockCompanyInfo,
   mockNavigation,
   mockSocialMediaProfiles,
-  mockCompanyInfo,
-} from "../mockData";
+} from "src/components/navigation/mockData";
+
+import Footer from "./Footer";
 
 const meta: Meta<typeof Footer> = {
   title: "Components/Navigation/Footer",

--- a/src/components/navigation/footer/Footer.tsx
+++ b/src/components/navigation/footer/Footer.tsx
@@ -1,19 +1,21 @@
 "use client";
 
-import { ILink, LinkType, Navigation } from "studio/lib/interfaces/navigation";
-import { CompanyInfo } from "studio/lib/interfaces/companyDetails";
+import { ReactNode } from "react";
+
+import CustomLink from "src/components/link/CustomLink";
+import SoMeLink from "src/components/link/SoMeLink";
+import Text from "src/components/text/Text";
 import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
-import styles from "./footer.module.css";
-import CustomLink from "../../link/CustomLink";
+import { BrandAssets } from "studio/lib/interfaces/brandAssets";
+import { CompanyInfo } from "studio/lib/interfaces/companyDetails";
+import { LegalDocument } from "studio/lib/interfaces/legalDocuments";
+import { ILink, LinkType, Navigation } from "studio/lib/interfaces/navigation";
 import {
   SocialMediaLink,
   SocialMediaProfiles,
 } from "studio/lib/interfaces/socialMedia";
-import SoMeLink from "src/components/link/SoMeLink";
-import { ReactNode } from "react";
-import Text from "src/components/text/Text";
-import { LegalDocument } from "studio/lib/interfaces/legalDocuments";
-import { BrandAssets } from "studio/lib/interfaces/brandAssets";
+
+import styles from "./footer.module.css";
 
 export interface IFooter {
   navigationData: Navigation;

--- a/src/components/navigation/footer/FooterPreview.tsx
+++ b/src/components/navigation/footer/FooterPreview.tsx
@@ -1,14 +1,16 @@
 "use client";
 import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
-import { NAV_QUERY } from "studio/lib/queries/navigation";
-import { Navigation } from "studio/lib/interfaces/navigation";
-import { CompanyInfo } from "studio/lib/interfaces/companyDetails";
-import { COMPANY_INFO_QUERY } from "studio/lib/queries/companyDetails";
-import Footer from "./Footer";
-import { SocialMediaProfiles } from "studio/lib/interfaces/socialMedia";
-import { SOMEPROFILES_QUERY } from "studio/lib/queries/socialMediaProfiles";
+
 import { BrandAssets } from "studio/lib/interfaces/brandAssets";
+import { CompanyInfo } from "studio/lib/interfaces/companyDetails";
+import { Navigation } from "studio/lib/interfaces/navigation";
+import { SocialMediaProfiles } from "studio/lib/interfaces/socialMedia";
 import { BRAND_ASSETS_QUERY } from "studio/lib/queries/brandAssets";
+import { COMPANY_INFO_QUERY } from "studio/lib/queries/companyDetails";
+import { NAV_QUERY } from "studio/lib/queries/navigation";
+import { SOMEPROFILES_QUERY } from "studio/lib/queries/socialMediaProfiles";
+
+import Footer from "./Footer";
 
 function useInitialData<T>(
   query: string,

--- a/src/components/navigation/header/Header.stories.tsx
+++ b/src/components/navigation/header/Header.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
+
+import { mockLogo, mockNavigation } from "src/components/navigation/mockData";
+
 import { Header } from "./Header";
-import { mockNavigation, mockLogo } from "../mockData";
 
 const meta: Meta<typeof Header> = {
   title: "Components/Navigation/Header",

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { FocusOn } from "react-focus-on";
-import { ILink, Navigation } from "studio/lib/interfaces/navigation";
-import styles from "./header.module.css";
-import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
-import { linkID } from "studio/schemas/objects/link";
-import { callToActionFieldID } from "studio/schemas/fields/callToActionFields";
-import CustomLink from "src/components/link/CustomLink";
-import LinkButton from "src/components/linkButton/LinkButton";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { FocusOn } from "react-focus-on";
+
+import CustomLink from "src/components/link/CustomLink";
+import LinkButton from "src/components/linkButton/LinkButton";
 import { getHref } from "src/utils/get";
-import { BrandAssets } from "../../../../studio/lib/interfaces/brandAssets";
+import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
+import { BrandAssets } from "studio/lib/interfaces/brandAssets";
+import { ILink, Navigation } from "studio/lib/interfaces/navigation";
+import { callToActionFieldID } from "studio/schemas/fields/callToActionFields";
+import { linkID } from "studio/schemas/objects/link";
+
+import styles from "./header.module.css";
 
 export interface IHeader {
   data: Navigation;

--- a/src/components/navigation/header/HeaderPreview.tsx
+++ b/src/components/navigation/header/HeaderPreview.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
-import { NAV_QUERY } from "studio/lib/queries/navigation";
+
+import { BrandAssets } from "studio/lib/interfaces/brandAssets";
 import { Navigation } from "studio/lib/interfaces/navigation";
+import { BRAND_ASSETS_QUERY } from "studio/lib/queries/brandAssets";
+import { NAV_QUERY } from "studio/lib/queries/navigation";
+
 import { Header } from "./Header";
-import { BrandAssets } from "../../../../studio/lib/interfaces/brandAssets";
-import { BRAND_ASSETS_QUERY } from "../../../../studio/lib/queries/brandAssets";
 
 export default function HeaderPreview({
   initialNav,

--- a/src/components/navigation/mockData.ts
+++ b/src/components/navigation/mockData.ts
@@ -1,13 +1,13 @@
+import primaryLogoFile from "src/stories/assets/energiai-primary-logo.svg";
+import secondaryLogoFile from "src/stories/assets/energiai-secondary-logo.svg";
 import {
-  Navigation,
   LinkType,
+  Navigation,
   SectionType,
 } from "studio/lib/interfaces/navigation";
+import { SocialMediaProfiles } from "studio/lib/interfaces/socialMedia";
 import { callToActionFieldID } from "studio/schemas/fields/callToActionFields";
 import { linkID } from "studio/schemas/objects/link";
-import primaryLogoFile from "../../stories/assets/energiai-primary-logo.svg";
-import secondaryLogoFile from "../../stories/assets/energiai-secondary-logo.svg";
-import { SocialMediaProfiles } from "studio/lib/interfaces/socialMedia";
 
 // Mock Navigation Data
 export const mockNavigation: Navigation = {

--- a/src/components/richText/RichText.tsx
+++ b/src/components/richText/RichText.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { PortableText } from "@portabletext/react";
-import Text from "../text/Text";
-import styles from "./richText.module.css";
-import textStyles from "../text/text.module.css";
+
+import Text from "src/components/text/Text";
+import textStyles from "src/components/text/text.module.css";
 import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
+
+import styles from "./richText.module.css";
 
 type Children = {
   _type: string;

--- a/src/components/sections/article/Article.stories.tsx
+++ b/src/components/sections/article/Article.stories.tsx
@@ -1,8 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
+
 import Article from "./Article";
 import {
-  articleRightMock,
   articleLeftMock,
+  articleRightMock,
   extendedArticleLargeLeftMock,
   extendedArticleLargeRightMock,
 } from "./mockData";

--- a/src/components/sections/article/Article.tsx
+++ b/src/components/sections/article/Article.tsx
@@ -1,10 +1,11 @@
 "use client";
+import CustomLink from "src/components/link/CustomLink";
 import { RichText } from "src/components/richText/RichText";
 import Text from "src/components/text/Text";
-import { ArticleSection } from "studio/lib/interfaces/pages";
-import styles from "./article.module.css";
 import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
-import CustomLink from "src/components/link/CustomLink";
+import { ArticleSection } from "studio/lib/interfaces/pages";
+
+import styles from "./article.module.css";
 
 interface ArticleProps {
   article: ArticleSection;

--- a/src/components/sections/article/ArticlePreview.tsx
+++ b/src/components/sections/article/ArticlePreview.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useQuery } from "@sanity/react-loader";
-import Article from "./Article";
-import { PageBuilder, ArticleSection } from "studio/lib/interfaces/pages";
-import { PAGE_QUERY } from "studio/lib/queries/pages";
 import { Suspense } from "react";
+
 import { PreviewProps } from "src/types/preview";
+import { ArticleSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { PAGE_QUERY } from "studio/lib/queries/pages";
+
+import Article from "./Article";
 
 export default function ArticlePreview({
   initialData,

--- a/src/components/sections/article/mockData.ts
+++ b/src/components/sections/article/mockData.ts
@@ -1,8 +1,8 @@
+import { PortableTextBlock } from "src/components/richText/RichText";
+import placeholder from "src/stories/assets/image-placeholder.png";
 import { LinkType } from "studio/lib/interfaces/navigation";
 import { ArticleSection } from "studio/lib/interfaces/pages";
 import { ImageAlignment } from "studio/schemas/fields/media";
-import placeholder from "../../../stories/assets/image-placeholder.png";
-import { PortableTextBlock } from "src/components/richText/RichText";
 
 const commonRichText: PortableTextBlock[] = [
   {

--- a/src/components/sections/callToAction/CallToAction.stories.tsx
+++ b/src/components/sections/callToAction/CallToAction.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+
 import CallToAction from "./CallToAction";
 import { ctaMockData } from "./mockData";
 

--- a/src/components/sections/callToAction/CallToAction.tsx
+++ b/src/components/sections/callToAction/CallToAction.tsx
@@ -1,6 +1,7 @@
-import Text from "src/components/text/Text";
 import LinkButton from "src/components/linkButton/LinkButton";
+import Text from "src/components/text/Text";
 import { CallToActionSection } from "studio/lib/interfaces/pages";
+
 import styles from "./callToAction.module.css";
 
 interface CallToActionProps {

--- a/src/components/sections/callToAction/CallToActionPreview.tsx
+++ b/src/components/sections/callToAction/CallToActionPreview.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useQuery } from "@sanity/react-loader";
-import CallToAction from "./CallToAction";
-import { PageBuilder, CallToActionSection } from "studio/lib/interfaces/pages";
-import { PAGE_QUERY } from "studio/lib/queries/pages";
 import { Suspense } from "react";
+
 import { PreviewProps } from "src/types/preview";
+import { CallToActionSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { PAGE_QUERY } from "studio/lib/queries/pages";
+
+import CallToAction from "./CallToAction";
 
 export default function CallToActionPreview({
   initialData,

--- a/src/components/sections/callout/Callout.stories.tsx
+++ b/src/components/sections/callout/Callout.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+
 import Callout from "./Callout";
 import { calloutMockData } from "./mockData";
 

--- a/src/components/sections/callout/Callout.tsx
+++ b/src/components/sections/callout/Callout.tsx
@@ -1,8 +1,10 @@
-import CustomLink from "src/components/link/CustomLink";
-import { CalloutSection } from "studio/lib/interfaces/pages";
-import styles from "./callout.module.css";
 import { PortableText } from "@portabletext/react";
+
+import CustomLink from "src/components/link/CustomLink";
 import Text from "src/components/text/Text";
+import { CalloutSection } from "studio/lib/interfaces/pages";
+
+import styles from "./callout.module.css";
 
 interface CalloutProps {
   callout: CalloutSection;

--- a/src/components/sections/callout/CalloutPreview.tsx
+++ b/src/components/sections/callout/CalloutPreview.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useQuery } from "@sanity/react-loader";
-import Callout from "./Callout";
-import { PageBuilder, CalloutSection } from "studio/lib/interfaces/pages";
-import { PAGE_QUERY } from "studio/lib/queries/pages";
 import { Suspense } from "react";
+
 import { PreviewProps } from "src/types/preview";
+import { CalloutSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { PAGE_QUERY } from "studio/lib/queries/pages";
+
+import Callout from "./Callout";
 
 export default function CalloutPreview({
   initialData,

--- a/src/components/sections/contactForm/ContactForm.tsx
+++ b/src/components/sections/contactForm/ContactForm.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import React, { useState, ChangeEvent, FormEvent } from "react";
+import React, { ChangeEvent, FormEvent, useState } from "react";
+
+import { ContactData } from "src/app/api/contactForm/route";
+import Button from "src/components/buttons/Button";
+import Checkbox from "src/components/forms/checkbox/Checkbox";
+import InputField from "src/components/forms/inputField/InputField";
+import InputTextArea from "src/components/forms/inputTextArea/InputTextArea";
 import Text from "src/components/text/Text";
 import { ContactFormSection } from "studio/lib/interfaces/pages";
+
 import styles from "./contactForm.module.css";
-import InputField from "src/components/forms/inputField/InputField";
-import Button from "src/components/buttons/Button";
-import InputTextArea from "src/components/forms/inputTextArea/InputTextArea";
-import Checkbox from "src/components/forms/checkbox/Checkbox";
-import { ContactData } from "src/app/api/contactForm/route";
 
 interface SubmitStatus {
   message?: string;

--- a/src/components/sections/grid/Grid.stories.tsx
+++ b/src/components/sections/grid/Grid.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+
 import Grid from "./Grid";
 import { mockGrid } from "./mockdata";
 

--- a/src/components/sections/grid/Grid.tsx
+++ b/src/components/sections/grid/Grid.tsx
@@ -1,11 +1,13 @@
 "use client";
-import Text from "src/components/text/Text";
-import { GridSection } from "studio/lib/interfaces/pages";
-import styles from "./grid.module.css";
-import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
 import { PortableText } from "@portabletext/react";
+
 import { PortableTextBlock } from "src/components/richText/RichText";
+import Text from "src/components/text/Text";
+import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
 import { IImage } from "studio/lib/interfaces/media";
+import { GridSection } from "studio/lib/interfaces/pages";
+
+import styles from "./grid.module.css";
 
 const Grid = ({ grid }: { grid: GridSection }) => {
   return (

--- a/src/components/sections/grid/GridPreview.tsx
+++ b/src/components/sections/grid/GridPreview.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useQuery } from "@sanity/react-loader";
-import { PageBuilder, GridSection } from "studio/lib/interfaces/pages";
-import { PAGE_QUERY } from "studio/lib/queries/pages";
 import { Suspense } from "react";
+
 import { PreviewProps } from "src/types/preview";
+import { GridSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { PAGE_QUERY } from "studio/lib/queries/pages";
+
 import Grid from "./Grid";
 
 export default function GridPreview({

--- a/src/components/sections/grid/mockdata.ts
+++ b/src/components/sections/grid/mockdata.ts
@@ -1,5 +1,5 @@
-import placeholder from "../../../stories/assets/image-placeholder.png";
 import { PortableTextBlock } from "src/components/richText/RichText";
+import placeholder from "src/stories/assets/image-placeholder.png";
 
 const commonRichText: PortableTextBlock[] = [
   {

--- a/src/components/sections/hero/Hero.stories.tsx
+++ b/src/components/sections/hero/Hero.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+
 import { Hero } from "./Hero";
 import { mockHeroSection } from "./mockData";
 

--- a/src/components/sections/hero/Hero.tsx
+++ b/src/components/sections/hero/Hero.tsx
@@ -1,8 +1,9 @@
-import Text from "src/components/text/Text";
 import LinkButton from "src/components/linkButton/LinkButton";
-import { HeroSection } from "studio/lib/interfaces/pages";
-import styles from "./hero.module.css";
+import Text from "src/components/text/Text";
 import { ILink } from "studio/lib/interfaces/navigation";
+import { HeroSection } from "studio/lib/interfaces/pages";
+
+import styles from "./hero.module.css";
 
 interface HeroProps {
   hero: HeroSection;

--- a/src/components/sections/hero/HeroPreview.tsx
+++ b/src/components/sections/hero/HeroPreview.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useQuery } from "@sanity/react-loader";
-import { Hero } from "./Hero";
-import { PageBuilder, HeroSection } from "studio/lib/interfaces/pages";
-import { PAGE_QUERY } from "studio/lib/queries/pages";
 import { Suspense } from "react";
+
 import { PreviewProps } from "src/types/preview";
+import { HeroSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { PAGE_QUERY } from "studio/lib/queries/pages";
+
+import { Hero } from "./Hero";
 
 interface HeroPreviewProps extends PreviewProps {
   isLanding: boolean;

--- a/src/components/sections/hero/mockData.ts
+++ b/src/components/sections/hero/mockData.ts
@@ -1,5 +1,5 @@
-import { HeroSection } from "studio/lib/interfaces/pages";
 import { LinkType } from "studio/lib/interfaces/navigation";
+import { HeroSection } from "studio/lib/interfaces/pages";
 
 export const mockHeroSection: HeroSection = {
   _key: "",

--- a/src/components/sections/imageSection/ImageSectionComponent.stories.tsx
+++ b/src/components/sections/imageSection/ImageSectionComponent.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
-import placeholder from "../../../stories/assets/image-placeholder.png";
+
+import placeholder from "src/stories/assets/image-placeholder.png";
+
 import ImageSectionComponent from "./ImageSectionComponent";
 
 const meta: Meta<typeof ImageSectionComponent> = {

--- a/src/components/sections/imageSection/ImageSectionComponent.tsx
+++ b/src/components/sections/imageSection/ImageSectionComponent.tsx
@@ -2,6 +2,7 @@
 import Text from "src/components/text/Text";
 import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
 import { ImageSection } from "studio/lib/interfaces/pages";
+
 import styles from "./imageSectionComponent.module.css";
 
 const ImageSectionComponent = ({ section }: { section: ImageSection }) => {

--- a/src/components/sections/imageSection/ImageSectionComponentPreview.tsx
+++ b/src/components/sections/imageSection/ImageSectionComponentPreview.tsx
@@ -1,13 +1,11 @@
 "use client";
 import { useQuery } from "@sanity/react-loader";
-import {
-  ImageSection,
-  PageBuilder,
-  TestimonialsSection,
-} from "studio/lib/interfaces/pages";
-import { PAGE_QUERY } from "studio/lib/queries/pages";
 import { Suspense } from "react";
+
 import { PreviewProps } from "src/types/preview";
+import { ImageSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { PAGE_QUERY } from "studio/lib/queries/pages";
+
 import ImageSectionComponent from "./ImageSectionComponent";
 
 export default function ImageSectionComponentPreview({

--- a/src/components/sections/logoSalad/LogoSalad.stories.tsx
+++ b/src/components/sections/logoSalad/LogoSalad.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+
 import { LogoSalad } from "./LogoSalad";
 import { extendedMockLogoSaladSection, mockLogoSaladSection } from "./mockData";
 

--- a/src/components/sections/logoSalad/LogoSalad.tsx
+++ b/src/components/sections/logoSalad/LogoSalad.tsx
@@ -1,8 +1,10 @@
+import { PortableText } from "@portabletext/react";
+
 import Text from "src/components/text/Text";
 import { LogoSaladSection } from "studio/lib/interfaces/pages";
-import styles from "./logoSalad.module.css";
+
 import { RenderLogo } from "./LogoRender";
-import { PortableText } from "@portabletext/react";
+import styles from "./logoSalad.module.css";
 
 interface LogoSaladProps {
   logoSalad: LogoSaladSection;

--- a/src/components/sections/logoSalad/LogoSaladPreview.tsx
+++ b/src/components/sections/logoSalad/LogoSaladPreview.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
-import { LogoSalad } from "./LogoSalad";
-import { PageBuilder, LogoSaladSection } from "studio/lib/interfaces/pages";
-import { PAGE_QUERY } from "studio/lib/queries/pages";
+import { useQuery } from "@sanity/react-loader";
 import { Suspense } from "react";
+
 import { PreviewProps } from "src/types/preview";
+import { LogoSaladSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { PAGE_QUERY } from "studio/lib/queries/pages";
+
+import { LogoSalad } from "./LogoSalad";
 
 export default function LogoSaladPreview({
   initialData,

--- a/src/components/sections/logoSalad/mockData.ts
+++ b/src/components/sections/logoSalad/mockData.ts
@@ -1,9 +1,9 @@
+import sevenoffice from "src/stories/assets/logoSalad/24sevenoffice.png";
+import credoPartners from "src/stories/assets/logoSalad/credo-partners.png";
+import skift from "src/stories/assets/logoSalad/skift.png";
+import sparebanknord from "src/stories/assets/logoSalad/sparebank1-nord-norge.png";
+import virke from "src/stories/assets/logoSalad/virke.png";
 import { LogoSaladSection } from "studio/lib/interfaces/pages";
-import sparebanknord from "../../../stories/assets/logoSalad/sparebank1-nord-norge.png";
-import sevenoffice from "../../../stories/assets/logoSalad/24sevenoffice.png";
-import credoPartners from "../../../stories/assets/logoSalad/credo-partners.png";
-import skift from "../../../stories/assets/logoSalad/skift.png";
-import virke from "../../../stories/assets/logoSalad/virke.png";
 
 const logos = [
   {

--- a/src/components/sections/testimonials/Testimonials.stories.tsx
+++ b/src/components/sections/testimonials/Testimonials.stories.tsx
@@ -1,8 +1,9 @@
 // Testimonials.stories.tsx
 
 import { Meta, StoryObj } from "@storybook/react";
-import { Testimonials } from "./Testimonials";
+
 import { testimonialsMockData } from "./mockData";
+import { Testimonials } from "./Testimonials";
 
 const meta: Meta<typeof Testimonials> = {
   title: "Components/Sections/Testimonials",

--- a/src/components/sections/testimonials/Testimonials.tsx
+++ b/src/components/sections/testimonials/Testimonials.tsx
@@ -1,10 +1,11 @@
 "use client";
-import Text from "src/components/text/Text";
-import { TestimonialsSection } from "studio/lib/interfaces/pages";
-import styles from "./testimonials.module.css";
-import { RenderImage } from "./RenderAvatar";
 import { RichText } from "src/components/richText/RichText";
+import Text from "src/components/text/Text";
 import useTabs from "src/utils/hooks/useTabs";
+import { TestimonialsSection } from "studio/lib/interfaces/pages";
+
+import { RenderImage } from "./RenderAvatar";
+import styles from "./testimonials.module.css";
 
 interface TestimonialsProps {
   testimonials: TestimonialsSection;

--- a/src/components/sections/testimonials/TestimonialsPreview.tsx
+++ b/src/components/sections/testimonials/TestimonialsPreview.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useQuery } from "@sanity/react-loader";
-import { Testimonials } from "./Testimonials";
+import { Suspense } from "react";
+
+import { PreviewProps } from "src/types/preview";
 import { PageBuilder, TestimonialsSection } from "studio/lib/interfaces/pages";
 import { PAGE_QUERY } from "studio/lib/queries/pages";
-import { Suspense } from "react";
-import { PreviewProps } from "src/types/preview";
+
+import { Testimonials } from "./Testimonials";
 
 export default function TestimonialsPreview({
   sectionIndex,

--- a/src/components/sections/testimonials/mockData.ts
+++ b/src/components/sections/testimonials/mockData.ts
@@ -1,7 +1,7 @@
+import alex from "src/stories/assets/alex.jpg";
+import mika from "src/stories/assets/mika.jpg";
+import vince from "src/stories/assets/vince.jpg";
 import { TestimonialsSection } from "studio/lib/interfaces/pages";
-import alex from "../../../stories/assets/alex.jpg";
-import mika from "../../../stories/assets/mika.jpg";
-import vince from "../../../stories/assets/vince.jpg";
 
 export const testimonialsMockData: TestimonialsSection = {
   _type: "testimonials",

--- a/src/components/skipToMain/SkipToMain.tsx
+++ b/src/components/skipToMain/SkipToMain.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+
 import styles from "./skipToMain.module.css";
 
 const SkipToMain = () => {

--- a/src/components/text/Text.stories.tsx
+++ b/src/components/text/Text.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+
 import Text from "./Text";
 
 const meta: Meta<typeof Text> = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { HTTP_STATUSES } from "./utils/http";
+
 import { RedirectDestinationSlugPage } from "studio/lib/interfaces/redirect";
-import { REDIRECT_BY_SOURCE_SLUG_QUERY } from "../studio/lib/queries/redirects";
+import { REDIRECT_BY_SOURCE_SLUG_QUERY } from "studio/lib/queries/redirects";
+
+import { HTTP_STATUSES } from "./utils/http";
 
 export async function middleware(request: NextRequest) {
   const slug = request.nextUrl.pathname;

--- a/src/post/PostPage.tsx
+++ b/src/post/PostPage.tsx
@@ -1,9 +1,10 @@
+import { RichText } from "src/components/richText/RichText";
 import { BlogPage, Post } from "studio/lib/interfaces/pages";
+
 import PostHero from "./hero/PostHero";
 import Lead from "./lead/Lead";
-import styles from "./post.module.css";
-import { RichText } from "src/components/richText/RichText";
 import MorePostsGrid from "./morePostsGrid/MorePostsGrid";
+import styles from "./post.module.css";
 
 const PostPage = ({
   post,

--- a/src/post/PostPagePreview.tsx
+++ b/src/post/PostPagePreview.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
+import { Suspense } from "react";
+
 import { BlogPage, Post } from "studio/lib/interfaces/pages";
 import { POST_SLUG_QUERY } from "studio/lib/queries/pages";
-import { Suspense } from "react";
+
 import PostPage from "./PostPage";
 
 interface PostPagePreviewProps {

--- a/src/post/hero/PostHero.stories.tsx
+++ b/src/post/hero/PostHero.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+
 import PostHero from "./PostHero";
 
 const meta: Meta<typeof PostHero> = {

--- a/src/post/hero/PostHero.tsx
+++ b/src/post/hero/PostHero.tsx
@@ -1,6 +1,7 @@
-import Text from "src/components/text/Text";
-import styles from "./postHero.module.css";
 import BackButton from "src/components/buttons/BackButton";
+import Text from "src/components/text/Text";
+
+import styles from "./postHero.module.css";
 
 const formatDate = (date: string | number | Date): string => {
   const d: Date = new Date(date);

--- a/src/post/lead/Lead.stories.tsx
+++ b/src/post/lead/Lead.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
+
+import placeholder from "src/stories/assets/image-placeholder.png";
+
 import Lead from "./Lead";
-import placeholder from "../../stories/assets/image-placeholder.png";
 
 const meta: Meta<typeof Lead> = {
   title: "Post/Lead",

--- a/src/post/lead/Lead.tsx
+++ b/src/post/lead/Lead.tsx
@@ -1,10 +1,12 @@
 "use client";
+import { PortableText } from "@portabletext/react";
+
 import { PortableTextBlock } from "src/components/richText/RichText";
+import Text from "src/components/text/Text";
 import { useConvertSanityImageToNextImage } from "src/utils/hooks/useConvertImage";
 import { IImage } from "studio/lib/interfaces/media";
+
 import styles from "./lead.module.css";
-import { PortableText } from "@portabletext/react";
-import Text from "src/components/text/Text";
 
 const myPortableTextComponents = {
   block: ({ children }: any) => <Text type="bodyLarge">{children}</Text>,

--- a/src/post/morePostsGrid/MorePostsGrid.stories.tsx
+++ b/src/post/morePostsGrid/MorePostsGrid.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
-import MorePostsGrid from "./MorePostsGrid";
+
 import { mockPosts } from "./mockdata";
+import MorePostsGrid from "./MorePostsGrid";
 
 const meta: Meta<typeof MorePostsGrid> = {
   title: "Post/MorePostsGrid",

--- a/src/post/morePostsGrid/MorePostsGrid.tsx
+++ b/src/post/morePostsGrid/MorePostsGrid.tsx
@@ -1,8 +1,9 @@
+import { PostCard } from "src/blog/components/postCard/PostCard";
+import BackButton from "src/components/buttons/BackButton";
 import Text from "src/components/text/Text";
 import { Post } from "studio/lib/interfaces/pages";
+
 import styles from "./morePostsGrid.module.css";
-import BackButton from "src/components/buttons/BackButton";
-import { PostCard } from "src/blog/components/postCard/PostCard";
 
 const MorePostsGrid = ({
   posts,

--- a/src/post/morePostsGrid/mockdata.ts
+++ b/src/post/morePostsGrid/mockdata.ts
@@ -1,5 +1,5 @@
+import placeholder from "src/stories/assets/image-placeholder.png";
 import { Post } from "studio/lib/interfaces/pages";
-import placeholder from "../../stories/assets/image-placeholder.png";
 
 export const mockPosts: Post[] = [
   {

--- a/src/types/preview.ts
+++ b/src/types/preview.ts
@@ -1,4 +1,5 @@
 import { QueryResponseInitial } from "@sanity/react-loader";
+
 import { PageBuilder } from "studio/lib/interfaces/pages";
 
 export interface PreviewProps {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,9 +1,9 @@
 import { client } from "studio/lib/client";
+import { Post } from "studio/lib/interfaces/pages";
 import {
   CATEGORIZED_POSTS_QUERY,
   COUNT_POSTS_QUERY,
 } from "studio/lib/queries/pages";
-import { Post } from "studio/lib/interfaces/pages";
 
 interface FetchResult {
   data: Post[];

--- a/src/utils/draftmode.ts
+++ b/src/utils/draftmode.ts
@@ -1,5 +1,5 @@
-import { ClientPerspective } from "next-sanity";
 import { draftMode } from "next/headers";
+import { ClientPerspective } from "next-sanity";
 
 export interface DraftModeInfo {
   isDraftMode: boolean;

--- a/src/utils/hooks/useConvertImage.tsx
+++ b/src/utils/hooks/useConvertImage.tsx
@@ -1,9 +1,11 @@
+import Image from "next/image";
 import { useNextSanityImage } from "next-sanity-image";
+
 // TODO: add support for sharedClient
+import { JSX } from "react";
+
 import { client } from "studio/lib/client";
 import { IImage } from "studio/lib/interfaces/media";
-import Image from "next/image";
-import { JSX } from "react";
 
 const MockImage = ({ image }: { image: IImage }) => {
   if (!image.src) {

--- a/src/utils/hooks/useConvertImage.tsx
+++ b/src/utils/hooks/useConvertImage.tsx
@@ -1,11 +1,11 @@
 import Image from "next/image";
 import { useNextSanityImage } from "next-sanity-image";
-
-// TODO: add support for sharedClient
 import { JSX } from "react";
 
 import { client } from "studio/lib/client";
 import { IImage } from "studio/lib/interfaces/media";
+
+// TODO: add support for sharedClient
 
 const MockImage = ({ image }: { image: IImage }) => {
   if (!image.src) {

--- a/src/utils/hooks/useFetchPosts.ts
+++ b/src/utils/hooks/useFetchPosts.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
+
+import { fetchCategorizedPosts, fetchPostCount } from "src/utils/api";
 import { Category, Post } from "studio/lib/interfaces/pages";
-import { fetchCategorizedPosts, fetchPostCount } from "../api";
 
 interface FetchState {
   data: Post[];

--- a/src/utils/hooks/useFetchPosts.ts
+++ b/src/utils/hooks/useFetchPosts.ts
@@ -60,6 +60,7 @@ export const useFetchPosts = ({
 
         setPostsCount(count);
       } catch (error) {
+        console.log("Error when fetching posts:", error);
         setPosts((prevState) => ({
           ...prevState,
           initialLoading: false,

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -162,7 +162,6 @@ const renderContactFormSection = (
   section: ContactFormSection,
   sectionIndex: number,
   isDraftMode: boolean,
-  initialData: QueryResponseInitial<PageBuilder>,
 ) => {
   return isDraftMode ? <div></div> : <ContactForm data={section} />;
 };
@@ -237,7 +236,6 @@ const SectionRenderer = ({
         section as ContactFormSection,
         sectionIndex,
         isDraftMode,
-        initialData,
       );
     default:
       return null;

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -1,35 +1,36 @@
 import { QueryResponseInitial } from "@sanity/react-loader";
 import React from "react";
+
 import Article from "src/components/sections/article/Article";
-import Callout from "src/components/sections/callout/Callout";
 import ArticlePreview from "src/components/sections/article/ArticlePreview";
+import Callout from "src/components/sections/callout/Callout";
+import CalloutPreview from "src/components/sections/callout/CalloutPreview";
+import CallToAction from "src/components/sections/callToAction/CallToAction";
+import CallToActionPreview from "src/components/sections/callToAction/CallToActionPreview";
+import ContactForm from "src/components/sections/contactForm/ContactForm";
+import Grid from "src/components/sections/grid/Grid";
+import GridPreview from "src/components/sections/grid/GridPreview";
 import { Hero } from "src/components/sections/hero/Hero";
 import HeroPreview from "src/components/sections/hero/HeroPreview";
+import ImageSectionComponent from "src/components/sections/imageSection/ImageSectionComponent";
+import ImageSectionComponentPreview from "src/components/sections/imageSection/ImageSectionComponentPreview";
 import { LogoSalad } from "src/components/sections/logoSalad/LogoSalad";
 import LogoSaladPreview from "src/components/sections/logoSalad/LogoSaladPreview";
+import { Testimonials } from "src/components/sections/testimonials/Testimonials";
+import TestimonialsPreview from "src/components/sections/testimonials/TestimonialsPreview";
 import {
   ArticleSection,
   CallToActionSection,
   CalloutSection,
+  ContactFormSection,
+  GridSection,
   HeroSection,
+  ImageSection,
   LogoSaladSection,
   PageBuilder,
-  TestimonialsSection,
   Section,
-  ImageSection,
-  GridSection,
-  ContactFormSection,
+  TestimonialsSection,
 } from "studio/lib/interfaces/pages";
-import CalloutPreview from "src/components/sections/callout/CalloutPreview";
-import CallToAction from "src/components/sections/callToAction/CallToAction";
-import CallToActionPreview from "src/components/sections/callToAction/CallToActionPreview";
-import { Testimonials } from "src/components/sections/testimonials/Testimonials";
-import TestimonialsPreview from "src/components/sections/testimonials/TestimonialsPreview";
-import ImageSectionComponent from "src/components/sections/imageSection/ImageSectionComponent";
-import Grid from "src/components/sections/grid/Grid";
-import ImageSectionComponentPreview from "src/components/sections/imageSection/ImageSectionComponentPreview";
-import GridPreview from "src/components/sections/grid/GridPreview";
-import ContactForm from "src/components/sections/contactForm/ContactForm";
 
 interface SectionRendererProps {
   section: Section;

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,14 +1,15 @@
-import { Metadata } from "next";
 import { toPlainText } from "@portabletext/toolkit";
-import { urlFor } from "studio/lib/image";
-import { COMPANY_INFO_QUERY } from "studio/lib/queries/companyDetails";
-import { loadQuery } from "studio/lib/store";
+import { Metadata } from "next";
+
 import { PortableTextBlock } from "src/components/richText/RichText";
-import { DEFAULT_SEO_QUERY } from "../../studio/lib/queries/seo";
-import { DefaultSeo } from "../../studio/lib/interfaces/defaultSeo";
-import { BrandAssets } from "../../studio/lib/interfaces/brandAssets";
-import { BRAND_ASSETS_QUERY } from "../../studio/lib/queries/brandAssets";
-import { CompanyInfo } from "../../studio/lib/interfaces/companyDetails";
+import { urlFor } from "studio/lib/image";
+import { BrandAssets } from "studio/lib/interfaces/brandAssets";
+import { CompanyInfo } from "studio/lib/interfaces/companyDetails";
+import { DefaultSeo } from "studio/lib/interfaces/defaultSeo";
+import { BRAND_ASSETS_QUERY } from "studio/lib/queries/brandAssets";
+import { COMPANY_INFO_QUERY } from "studio/lib/queries/companyDetails";
+import { DEFAULT_SEO_QUERY } from "studio/lib/queries/seo";
+import { loadQuery } from "studio/lib/store";
 
 type SeoData = {
   title: string;

--- a/studio/components/AnchorSelect.tsx
+++ b/studio/components/AnchorSelect.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from "react";
+import { Button, Select, Stack } from "@sanity/ui";
+import React, { useEffect, useState } from "react";
 import { PatchEvent, set, unset, useFormValue } from "sanity";
-import { Select, Button, Stack } from "@sanity/ui";
+
 import { fetchWithToken } from "studio/lib/fetchWithToken";
 
 interface AnchorSelectProps {

--- a/studio/components/AnchorSelect.tsx
+++ b/studio/components/AnchorSelect.tsx
@@ -53,7 +53,7 @@ const AnchorSelect = ({ value, onChange, path }: AnchorSelectProps) => {
       });
 
       const formattedResponseToListItems = response.sections.map(
-        (section: AnchorItem, index: number) => {
+        (section: AnchorItem) => {
           const title = section.basicTitle || fromCamelCase(section._type);
           return {
             basicTitle: title,

--- a/studio/components/CategorySelect.tsx
+++ b/studio/components/CategorySelect.tsx
@@ -1,5 +1,5 @@
 import { Select } from "@sanity/ui";
-import React, { useEffect, useState } from "react";
+import React, { forwardRef, useEffect, useState } from "react";
 import { PatchEvent, StringInputProps, set, useClient } from "sanity";
 
 import { fetchWithToken } from "studio/lib/fetchWithToken";
@@ -9,49 +9,48 @@ interface Category {
   name: string;
 }
 
-interface CategorySelectorProps extends StringInputProps {}
+type CategorySelectorProps = StringInputProps;
 
-const CategorySelector = React.forwardRef<
-  HTMLSelectElement,
-  CategorySelectorProps
->((props, ref) => {
-  const { value, onChange } = props;
-  const client = useClient();
-  const [categories, setCategories] = useState<Category[]>([]);
+const CategorySelector = forwardRef<HTMLSelectElement, CategorySelectorProps>(
+  (props, ref) => {
+    const { value, onChange } = props;
+    const client = useClient();
+    const [categories, setCategories] = useState<Category[]>([]);
 
-  useEffect(() => {
-    async function fetchCategories() {
-      const result = await fetchWithToken<Category[]>(
-        `*[_type == "blog"][0].categories`,
-      );
+    useEffect(() => {
+      async function fetchCategories() {
+        const result = await fetchWithToken<Category[]>(
+          `*[_type == "blog"][0].categories`,
+        );
 
-      setCategories(result || []);
-    }
-    fetchCategories();
-  }, [client]);
+        setCategories(result || []);
+      }
+      fetchCategories();
+    }, [client]);
 
-  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    onChange(PatchEvent.from(set(event.target.value)));
-  };
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+      onChange(PatchEvent.from(set(event.target.value)));
+    };
 
-  return (
-    <Select
-      ref={ref}
-      value={value || ""}
-      onChange={handleChange}
-      placeholder="Select a category"
-    >
-      <option value="" disabled>
-        Select a category
-      </option>
-      {categories.map((category) => (
-        <option key={category.name} value={category.name}>
-          {category.name}
+    return (
+      <Select
+        ref={ref}
+        value={value || ""}
+        onChange={handleChange}
+        placeholder="Select a category"
+      >
+        <option value="" disabled>
+          Select a category
         </option>
-      ))}
-    </Select>
-  );
-});
+        {categories.map((category) => (
+          <option key={category.name} value={category.name}>
+            {category.name}
+          </option>
+        ))}
+      </Select>
+    );
+  },
+);
 
 CategorySelector.displayName = "CategorySelector";
 

--- a/studio/components/CategorySelect.tsx
+++ b/studio/components/CategorySelect.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
 import { Select } from "@sanity/ui";
-import { useClient, set, StringInputProps, PatchEvent } from "sanity";
+import React, { useEffect, useState } from "react";
+import { PatchEvent, StringInputProps, set, useClient } from "sanity";
+
 import { fetchWithToken } from "studio/lib/fetchWithToken";
 
 interface Category {

--- a/studio/components/ClearLinkFieldsButton.tsx
+++ b/studio/components/ClearLinkFieldsButton.tsx
@@ -1,7 +1,8 @@
-import { useFormValue } from "sanity";
 import { Button } from "@sanity/ui";
-import { client } from "../lib/client";
-import { linkID } from "../schemas/objects/link";
+import { useFormValue } from "sanity";
+
+import { client } from "studio/lib/client";
+import { linkID } from "studio/schemas/objects/link";
 
 interface ClearLinkFieldsButtonProps {
   path: Array<string | { _key: string }>;

--- a/studio/components/CustomCallToActions.tsx
+++ b/studio/components/CustomCallToActions.tsx
@@ -1,3 +1,4 @@
+import { Card, Text } from "@sanity/ui";
 import React, { useEffect, useState } from "react";
 import {
   ArrayOfObjectsInput,
@@ -6,7 +7,7 @@ import {
   LoadingBlock,
   useFormValue,
 } from "sanity";
-import { Text, Card } from "@sanity/ui";
+
 import { fetchWithToken } from "studio/lib/fetchWithToken";
 import { LANDING_QUERY } from "studio/lib/queries/navigation";
 
@@ -17,7 +18,7 @@ type CustomCallToActionsProps = ArrayOfObjectsInputProps<
 
 const CustomCallToActions: React.FC<CustomCallToActionsProps> = (props) => {
   const [isLandingPage, setIsLandingPage] = useState(false);
-  const [landingPageId, setLandingPageId] = useState<String | null>(null);
+  const [landingPageId, setLandingPageId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/studio/components/LinkTypeSelector.tsx
+++ b/studio/components/LinkTypeSelector.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { Box, Card, Flex, Grid, Text } from "@sanity/ui";
+import React from "react";
 import { PatchEvent, set } from "sanity";
 
 interface LinkTypeSelectorProps {

--- a/studio/components/NewTabSelector.tsx
+++ b/studio/components/NewTabSelector.tsx
@@ -1,5 +1,5 @@
+import { Box, Card, Flex, Grid, Stack, Text } from "@sanity/ui";
 import React from "react";
-import { Box, Card, Flex, Grid, Text, Stack } from "@sanity/ui";
 import { PatchEvent, set } from "sanity";
 
 interface NewTabSelectorProps {

--- a/studio/components/SoMeInputs.tsx
+++ b/studio/components/SoMeInputs.tsx
@@ -1,6 +1,6 @@
+import { Box, Label, Select, Stack, TextInput } from "@sanity/ui";
 import React from "react";
 import { ObjectInputProps, set } from "sanity";
-import { Box, TextInput, Select, Stack, Label } from "@sanity/ui";
 
 export const SoMePlatforms: { [key: string]: string } = {
   facebook: "Facebook",

--- a/studio/components/salariesInput/SalariesInput.tsx
+++ b/studio/components/salariesInput/SalariesInput.tsx
@@ -1,15 +1,16 @@
-import { set, StringInputProps } from "sanity";
 import { Inline, Stack, Text, useToast } from "@sanity/ui";
+import { useState } from "react";
+import { StringInputProps, set } from "sanity";
+
+import SalariesFileUpload from "./components/SalariesFileUpload";
+import { SalariesParseErrorsToastDescription } from "./components/SalariesParseErrorsToastDescription";
+import SalariesTableEditor from "./components/SalariesTableEditor";
 import {
   Salaries,
+  SalariesParseError,
   salariesAsStoredString,
   salariesFromStoredString,
-  SalariesParseError,
 } from "./utils/parseSalaries";
-import { SalariesParseErrorsToastDescription } from "./components/SalariesParseErrorsToastDescription";
-import SalariesFileUpload from "./components/SalariesFileUpload";
-import SalariesTableEditor from "./components/SalariesTableEditor";
-import { useState } from "react";
 
 export const SalariesInput = (props: StringInputProps) => {
   const toast = useToast();

--- a/studio/components/salariesInput/components/SalariesFileUpload.tsx
+++ b/studio/components/salariesInput/components/SalariesFileUpload.tsx
@@ -1,13 +1,14 @@
-import styles from "../salariesInput.module.css";
-import { Box, Inline, Text } from "@sanity/ui";
 import { UploadIcon } from "@sanity/icons";
+import { Box, Inline, Text } from "@sanity/ui";
+import { ChangeEvent, MouseEvent, useState } from "react";
+
+import styles from "studio/components/salariesInput/salariesInput.module.css";
 import {
   Salaries,
-  salariesFromCsvString,
   SalariesParseError,
   SalariesParseErrorType,
-} from "../utils/parseSalaries";
-import { ChangeEvent, useState, MouseEvent } from "react";
+  salariesFromCsvString,
+} from "studio/components/salariesInput/utils/parseSalaries";
 
 const UPLOAD_CSV_INPUT_ID = "upload-csv-input";
 

--- a/studio/components/salariesInput/components/SalariesParseErrorsToastDescription.tsx
+++ b/studio/components/salariesInput/components/SalariesParseErrorsToastDescription.tsx
@@ -1,7 +1,7 @@
 import {
   SalariesParseError,
   SalariesParseErrorType,
-} from "../utils/parseSalaries";
+} from "studio/components/salariesInput/utils/parseSalaries";
 
 function descriptionOfSalariesParseError(error: SalariesParseError): string {
   switch (error.error) {

--- a/studio/components/salariesInput/components/SalariesTableEditor.tsx
+++ b/studio/components/salariesInput/components/SalariesTableEditor.tsx
@@ -24,7 +24,7 @@ const SalariesTableEditor = ({
       </div>
       {Object.entries(salaries)
         .toSorted(([a], [b]) => Number(b) - Number(a))
-        .map(([year, salary], index) => (
+        .map(([year, salary]) => (
           <>
             <div key={year} className={styles.tableCell}>
               <label htmlFor={`salary-number-input-${year}`}>

--- a/studio/components/salariesInput/components/SalariesTableEditor.tsx
+++ b/studio/components/salariesInput/components/SalariesTableEditor.tsx
@@ -1,7 +1,9 @@
-import styles from "../salariesInput.module.css";
-import SalaryNumberInput from "./SalaryNumberInput";
 import { Grid } from "@sanity/ui";
-import { Salaries } from "../utils/parseSalaries";
+
+import styles from "studio/components/salariesInput/salariesInput.module.css";
+import { Salaries } from "studio/components/salariesInput/utils/parseSalaries";
+
+import SalaryNumberInput from "./SalaryNumberInput";
 
 interface SalariesTableEditorProps {
   salaries: Salaries;

--- a/studio/components/salariesInput/components/SalaryNumberInput.tsx
+++ b/studio/components/salariesInput/components/SalaryNumberInput.tsx
@@ -1,5 +1,6 @@
-import { HTMLProps, useState, ChangeEvent, useEffect } from "react";
-import { VALID_SALARY_REGEX } from "../utils/parseSalaries";
+import { ChangeEvent, HTMLProps, useEffect, useState } from "react";
+
+import { VALID_SALARY_REGEX } from "studio/components/salariesInput/utils/parseSalaries";
 
 type SalaryNumberInputProps = Omit<
   HTMLProps<HTMLInputElement>,

--- a/studio/components/salariesInput/utils/parseSalaries.tsx
+++ b/studio/components/salariesInput/utils/parseSalaries.tsx
@@ -1,4 +1,4 @@
-import { Result, ResultError, ResultOk } from "../../../utils/result";
+import { Result, ResultError, ResultOk } from "studio/utils/result";
 
 export interface Salaries {
   [year: string]: number;

--- a/studio/components/slug/PrefixedSlugInput.tsx
+++ b/studio/components/slug/PrefixedSlugInput.tsx
@@ -1,6 +1,7 @@
-import { SlugInputProps } from "sanity";
-import styles from "./prefixedSlugInput.module.css";
 import { useTheme } from "@sanity/ui";
+import { SlugInputProps } from "sanity";
+
+import styles from "./prefixedSlugInput.module.css";
 
 type PrefixedSlugInputProps = SlugInputProps & {
   prefix: string;

--- a/studio/components/slug/ReferenceSlugInput.tsx
+++ b/studio/components/slug/ReferenceSlugInput.tsx
@@ -1,8 +1,8 @@
 // components/ReferenceSlugInput.tsx
 
-import React, { useEffect, useState } from "react";
-import { useClient, PatchEvent, set, unset } from "sanity";
 import { TextInput } from "@sanity/ui";
+import React, { useEffect, useState } from "react";
+import { PatchEvent, set, unset, useClient } from "sanity";
 
 interface ReferenceSlugInputProps {
   value?: string;

--- a/studio/components/slug/ReferenceSlugInput.tsx
+++ b/studio/components/slug/ReferenceSlugInput.tsx
@@ -29,8 +29,7 @@ interface ReferenceSlugInputProps {
 }
 
 const ReferenceSlugInput: React.FC<ReferenceSlugInputProps> = (props) => {
-  const { value, readOnly, schemaType, onChange, elementProps, document } =
-    props;
+  const { value, readOnly, onChange, elementProps, document } = props;
   const [slug, setSlug] = useState<string | null>(value || null);
   const client = useClient();
 

--- a/studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount.tsx
+++ b/studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Box, Stack, Text } from "@sanity/ui";
 import { StringInputProps } from "sanity";
+
 import styles from "./stringInputWithCharacterCount.module.css";
 
 type StringInputWithCharacterCountProps = StringInputProps & {

--- a/studio/components/studioIcon/StudioIcon.tsx
+++ b/studio/components/studioIcon/StudioIcon.tsx
@@ -1,5 +1,6 @@
-import styles from "./studioIcon.module.css";
 import Image from "next/image";
+
+import styles from "./studioIcon.module.css";
 
 const StudioIcon = ({ variant }: { variant: "studio" | "shared" }) => {
   return (

--- a/studio/lib/client.ts
+++ b/studio/lib/client.ts
@@ -1,7 +1,8 @@
 // Sanity Client Configuration
 
 import { createClient } from "next-sanity";
-import { apiVersion, dataset, projectId, useCdn } from "../env";
+
+import { apiVersion, dataset, projectId, useCdn } from "studio/env";
 
 export const client = createClient({
   apiVersion,

--- a/studio/lib/image.ts
+++ b/studio/lib/image.ts
@@ -1,6 +1,7 @@
 import imageUrlBuilder from "@sanity/image-url";
-import { client } from "./client";
 import { SanityImageSource } from "@sanity/image-url/lib/types/types";
+
+import { client } from "./client";
 
 const builder = imageUrlBuilder(client);
 

--- a/studio/lib/interfaces/compensations.ts
+++ b/studio/lib/interfaces/compensations.ts
@@ -1,4 +1,5 @@
 import { PortableTextBlock } from "src/components/richText/RichText";
+
 import { Reference, Slug } from "./global";
 
 export interface Benefit {

--- a/studio/lib/interfaces/languages.ts
+++ b/studio/lib/interfaces/languages.ts
@@ -1,3 +1,3 @@
-interface DefaultLanguageObject {
+export interface DefaultLanguageObject {
   defaultLanguage: string;
 }

--- a/studio/lib/interfaces/legalDocuments.ts
+++ b/studio/lib/interfaces/legalDocuments.ts
@@ -1,4 +1,5 @@
 import { PortableTextBlock } from "src/components/richText/RichText";
+
 import { Slug } from "./global";
 
 export interface LegalDocument {

--- a/studio/lib/interfaces/media.ts
+++ b/studio/lib/interfaces/media.ts
@@ -1,4 +1,5 @@
 import { SanityImageSource } from "@sanity/image-url/lib/types/types";
+
 import { ImageAlignment } from "studio/schemas/fields/media";
 
 interface IHotspot {

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -1,7 +1,8 @@
 import { PortableTextBlock } from "src/components/richText/RichText";
+
+import { Slug } from "./global";
 import { IImage, ImageExtendedProps } from "./media";
 import { ILink } from "./navigation";
-import { Slug } from "./global";
 
 export type ThemeType = "primary" | "secondary";
 

--- a/studio/lib/loaders/AutomaticVisualEditing.tsx
+++ b/studio/lib/loaders/AutomaticVisualEditing.tsx
@@ -5,7 +5,8 @@
 import { useLiveMode } from "@sanity/react-loader";
 import { VisualEditing } from "next-sanity";
 import { useEffect } from "react";
-import { client } from "../client";
+
+import { client } from "studio/lib/client";
 
 // Always enable stega in Live Mode
 const stegaClient = client.withConfig({ stega: true });

--- a/studio/lib/queries/brandAssets.ts
+++ b/studio/lib/queries/brandAssets.ts
@@ -1,5 +1,6 @@
 import { groq } from "next-sanity";
-import { brandAssetsID } from "../../schemas/documents/brandAssets";
+
+import { brandAssetsID } from "studio/schemas/documents/brandAssets";
 
 export const BRAND_ASSETS_QUERY = groq`
   *[_type == "${brandAssetsID}" && _id == "${brandAssetsID}"][0]

--- a/studio/lib/queries/companyDetails.ts
+++ b/studio/lib/queries/companyDetails.ts
@@ -1,5 +1,6 @@
 import { groq } from "next-sanity";
-import { companyInfoID } from "../../schemas/documents/companyInfo";
+
+import { companyInfoID } from "studio/schemas/documents/companyInfo";
 
 export const COMPANY_INFO_QUERY = groq`*[_type == "${companyInfoID}"][0]`;
 

--- a/studio/lib/queries/languages.ts
+++ b/studio/lib/queries/languages.ts
@@ -1,5 +1,6 @@
 import { groq } from "next-sanity";
-import { supportedLanguagesID } from "../../schemas/documents/supportedLanguages";
+
+import { supportedLanguagesID } from "studio/schemas/documents/supportedLanguages";
 
 export const DEFAULT_LANGUAGE_QUERY = groq`*[_type == "${supportedLanguagesID}" && _id == "${supportedLanguagesID}"][0] {
     "defaultLanguage": languages[isDefault == true][0].language

--- a/studio/lib/token.ts
+++ b/studio/lib/token.ts
@@ -1,5 +1,6 @@
 // Server-Only Token Management
 
+// eslint-disable-next-line import/no-unresolved
 import "server-only";
 import { experimental_taintUniqueValue } from "react";
 

--- a/studio/schema.ts
+++ b/studio/schema.ts
@@ -1,23 +1,24 @@
 import { type SchemaTypeDefinition } from "sanity";
+
 import pageBuilder from "./schemas/builders/pageBuilder";
-import navigationManager from "./schemas/documents/navigationManager";
-import { link } from "./schemas/objects/link";
-import { socialMedia } from "./schemas/objects/socialMedia";
-import { footerSection } from "./schemas/objects/footerSection";
-import socialMediaLinks from "./schemas/documents/socialMediaProfiles";
-import callToActionField from "./schemas/fields/callToActionFields";
-import companyInfo from "./schemas/documents/companyInfo";
+import defaultSeo from "./schemas/documents/admin/defaultSeo";
 import blog from "./schemas/documents/blog";
-import posts from "./schemas/documents/post";
-import categories from "./schemas/fields/categories";
-import legalDocument from "./schemas/documents/legalDocuments";
+import brandAssets from "./schemas/documents/brandAssets";
+import companyInfo from "./schemas/documents/companyInfo";
 import companyLocation from "./schemas/documents/companyLocation";
 import compensations from "./schemas/documents/compensations";
+import legalDocument from "./schemas/documents/legalDocuments";
+import navigationManager from "./schemas/documents/navigationManager";
+import posts from "./schemas/documents/post";
 import redirect from "./schemas/documents/redirect";
-import benefitsByLocation from "./schemas/objects/compensations/benefitsByLocation";
+import socialMediaLinks from "./schemas/documents/socialMediaProfiles";
 import supportedLanguages from "./schemas/documents/supportedLanguages";
-import defaultSeo from "./schemas/documents/admin/defaultSeo";
-import brandAssets from "./schemas/documents/brandAssets";
+import callToActionField from "./schemas/fields/callToActionFields";
+import categories from "./schemas/fields/categories";
+import benefitsByLocation from "./schemas/objects/compensations/benefitsByLocation";
+import { footerSection } from "./schemas/objects/footerSection";
+import { link } from "./schemas/objects/link";
+import { socialMedia } from "./schemas/objects/socialMedia";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [

--- a/studio/schemas/builders/pageBuilder.ts
+++ b/studio/schemas/builders/pageBuilder.ts
@@ -1,17 +1,17 @@
 import { defineField, defineType } from "sanity";
 
-import seo from "../objects/seo";
-import { pageSlug } from "../schemaTypes/slug";
-import hero from "../objects/sections/hero";
-import article from "../objects/sections/article";
-import logoSalad from "../objects/sections/logoSalad";
-import callout from "../objects/sections/callout";
-import callToAction from "../objects/sections/callToAction";
-import testimonals from "../objects/sections/testimonials";
-import imageSection from "../objects/sections/image";
-import grid from "../objects/sections/grid";
-import contactForm from "../objects/sections/form";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import article from "studio/schemas/objects/sections/article";
+import callout from "studio/schemas/objects/sections/callout";
+import callToAction from "studio/schemas/objects/sections/callToAction";
+import contactForm from "studio/schemas/objects/sections/form";
+import grid from "studio/schemas/objects/sections/grid";
+import hero from "studio/schemas/objects/sections/hero";
+import imageSection from "studio/schemas/objects/sections/image";
+import logoSalad from "studio/schemas/objects/sections/logoSalad";
+import testimonals from "studio/schemas/objects/sections/testimonials";
+import seo from "studio/schemas/objects/seo";
+import { pageSlug } from "studio/schemas/schemaTypes/slug";
 
 export const pageBuilderID = "pageBuilder";
 

--- a/studio/schemas/deskStructure.ts
+++ b/studio/schemas/deskStructure.ts
@@ -1,30 +1,31 @@
+import {
+  CaseIcon,
+  CogIcon,
+  DoubleChevronRightIcon,
+  HeartIcon,
+  ImagesIcon,
+  InfoOutlineIcon,
+  PinIcon,
+  ProjectsIcon,
+  SearchIcon,
+  SparkleIcon,
+  TransferIcon,
+  TranslateIcon,
+  UsersIcon,
+} from "@sanity/icons";
 import { StructureBuilder } from "sanity/structure";
+
 import { pageBuilderID } from "./builders/pageBuilder";
 //import { blogId } from "./documents/blog";
-import {
-  TransferIcon,
-  UsersIcon,
-  CogIcon,
-  ProjectsIcon,
-  InfoOutlineIcon,
-  HeartIcon,
-  SparkleIcon,
-  CaseIcon,
-  TranslateIcon,
-  DoubleChevronRightIcon,
-  PinIcon,
-  SearchIcon,
-  ImagesIcon,
-} from "@sanity/icons";
-import { soMeLinksID } from "./documents/socialMediaProfiles";
-import { companyInfoID } from "./documents/companyInfo";
-import { legalDocumentID } from "./documents/legalDocuments";
-import { compensationsId } from "./documents/compensations";
-import { redirectId } from "./documents/redirect";
-import { companyLocationID } from "./documents/companyLocation";
-import { supportedLanguagesID } from "./documents/supportedLanguages";
 import { defaultSeoID } from "./documents/admin/defaultSeo";
 import { brandAssetsID } from "./documents/brandAssets";
+import { companyInfoID } from "./documents/companyInfo";
+import { companyLocationID } from "./documents/companyLocation";
+import { compensationsId } from "./documents/compensations";
+import { legalDocumentID } from "./documents/legalDocuments";
+import { redirectId } from "./documents/redirect";
+import { soMeLinksID } from "./documents/socialMediaProfiles";
+import { supportedLanguagesID } from "./documents/supportedLanguages";
 
 // Admin Section
 const adminSection = (S: StructureBuilder) =>

--- a/studio/schemas/documents/admin/defaultSeo.ts
+++ b/studio/schemas/documents/admin/defaultSeo.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from "sanity";
+
 import seo from "studio/schemas/objects/seo";
 
 export const defaultSeoID = "seoFallback";

--- a/studio/schemas/documents/blog.ts
+++ b/studio/schemas/documents/blog.ts
@@ -1,8 +1,9 @@
 import { defineField, defineType } from "sanity";
-import seo from "../objects/seo";
-import { pageSlug } from "../schemaTypes/slug";
-import { title } from "../fields/text";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { title } from "studio/schemas/fields/text";
+import seo from "studio/schemas/objects/seo";
+import { pageSlug } from "studio/schemas/schemaTypes/slug";
 
 export const blogId = "blog";
 

--- a/studio/schemas/documents/companyInfo.ts
+++ b/studio/schemas/documents/companyInfo.ts
@@ -1,5 +1,6 @@
-import { defineType, defineField } from "sanity";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { defineField, defineType } from "sanity";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 export const companyInfoID = "companyInfo";
 

--- a/studio/schemas/documents/companyLocation.ts
+++ b/studio/schemas/documents/companyLocation.ts
@@ -1,5 +1,6 @@
 import { defineField, defineType } from "sanity";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 export const companyLocationID = "companyLocation";
 export const companyLocationNameID = "companyLocationName";

--- a/studio/schemas/documents/compensations.ts
+++ b/studio/schemas/documents/compensations.ts
@@ -1,11 +1,12 @@
 import { defineField, defineType } from "sanity";
-import { titleSlug } from "../schemaTypes/slug";
-import seo from "../objects/seo";
-import { title } from "../fields/text";
-import { bonusesByLocation } from "../objects/compensations/bonusesByLocation";
-import { pensionPercent } from "../objects/compensations/pension";
-import { benefitsByLocation } from "../objects/compensations/benefitsByLocation";
-import { salariesByLocation } from "../objects/compensations/salariesByLocation";
+
+import { title } from "studio/schemas/fields/text";
+import { benefitsByLocation } from "studio/schemas/objects/compensations/benefitsByLocation";
+import { bonusesByLocation } from "studio/schemas/objects/compensations/bonusesByLocation";
+import { pensionPercent } from "studio/schemas/objects/compensations/pension";
+import { salariesByLocation } from "studio/schemas/objects/compensations/salariesByLocation";
+import seo from "studio/schemas/objects/seo";
+import { titleSlug } from "studio/schemas/schemaTypes/slug";
 
 export const compensationsId = "compensations";
 

--- a/studio/schemas/documents/legalDocuments.ts
+++ b/studio/schemas/documents/legalDocuments.ts
@@ -1,6 +1,7 @@
 import { defineField } from "sanity";
-import { richText, title } from "../fields/text";
-import { titleSlug } from "../schemaTypes/slug";
+
+import { richText, title } from "studio/schemas/fields/text";
+import { titleSlug } from "studio/schemas/schemaTypes/slug";
 
 export const legalDocumentID = "legalDocuments";
 

--- a/studio/schemas/documents/navigationManager.ts
+++ b/studio/schemas/documents/navigationManager.ts
@@ -1,8 +1,9 @@
 import { defineType } from "sanity";
-import { linkID } from "../objects/link";
-import { footerSectionID } from "../objects/footerSection";
-import { pageBuilderID } from "../builders/pageBuilder";
-import { callToActionFieldID } from "../fields/callToActionFields";
+
+import { pageBuilderID } from "studio/schemas/builders/pageBuilder";
+import { callToActionFieldID } from "studio/schemas/fields/callToActionFields";
+import { footerSectionID } from "studio/schemas/objects/footerSection";
+import { linkID } from "studio/schemas/objects/link";
 
 export const navManagerID = {
   navigationManager: "navigationManager",

--- a/studio/schemas/documents/post.ts
+++ b/studio/schemas/documents/post.ts
@@ -1,9 +1,10 @@
-import { defineField, defineType } from "sanity";
 import { format, parseISO } from "date-fns";
-import { titleSlug } from "../schemaTypes/slug";
-import { richText, title } from "../fields/text";
+import { defineField, defineType } from "sanity";
+
 import CategorySelector from "studio/components/CategorySelect";
-import image from "../fields/media";
+import image from "studio/schemas/fields/media";
+import { richText, title } from "studio/schemas/fields/text";
+import { titleSlug } from "studio/schemas/schemaTypes/slug";
 
 export const postId = "blogPosts";
 

--- a/studio/schemas/documents/redirect.ts
+++ b/studio/schemas/documents/redirect.ts
@@ -1,9 +1,11 @@
-import { defineField, defineType, type Slug } from "sanity";
 import { SanityDocument, SlugRule } from "@sanity/types";
-import { pageBuilderID } from "../builders/pageBuilder";
+import { type Slug, defineField, defineType } from "sanity";
+
+import PrefixedSlugInput from "studio/components/slug/PrefixedSlugInput";
+import { pageBuilderID } from "studio/schemas/builders/pageBuilder";
+
 import { blogId } from "./blog";
 import { compensationsId } from "./compensations";
-import PrefixedSlugInput from "../../components/slug/PrefixedSlugInput";
 
 const slugRequired = (rule: SlugRule) =>
   rule.required().custom((value: Slug | undefined) => {

--- a/studio/schemas/documents/socialMediaProfiles.ts
+++ b/studio/schemas/documents/socialMediaProfiles.ts
@@ -1,5 +1,6 @@
 import { defineType } from "sanity";
-import { SocialMediaID } from "../objects/socialMedia";
+
+import { SocialMediaID } from "studio/schemas/objects/socialMedia";
 
 export const soMeLinksID = "soMeLinksID";
 

--- a/studio/schemas/documents/supportedLanguages.ts
+++ b/studio/schemas/documents/supportedLanguages.ts
@@ -1,4 +1,5 @@
 import { defineType } from "sanity";
+
 import { languages } from "languages";
 
 const languageOptions = languages.map((language) => {

--- a/studio/schemas/fields/callToActionFields.ts
+++ b/studio/schemas/fields/callToActionFields.ts
@@ -1,5 +1,7 @@
 import { defineField } from "sanity";
-import { link } from "../objects/link";
+
+import { link } from "studio/schemas/objects/link";
+
 import { clearLinkFields } from "./clearLinkFields";
 
 export const callToActionFieldID = "callToActionField";

--- a/studio/schemas/fields/categories.ts
+++ b/studio/schemas/fields/categories.ts
@@ -1,5 +1,6 @@
-import { defineField, StringInputProps } from "sanity";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { StringInputProps, defineField } from "sanity";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 export const categoriesId = "categories";
 

--- a/studio/schemas/fields/clearLinkFields.ts
+++ b/studio/schemas/fields/clearLinkFields.ts
@@ -1,4 +1,4 @@
-import ClearLinkFieldsButton from "../../components/ClearLinkFieldsButton";
+import ClearLinkFieldsButton from "studio/components/ClearLinkFieldsButton";
 
 export const clearLinkFields = {
   name: "clearFields",

--- a/studio/schemas/fields/media.ts
+++ b/studio/schemas/fields/media.ts
@@ -1,5 +1,6 @@
-import { defineField, StringInputProps } from "sanity";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { StringInputProps, defineField } from "sanity";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 export enum ImageAlignment {
   Left = "left",

--- a/studio/schemas/fields/text.ts
+++ b/studio/schemas/fields/text.ts
@@ -1,5 +1,6 @@
 import { StringRule, defineField } from "sanity";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 enum titleID {
   basic = "basicTitle",

--- a/studio/schemas/objects/compensations/benefitsByLocation.ts
+++ b/studio/schemas/objects/compensations/benefitsByLocation.ts
@@ -1,10 +1,12 @@
 import { defineField } from "sanity";
-import { location, locationID } from "../locations";
+
 import { companyLocationNameID } from "studio/schemas/documents/companyLocation";
 import { richText, title } from "studio/schemas/fields/text";
+import { location, locationID } from "studio/schemas/objects/locations";
+
 import {
-  checkForDuplicateLocations,
   DocumentWithLocation,
+  checkForDuplicateLocations,
 } from "./utils/validation";
 
 const benefitTypeId = "benefitType";

--- a/studio/schemas/objects/compensations/bonusesByLocation.ts
+++ b/studio/schemas/objects/compensations/bonusesByLocation.ts
@@ -1,11 +1,13 @@
 import { defineField } from "sanity";
-import { location, locationID } from "../locations";
+
+import { BonusPage } from "studio/lib/interfaces/compensations";
 import { companyLocationNameID } from "studio/schemas/documents/companyLocation";
+import { location, locationID } from "studio/schemas/objects/locations";
+
 import {
   DocumentWithLocation,
   checkForDuplicateLocations,
 } from "./utils/validation";
-import { BonusPage } from "../../../lib/interfaces/compensations";
 
 export const bonusesByLocation = defineField({
   name: "bonusesByLocation",

--- a/studio/schemas/objects/compensations/salariesByLocation.ts
+++ b/studio/schemas/objects/compensations/salariesByLocation.ts
@@ -1,12 +1,14 @@
 import { defineField } from "sanity";
-import { location, locationID } from "../locations";
+
+import { SalariesInput } from "studio/components/salariesInput/SalariesInput";
+import { SalariesPage } from "studio/lib/interfaces/compensations";
+import { companyLocationNameID } from "studio/schemas/documents/companyLocation";
+import { location, locationID } from "studio/schemas/objects/locations";
+
 import {
   DocumentWithLocation,
   checkForDuplicateLocations,
 } from "./utils/validation";
-import { companyLocationNameID } from "../../documents/companyLocation";
-import { SalariesInput } from "../../../components/salariesInput/SalariesInput";
-import { SalariesPage } from "../../../lib/interfaces/compensations";
 
 export const salariesByLocation = defineField({
   name: "salariesByLocation",

--- a/studio/schemas/objects/footerSection.ts
+++ b/studio/schemas/objects/footerSection.ts
@@ -1,8 +1,10 @@
-import { defineType, StringInputProps } from "sanity";
+import { StringInputProps, defineType } from "sanity";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { soMeLinksID } from "studio/schemas/documents/socialMediaProfiles";
+import { richText } from "studio/schemas/fields/text";
+
 import { linkID } from "./link";
-import { soMeLinksID } from "../documents/socialMediaProfiles";
-import { richText, richTextID } from "../fields/text";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 export const footerSectionID = {
   main: "footerSection",

--- a/studio/schemas/objects/link.ts
+++ b/studio/schemas/objects/link.ts
@@ -1,8 +1,9 @@
-import { defineField, StringInputProps } from "sanity";
-import AnchorSelect from "../../components/AnchorSelect";
-import LinkTypeSelector from "../../components/LinkTypeSelector";
-import NewTabSelector from "../../components/NewTabSelector";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { StringInputProps, defineField } from "sanity";
+
+import AnchorSelect from "studio/components/AnchorSelect";
+import LinkTypeSelector from "studio/components/LinkTypeSelector";
+import NewTabSelector from "studio/components/NewTabSelector";
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 export const linkID = "link";
 

--- a/studio/schemas/objects/locations.ts
+++ b/studio/schemas/objects/locations.ts
@@ -1,5 +1,6 @@
 import { defineField } from "sanity";
-import { companyLocationID } from "../documents/companyLocation";
+
+import { companyLocationID } from "studio/schemas/documents/companyLocation";
 
 export const locationsID = "locations";
 export const locationID = "location";

--- a/studio/schemas/objects/sections/article.ts
+++ b/studio/schemas/objects/sections/article.ts
@@ -1,8 +1,9 @@
-import { defineField, StringInputProps } from "sanity";
-import { richText, title } from "../../../schemas/fields/text";
-import { imageExtended } from "../../../schemas/fields/media";
-import { link } from "../link";
-import { StringInputWithCharacterCount } from "../../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { StringInputProps, defineField } from "sanity";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { imageExtended } from "studio/schemas/fields/media";
+import { richText, title } from "studio/schemas/fields/text";
+import { link } from "studio/schemas/objects/link";
 
 export const articleID = "article";
 

--- a/studio/schemas/objects/sections/blogPosts.ts
+++ b/studio/schemas/objects/sections/blogPosts.ts
@@ -1,11 +1,8 @@
 import { defineArrayMember, defineField } from "sanity";
-import {
-  optionalSubtitle,
-  richText,
-  title,
-} from "../../../schemas/fields/text";
-import image from "../../../schemas/fields/media";
-import callToActionField from "../../../schemas/fields/callToActionFields";
+
+import callToActionField from "studio/schemas/fields/callToActionFields";
+import image from "studio/schemas/fields/media";
+import { optionalSubtitle, richText, title } from "studio/schemas/fields/text";
 
 export const articleID = "blogPostsID";
 

--- a/studio/schemas/objects/sections/callToAction.ts
+++ b/studio/schemas/objects/sections/callToAction.ts
@@ -1,6 +1,7 @@
 import { defineField } from "sanity";
-import { title } from "../../../schemas/fields/text";
+
 import callToActionField from "studio/schemas/fields/callToActionFields";
+import { title } from "studio/schemas/fields/text";
 import { theme } from "studio/schemas/fields/theme";
 
 export const callToActionSectionID = "ctaSection";

--- a/studio/schemas/objects/sections/callout.ts
+++ b/studio/schemas/objects/sections/callout.ts
@@ -1,7 +1,8 @@
 import { defineField } from "sanity";
-import { richText, richTextID } from "../../fields/text";
-import { link } from "../link";
+
+import { richText, richTextID } from "studio/schemas/fields/text";
 import { theme } from "studio/schemas/fields/theme";
+import { link } from "studio/schemas/objects/link";
 
 export const calloutID = "callout";
 

--- a/studio/schemas/objects/sections/form.ts
+++ b/studio/schemas/objects/sections/form.ts
@@ -1,5 +1,6 @@
 import { defineField } from "sanity";
-import { richText, title } from "../../../schemas/fields/text";
+
+import { title } from "studio/schemas/fields/text";
 
 export const contactFormID = "contactForm";
 

--- a/studio/schemas/objects/sections/grid.ts
+++ b/studio/schemas/objects/sections/grid.ts
@@ -1,7 +1,7 @@
 import { defineField } from "sanity";
-import { richText, title } from "../../../schemas/fields/text";
+
 import image from "studio/schemas/fields/media";
-import { theme } from "studio/schemas/fields/theme";
+import { richText, title } from "studio/schemas/fields/text";
 
 export const gridID = "grid";
 

--- a/studio/schemas/objects/sections/hero.ts
+++ b/studio/schemas/objects/sections/hero.ts
@@ -1,9 +1,10 @@
 // hero.ts
-import { defineField, StringInputProps } from "sanity";
-import callToActionField from "../../fields/callToActionFields";
-import CustomCallToActions from "../../../components/CustomCallToActions";
+import { StringInputProps, defineField } from "sanity";
+
+import CustomCallToActions from "studio/components/CustomCallToActions";
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import callToActionField from "studio/schemas/fields/callToActionFields";
 import { title } from "studio/schemas/fields/text";
-import { StringInputWithCharacterCount } from "../../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 export const heroID = "hero";
 

--- a/studio/schemas/objects/sections/image.ts
+++ b/studio/schemas/objects/sections/image.ts
@@ -1,6 +1,7 @@
 import { defineField } from "sanity";
-import { title } from "../../../schemas/fields/text";
+
 import image from "studio/schemas/fields/media";
+import { title } from "studio/schemas/fields/text";
 
 export const imageID = "imageSection";
 

--- a/studio/schemas/objects/sections/logoSalad.ts
+++ b/studio/schemas/objects/sections/logoSalad.ts
@@ -1,7 +1,8 @@
-import { defineField, StringInputProps } from "sanity";
+import { StringInputProps, defineField } from "sanity";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 import image from "studio/schemas/fields/media";
 import { richText } from "studio/schemas/fields/text";
-import { StringInputWithCharacterCount } from "../../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 export const logoSaladID = "logoSalad";
 

--- a/studio/schemas/objects/sections/testimonials.ts
+++ b/studio/schemas/objects/sections/testimonials.ts
@@ -1,6 +1,7 @@
 import { defineField } from "sanity";
-import { title } from "../../fields/text";
-import testimony from "../testimony";
+
+import { title } from "studio/schemas/fields/text";
+import testimony from "studio/schemas/objects/testimony";
 
 export const testimonialsID = "testimonials";
 

--- a/studio/schemas/objects/seo.ts
+++ b/studio/schemas/objects/seo.ts
@@ -1,4 +1,5 @@
 import { defineField } from "sanity";
+
 import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 
 const seoFieldID = {

--- a/studio/schemas/objects/socialMedia.ts
+++ b/studio/schemas/objects/socialMedia.ts
@@ -1,5 +1,6 @@
 import { defineType } from "sanity";
-import SoMeInputs, { SoMePlatforms } from "../../components/SoMeInputs";
+
+import SoMeInputs, { SoMePlatforms } from "studio/components/SoMeInputs";
 
 export const SocialMediaID = {
   link: "socialMediaLinkID",

--- a/studio/schemas/objects/testimony.ts
+++ b/studio/schemas/objects/testimony.ts
@@ -1,7 +1,8 @@
-import { richText, title } from "../fields/text";
-import image from "../fields/media";
-import { StringInputWithCharacterCount } from "../../components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 import { StringInputProps, StringRule } from "sanity";
+
+import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import image from "studio/schemas/fields/media";
+import { richText, title } from "studio/schemas/fields/text";
 
 export const testimony = {
   name: "testimony",

--- a/studio/schemas/schemaTypes/slug.ts
+++ b/studio/schemas/schemaTypes/slug.ts
@@ -1,5 +1,6 @@
-import { defineField, SlugValidationContext } from "sanity";
-import { isPublished } from "../../utils/documentUtils";
+import { SlugValidationContext, defineField } from "sanity";
+
+import { isPublished } from "studio/utils/documentUtils";
 
 async function isSlugUniqueAcrossAllDocuments(
   slug: string,

--- a/studio/studioConfig.tsx
+++ b/studio/studioConfig.tsx
@@ -1,13 +1,13 @@
 import { visionTool } from "@sanity/vision";
+import { WorkspaceOptions } from "sanity";
 import { presentationTool } from "sanity/presentation";
 import { structureTool } from "sanity/structure";
 
 // Go to https://www.sanity.io/docs/api-versioning to learn how API versioning works
+import StudioIcon from "./components/studioIcon/StudioIcon";
 import { apiVersion, dataset, projectId } from "./env";
 import { schema } from "./schema";
 import deskStructure from "./schemas/deskStructure";
-import { WorkspaceOptions } from "sanity";
-import StudioIcon from "./components/studioIcon/StudioIcon";
 
 const config: WorkspaceOptions = {
   name: "studio",

--- a/studioShared/deskStructure.ts
+++ b/studioShared/deskStructure.ts
@@ -1,5 +1,7 @@
-import { i18n } from "languages";
 import { StructureResolver } from "sanity/structure";
+
+import { i18n } from "languages";
+
 import { customerCaseID } from "./schemas/documents/customerCase";
 
 export const deskStructure: StructureResolver = (S) =>

--- a/studioShared/lib/client.ts
+++ b/studioShared/lib/client.ts
@@ -1,7 +1,8 @@
 // Sanity Client Configuration
 
 import { createClient } from "next-sanity";
-import { apiVersion, dataset, projectId, useCdn } from "../env";
+
+import { apiVersion, dataset, projectId, useCdn } from "studioShared/env";
 
 export const sharedClient = createClient({
   apiVersion,

--- a/studioShared/lib/image.ts
+++ b/studioShared/lib/image.ts
@@ -1,6 +1,7 @@
 import imageUrlBuilder from "@sanity/image-url";
-import { sharedClient } from "./client";
 import { SanityImageSource } from "@sanity/image-url/lib/types/types";
+
+import { sharedClient } from "./client";
 
 const builder = imageUrlBuilder(sharedClient);
 

--- a/studioShared/lib/token.ts
+++ b/studioShared/lib/token.ts
@@ -1,5 +1,6 @@
 // Server-Only Token Management
 
+// eslint-disable-next-line import/no-unresolved
 import "server-only";
 import { experimental_taintUniqueValue } from "react";
 

--- a/studioShared/schema.ts
+++ b/studioShared/schema.ts
@@ -1,4 +1,5 @@
 import { type SchemaTypeDefinition } from "sanity";
+
 import blogPosts from "./schemas/documents/blogPosts";
 import customerCases from "./schemas/documents/customerCase";
 

--- a/studioShared/schemas/documents/blogPosts.ts
+++ b/studioShared/schemas/documents/blogPosts.ts
@@ -1,5 +1,6 @@
-import { defineField, defineType } from "sanity";
 import { format, parseISO } from "date-fns";
+import { defineField, defineType } from "sanity";
+
 import { richText, title } from "studio/schemas/fields/text";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
 

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from "sanity";
+
 import { richText, title } from "studio/schemas/fields/text";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
 

--- a/studioShared/studioConfig.tsx
+++ b/studioShared/studioConfig.tsx
@@ -1,14 +1,15 @@
-import { WorkspaceOptions } from "sanity";
-import StudioIcon from "../studio/components/studioIcon/StudioIcon";
-import { defineField } from "sanity";
 import { documentInternationalization } from "@sanity/document-internationalization";
 import { visionTool } from "@sanity/vision";
+import { WorkspaceOptions } from "sanity";
 import { structureTool } from "sanity/structure";
+
+import { i18n } from "languages";
+import StudioIcon from "studio/components/studioIcon/StudioIcon";
+
+import { deskStructure } from "./deskStructure";
 import { apiVersion, dataset, projectId } from "./env";
 import { schema } from "./schema";
-import { i18n } from "languages";
 import { customerCaseID } from "./schemas/documents/customerCase";
-import { deskStructure } from "./deskStructure";
 
 const config: WorkspaceOptions = {
   name: "sharedStudio",


### PR DESCRIPTION
Updated eslint configuration with various tools for organizing imports. Also improved typescript checking.

Highlights of the import rules defined in `.eslintrc.cjs`:
- no relative imports (`no-relative-import-paths/no-relative-import-paths`)
  - expect for siblings, i.e. files within the same directory
- no unused imports (`unused-imports/no-unused-imports`)
- imports are ordered alphabetically (ascending) and grouped based on location type (`import/order`)
  - builtin
  - external
  - internal
  - sibling, parent
  - index
  - unknown
- members within an import are sorted based on type (`sort-imports`) 

Some rules have not been included yet, to reduce the scope of this PR. These have been mentioned in separate issues: #659 #660

Also added `npm run fix` to run linting (`npm run lint`) and formatting (`npm run format`) in one command.

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?