### PR TITLE
v3 - fix button and link hover color

### DIFF
--- a/src/components/buttons/button.module.css
+++ b/src/components/buttons/button.module.css
@@ -43,11 +43,11 @@
   border: 1px solid var(--primary-dark);
 
   &:hover {
-    background: #085156;
+    background: var(--primary-darker);
   }
 
   &:active {
-    background: #053235;
+    background: var(--primary-darker);
   }
 }
 

--- a/src/components/linkButton/linkButton.module.css
+++ b/src/components/linkButton/linkButton.module.css
@@ -58,11 +58,11 @@
   border: 1px solid var(--primary-dark);
 
   &:hover {
-    background: #085156;
+    background: var(--primary-darker);
   }
 
   &:active {
-    background: #053235;
+    background: var(--primary-darker);
   }
 
   &::after {


### PR DESCRIPTION
Some forgotten hard-coded colors have been replaced with the proper CSS vars.

**Before**:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/64e4d864-3e3a-4996-8d1d-b9125b2732d1">

**After**:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/86f5abf0-f5fe-4bf9-9602-5710d513f7fc">

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?