### PR TITLE
v3 - footer section SoMe links initial value

### DIFF
--- a/studio/lib/queries/socialMediaProfiles.ts
+++ b/studio/lib/queries/socialMediaProfiles.ts
@@ -1,4 +1,5 @@
 import { groq } from "next-sanity";
 
 export const SOMEPROFILES_QUERY = groq`
-  *[_type == "soMeLinksID"][0]`;
+  *[_type == "soMeLinksID" && _id == "soMeLinksID"][0]
+`;

--- a/studio/schemas/objects/footerSection.ts
+++ b/studio/schemas/objects/footerSection.ts
@@ -1,6 +1,8 @@
 import { StringInputProps, defineType } from "sanity";
 
 import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { client } from "studio/lib/client";
+import { SOMEPROFILES_QUERY } from "studio/lib/queries/socialMediaProfiles";
 import { soMeLinksID } from "studio/schemas/documents/siteSettings/socialMediaProfiles";
 import { richText } from "studio/schemas/fields/text";
 
@@ -86,9 +88,14 @@ export const footerSection = defineType({
       description:
         "This section automatically uses your social media links. Any updates to your social media links will appear here.",
       hidden: ({ parent }) => parent?.sectionType !== SectionType.SocialMedia,
-      initialValue: {
-        _type: "reference",
-        _ref: soMeLinksID,
+      initialValue: async () => {
+        // use Social Media Profiles singleton document if it exists
+        return (await client.fetch(SOMEPROFILES_QUERY)) !== null
+          ? {
+              _type: "reference",
+              _ref: soMeLinksID,
+            }
+          : undefined;
       },
     },
   ],


### PR DESCRIPTION
Structure tool crashed if the SoMe links document was not available, since this is set as `initialValue` for `footerSectionID.soMeLinks`. This has now been fixed by checking if the document exists before using it as initial value.

<img width="941" alt="image" src="https://github.com/user-attachments/assets/544c1bf7-d620-4c09-acf9-82785f0dda63">

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?