### PR TITLE
v3 - include root path in sitemap

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -6,12 +6,14 @@ import SectionRenderer from "src/utils/renderSection";
 import { fetchSeoData, generateMetadataFromSeo } from "src/utils/seo";
 import { LinkType } from "studio/lib/interfaces/navigation";
 import { PageBuilder } from "studio/lib/interfaces/pages";
-import { LANDING_QUERY } from "studio/lib/queries/navigation";
+import { LANDING_PAGE_REF_QUERY } from "studio/lib/queries/navigation";
 import { PAGE_QUERY, SEO_PAGE_QUERY } from "studio/lib/queries/page";
 import { loadStudioQuery } from "studio/lib/store";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { data: landingId } = await loadStudioQuery<string>(LANDING_QUERY);
+  const { data: landingId } = await loadStudioQuery<string>(
+    LANDING_PAGE_REF_QUERY,
+  );
   const seo = await fetchSeoData(SEO_PAGE_QUERY, { id: landingId });
   return generateMetadataFromSeo(seo);
 }
@@ -36,7 +38,7 @@ const Home = async () => {
   const { perspective, isDraftMode } = getDraftModeInfo();
 
   const { data: landingId } = await loadStudioQuery<string>(
-    LANDING_QUERY,
+    LANDING_PAGE_REF_QUERY,
     {},
     { perspective },
   );

--- a/src/app/env.ts
+++ b/src/app/env.ts
@@ -1,0 +1,12 @@
+import { Result, ResultError, ResultOk } from "studio/utils/result";
+
+export function readBaseUrl(): Result<URL, string> {
+  const url = process.env.NEXT_PUBLIC_URL;
+  if (url === undefined) {
+    return ResultError("Missing environment variable: NEXT_PUBLIC_URL");
+  }
+  if (!URL.canParse(url)) {
+    return ResultError("Invalid environment variable: NEXT_PUBLIC_URL");
+  }
+  return ResultOk(new URL(url));
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,11 +1,22 @@
 import type { MetadataRoute } from "next";
 
+import { readBaseUrl } from "./env";
+
 export default function robots(): MetadataRoute.Robots {
-  return {
+  const robotsFile: MetadataRoute.Robots = {
     rules: {
       userAgent: "*",
       disallow: ["/studio", "/shared", "/api"],
     },
-    sitemap: new URL("sitemap.xml", process.env.NEXT_PUBLIC_URL).toString(),
   };
+  const baseUrlResult = readBaseUrl();
+  if (baseUrlResult.ok) {
+    robotsFile.sitemap = new URL("sitemap.xml", baseUrlResult.value).toString();
+  } else {
+    console.warn(
+      "Could not include sitemap in robots.txt, missing base url:",
+      baseUrlResult.error,
+    );
+  }
+  return robotsFile;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,11 @@
 import type { MetadataRoute } from "next";
 
 import { client } from "studio/lib/client";
-import { Slug } from "studio/lib/interfaces/global";
+import { DocumentWithSlug } from "studio/lib/interfaces/global";
+import { PageBuilder } from "studio/lib/interfaces/pages";
+import { DOCUMENTS_WITH_SLUG_QUERY } from "studio/lib/queries/document";
+import { LANDING_PAGE_QUERY } from "studio/lib/queries/navigation";
 import { token } from "studio/lib/token";
-
-interface SitemapDocument {
-  slug: Slug;
-  _updatedAt: string;
-}
 
 const clientWithToken = client.withConfig({ token });
 
@@ -15,11 +13,30 @@ export const dynamic = "force-dynamic";
 export const fetchCache = "default-no-store";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const documents =
-    await clientWithToken.fetch<SitemapDocument[]>(`*[defined(slug)]`);
-
-  return documents.map((s) => ({
-    url: new URL(s.slug.current, process.env.NEXT_PUBLIC_URL).toString(),
+  const baseUrl =
+    process.env.NEXT_PUBLIC_URL !== undefined &&
+    URL.canParse(process.env.NEXT_PUBLIC_URL)
+      ? new URL(process.env.NEXT_PUBLIC_URL)
+      : undefined;
+  if (baseUrl === undefined) {
+    console.error("Failed to generate sitemap, missing baseUrl");
+    return [];
+  }
+  const slugDocuments = await clientWithToken.fetch<DocumentWithSlug[]>(
+    DOCUMENTS_WITH_SLUG_QUERY,
+  );
+  const sitemapEntries = slugDocuments.map((s) => ({
+    url: new URL(s.slug.current, baseUrl).toString(),
     lastModified: new Date(s._updatedAt),
   }));
+  const landingPage = await clientWithToken.fetch<PageBuilder | null>(
+    LANDING_PAGE_QUERY,
+  );
+  if (landingPage !== null) {
+    sitemapEntries.push({
+      url: baseUrl.toString(),
+      lastModified: new Date(landingPage._updatedAt),
+    });
+  }
+  return sitemapEntries;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,21 +7,20 @@ import { DOCUMENTS_WITH_SLUG_QUERY } from "studio/lib/queries/document";
 import { LANDING_PAGE_QUERY } from "studio/lib/queries/navigation";
 import { token } from "studio/lib/token";
 
+import { readBaseUrl } from "./env";
+
 const clientWithToken = client.withConfig({ token });
 
 export const dynamic = "force-dynamic";
 export const fetchCache = "default-no-store";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl =
-    process.env.NEXT_PUBLIC_URL !== undefined &&
-    URL.canParse(process.env.NEXT_PUBLIC_URL)
-      ? new URL(process.env.NEXT_PUBLIC_URL)
-      : undefined;
-  if (baseUrl === undefined) {
-    console.error("Failed to generate sitemap, missing baseUrl");
+  const baseUrlResult = readBaseUrl();
+  if (!baseUrlResult.ok) {
+    console.error("Failed to generate sitemap:", baseUrlResult.error);
     return [];
   }
+  const baseUrl = baseUrlResult.value;
   const slugDocuments = await clientWithToken.fetch<DocumentWithSlug[]>(
     DOCUMENTS_WITH_SLUG_QUERY,
   );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -25,9 +25,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const slugDocuments = await clientWithToken.fetch<DocumentWithSlug[]>(
     DOCUMENTS_WITH_SLUG_QUERY,
   );
-  const sitemapEntries = slugDocuments.map((s) => ({
-    url: new URL(s.slug.current, baseUrl).toString(),
-    lastModified: new Date(s._updatedAt),
+  const sitemapEntries = slugDocuments.map((slugDocument) => ({
+    url: new URL(slugDocument.slug.current, baseUrl).toString(),
+    lastModified: new Date(slugDocument._updatedAt),
   }));
   const landingPage = await clientWithToken.fetch<PageBuilder | null>(
     LANDING_PAGE_QUERY,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,28 +3,35 @@ import { NextRequest, NextResponse } from "next/server";
 import { RedirectDestinationSlugPage } from "studio/lib/interfaces/redirect";
 import { REDIRECT_BY_SOURCE_SLUG_QUERY } from "studio/lib/queries/redirects";
 
+import { readBaseUrl } from "./app/env";
 import { HTTP_STATUSES } from "./utils/http";
 
 export async function middleware(request: NextRequest) {
+  const baseUrlResult = readBaseUrl();
+  if (!baseUrlResult.ok) {
+    console.error(
+      "Failed to run middleware, missing base url:",
+      baseUrlResult.error,
+    );
+    return;
+  }
+  const baseUrl = baseUrlResult.value;
   const slug = request.nextUrl.pathname;
   const slugQueryParam = slug.replace(/^\/+/, "");
   /*
    fetching redirect data via API route to avoid token leaking to client
    (middleware should run on server, but `experimental_taintUniqueValue` begs to differ...)
   */
-  const redirectRes = await fetch(
-    new URL("/api/fetchData", process.env.NEXT_PUBLIC_URL),
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: REDIRECT_BY_SOURCE_SLUG_QUERY,
-        params: { slug: slugQueryParam },
-      }),
+  const redirectRes = await fetch(new URL("/api/fetchData", baseUrl), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
     },
-  );
+    body: JSON.stringify({
+      query: REDIRECT_BY_SOURCE_SLUG_QUERY,
+      params: { slug: slugQueryParam },
+    }),
+  });
   if (redirectRes.ok) {
     const redirect: RedirectDestinationSlugPage | null =
       await redirectRes.json();

--- a/studio/components/CustomCallToActions.tsx
+++ b/studio/components/CustomCallToActions.tsx
@@ -9,7 +9,7 @@ import {
 } from "sanity";
 
 import { fetchWithToken } from "studio/lib/fetchWithToken";
-import { LANDING_QUERY } from "studio/lib/queries/navigation";
+import { LANDING_PAGE_REF_QUERY } from "studio/lib/queries/navigation";
 
 type CustomCallToActionsProps = ArrayOfObjectsInputProps<
   { _key: string },
@@ -28,7 +28,7 @@ const CustomCallToActions: React.FC<CustomCallToActionsProps> = (props) => {
     const fetchLandingId = async () => {
       try {
         setLoading(true);
-        const landingId = await fetchWithToken<string>(LANDING_QUERY);
+        const landingId = await fetchWithToken<string>(LANDING_PAGE_REF_QUERY);
         setLandingPageId(landingId);
       } catch (error) {
         console.error("Failed to fetch navigation manager", error);

--- a/studio/lib/interfaces/global.ts
+++ b/studio/lib/interfaces/global.ts
@@ -7,3 +7,8 @@ export interface Reference {
   _type: "reference";
   _ref: string;
 }
+
+export interface DocumentWithSlug {
+  slug: Slug;
+  _updatedAt: string;
+}

--- a/studio/lib/queries/document.ts
+++ b/studio/lib/queries/document.ts
@@ -1,0 +1,5 @@
+import { groq } from "next-sanity";
+
+export const DOCUMENTS_WITH_SLUG_QUERY = groq`
+  *[defined(slug)]
+`;

--- a/studio/lib/queries/navigation.ts
+++ b/studio/lib/queries/navigation.ts
@@ -38,6 +38,10 @@ export const NAV_QUERY = groq`
   }
 `;
 
-export const LANDING_QUERY = groq`
+export const LANDING_PAGE_REF_QUERY = groq`
   *[_type == "navigationManager"][0].setLanding._ref
+`;
+
+export const LANDING_PAGE_QUERY = groq`
+  *[_type == "navigationManager"][0].setLanding ->
 `;


### PR DESCRIPTION
See #693 

Originally, the landing page only showed up in the sitemap with a slug value (e.g. `/home`). Since it can be reached by the root/index path (e.g. `https://variant.no/`), this has now been included in `sitemap.xml`.

<img width="379" alt="image" src="https://github.com/user-attachments/assets/ef6de403-0e42-4226-a7cf-31c230512601">

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?