### PR TITLE
Temporarily replace Tjenesteområder with Sommerjobb in header

### DIFF
--- a/src/components/page-header/index.tsx
+++ b/src/components/page-header/index.tsx
@@ -108,7 +108,7 @@ export default function PageHeader({
               ref={navRef}
             >
               <li>
-                <Link href="/tjenesteomrader">Tjenester</Link>
+                <Link href="/sommerjobb">Sommerjobb</Link>
               </li>
               <li>
                 <a href="http://handbook.variant.no" rel="noopener">


### PR DESCRIPTION
## Short Description

We need an entry point for the summerjob splash. This is a suggestion to temporarily switch Tjenesteområder to Sommerjobb in the header menu. Will revert back to Tjenesteområder 04.10.24.

---

## Visual Overview (Image/Video)

If applicable, please include screenshots or a short video showcasing the changes you have made.

*Insert images or videos here.*

---

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [ ] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [ ] **Testing**: Have you tested your changes thoroughly?
  - Please list the types of tests you've run (unit, integration, manual, etc.):

---

## Additional Notes

Other comments relevant to this pull request.