### PR TITLE
v3 - custom ordered array input component

### DIFF
--- a/studio/components/ValueOrderedArrayOfObjectsInput.tsx
+++ b/studio/components/ValueOrderedArrayOfObjectsInput.tsx
@@ -1,13 +1,14 @@
 import { ArrayOfObjectsInputProps, ObjectItem } from "sanity";
 
-interface OrderedArrayOfObjectsInputProps extends ArrayOfObjectsInputProps {
+interface ValueOrderedArrayOfObjectsInputProps
+  extends ArrayOfObjectsInputProps {
   valueCompareFn: (a: ObjectItem, b: ObjectItem) => number;
 }
 
 export default function ValueOrderedArrayOfObjectsInput({
   valueCompareFn,
   ...defaultProps
-}: OrderedArrayOfObjectsInputProps) {
+}: ValueOrderedArrayOfObjectsInputProps) {
   const orderedMembers = defaultProps.members.toSorted((a, b) => {
     // place error items at the end
     if (a.kind === "error") {

--- a/studio/components/ValueOrderedArrayOfObjectsInput.tsx
+++ b/studio/components/ValueOrderedArrayOfObjectsInput.tsx
@@ -1,0 +1,28 @@
+import { ArrayOfObjectsInputProps, ObjectItem } from "sanity";
+
+interface OrderedArrayOfObjectsInputProps extends ArrayOfObjectsInputProps {
+  valueCompareFn: (a: ObjectItem, b: ObjectItem) => number;
+}
+
+export default function ValueOrderedArrayOfObjectsInput({
+  valueCompareFn,
+  ...defaultProps
+}: OrderedArrayOfObjectsInputProps) {
+  const orderedMembers = defaultProps.members.toSorted((a, b) => {
+    // place error items at the end
+    if (a.kind === "error") {
+      if (b.kind === "error") {
+        return 0;
+      } else {
+        return 1;
+      }
+    } else if (b.kind === "error") {
+      return -1;
+    }
+    return valueCompareFn(a.item.value, b.item.value);
+  });
+  return defaultProps.renderDefault({
+    ...defaultProps,
+    members: orderedMembers,
+  });
+}

--- a/studio/lib/interfaces/compensations.ts
+++ b/studio/lib/interfaces/compensations.ts
@@ -1,6 +1,6 @@
-import { PortableTextBlock } from "sanity";
+import { PortableTextBlock, Reference } from "sanity";
 
-import { Reference, Slug } from "./global";
+import { Slug } from "./global";
 
 export interface Benefit {
   _type: string;
@@ -16,11 +16,25 @@ export interface BenefitsByLocation {
 }
 
 export interface SalariesPage {
-  _type: string;
+  _type?: string;
   _key: string;
   year: number;
   salaries: string;
 }
+
+export const isSalariesPage = (value: unknown): value is SalariesPage => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (!("_type" in value) || typeof value._type === "string") &&
+    "_key" in value &&
+    typeof value._key === "string" &&
+    "year" in value &&
+    typeof value.year === "number" &&
+    "salaries" in value &&
+    typeof value.salaries === "string"
+  );
+};
 
 export interface BonusesByLocationPage {
   _type: string;
@@ -30,11 +44,25 @@ export interface BonusesByLocationPage {
 }
 
 export interface BonusPage {
-  _type: string;
+  _type?: string;
   _key: string;
   year: number;
   bonus: number;
 }
+
+export const isBonusPage = (value: unknown): value is BonusPage => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (!("_type" in value) || typeof value._type === "string") &&
+    "_key" in value &&
+    typeof value._key === "string" &&
+    "year" in value &&
+    typeof value.year === "number" &&
+    "bonus" in value &&
+    typeof value.bonus === "number"
+  );
+};
 
 export interface SalariesByLocation {
   _key: string;

--- a/studio/lib/interfaces/global.ts
+++ b/studio/lib/interfaces/global.ts
@@ -3,11 +3,6 @@ export interface Slug {
   current: string;
 }
 
-export interface Reference {
-  _type: "reference";
-  _ref: string;
-}
-
 export interface DocumentWithSlug {
   slug: Slug;
   _updatedAt: string;

--- a/studio/schemas/objects/compensations/bonusesByLocation.ts
+++ b/studio/schemas/objects/compensations/bonusesByLocation.ts
@@ -1,6 +1,7 @@
-import { defineField } from "sanity";
+import { ArrayOfObjectsInputProps, defineField } from "sanity";
 
-import { BonusPage } from "studio/lib/interfaces/compensations";
+import ValueOrderedArrayOfObjectsInput from "studio/components/ValueOrderedArrayOfObjectsInput";
+import { BonusPage, isBonusPage } from "studio/lib/interfaces/compensations";
 import { companyLocationNameID } from "studio/schemas/documents/admin/companyLocation";
 import { location, locationID } from "studio/schemas/objects/locations";
 
@@ -35,6 +36,26 @@ export const bonusesByLocation = defineField({
           description:
             "Bonus data reflecting the bonus given to employees for a given year.",
           type: "array",
+          options: {
+            sortable: false,
+          },
+          components: {
+            input: (props: ArrayOfObjectsInputProps) =>
+              ValueOrderedArrayOfObjectsInput({
+                ...props,
+                valueCompareFn: (a, b) => {
+                  if (isBonusPage(a)) {
+                    if (isBonusPage(b)) {
+                      return b.year - a.year;
+                    }
+                    return -1;
+                  } else if (isBonusPage(b)) {
+                    return 1;
+                  }
+                  return 0;
+                },
+              }),
+          },
           of: [
             {
               type: "object",

--- a/studio/schemas/objects/compensations/salariesByLocation.ts
+++ b/studio/schemas/objects/compensations/salariesByLocation.ts
@@ -1,7 +1,11 @@
-import { defineField } from "sanity";
+import { ArrayOfObjectsInputProps, defineField } from "sanity";
 
 import { SalariesInput } from "studio/components/salariesInput/SalariesInput";
-import { SalariesPage } from "studio/lib/interfaces/compensations";
+import ValueOrderedArrayOfObjectsInput from "studio/components/ValueOrderedArrayOfObjectsInput";
+import {
+  SalariesPage,
+  isSalariesPage,
+} from "studio/lib/interfaces/compensations";
 import { companyLocationNameID } from "studio/schemas/documents/admin/companyLocation";
 import { location, locationID } from "studio/schemas/objects/locations";
 
@@ -34,6 +38,26 @@ export const salariesByLocation = defineField({
           description:
             "Salary data reflecting salaries given to employees for a given year. ",
           type: "array",
+          options: {
+            sortable: false,
+          },
+          components: {
+            input: (props: ArrayOfObjectsInputProps) =>
+              ValueOrderedArrayOfObjectsInput({
+                ...props,
+                valueCompareFn: (a, b) => {
+                  if (isSalariesPage(a)) {
+                    if (isSalariesPage(b)) {
+                      return b.year - a.year;
+                    }
+                    return -1;
+                  } else if (isSalariesPage(b)) {
+                    return 1;
+                  }
+                  return 0;
+                },
+              }),
+          },
           of: [
             {
               type: "object",


### PR DESCRIPTION
See #611 

Added custom input compent to allow fixed ordering of array input elements in Studio. Currently only supports direct value comparison, i.e. not references.

Used for ordering salary and bonuses data by year (descending).

## Visual Overview (Image/Video)

<img width="690" alt="image" src="https://github.com/user-attachments/assets/e9e2a29b-23cc-4be2-98c8-81582dfb6c0b">

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?