### PR TITLE
dependabot storybook group for v3 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     target-branch: "v3"
     schedule:
       interval: "daily"
+    groups:
+      storybook:
+        patterns:
+          - "@storybook/*"
+          - "storybook"


### PR DESCRIPTION
Only applies to v3 branch, but the dependabot config must be in default branch.