### PR TITLE
v3 - include non-dynamic pages in SEO fetching

### DIFF
--- a/studio/lib/queries/page.ts
+++ b/studio/lib/queries/page.ts
@@ -77,7 +77,7 @@ export const SLUG_QUERY = groq`
 `;
 
 export const SEO_SLUG_QUERY = groq`
-  *[_type == "pageBuilder" && slug.current == $slug][0]{
+  *[defined(seo) && slug.current == $slug][0]{
         "title": seo.seoTitle,
         "description": seo.seoDescription,
         "imageUrl": seo.seoImage.asset->url

--- a/studio/schemas/documents/specialPages/customerCasesPage.ts
+++ b/studio/schemas/documents/specialPages/customerCasesPage.ts
@@ -1,6 +1,7 @@
 import { defineType } from "sanity";
 
 import { title } from "studio/schemas/fields/text";
+import seo from "studio/schemas/objects/seo";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
 
 export const customerCasesPageID = "customerCasesPage";
@@ -17,6 +18,7 @@ const customerCasesPage = defineType({
         "Enter the primary title that will be displayed at the top of the customer cases page. This is what users will see when they visit the page.",
     },
     titleSlug,
+    seo,
   ],
   preview: {
     select: {


### PR DESCRIPTION
See #694 

Currently, SEO data is not fetched for non-dynamic pages. This is becuase the query has a filter on the `pageBuilder` type. This has been changed to filter based on the existence of the `seo` field instead. This means that pages such as `Compensations` and `CustomerCasePage` also get SEO metadata.

`CustomerCasePage` was missing the seo fields, so this has also been added.

## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?