### PR TITLE
v3 - proper slug change validation

### DIFF
--- a/studio/components/CustomCallToActions.tsx
+++ b/studio/components/CustomCallToActions.tsx
@@ -10,6 +10,7 @@ import {
 
 import { fetchWithToken } from "studio/lib/fetchWithToken";
 import { LANDING_PAGE_REF_QUERY } from "studio/lib/queries/navigation";
+import { buildPublishedId } from "studio/utils/documentUtils";
 
 type CustomCallToActionsProps = ArrayOfObjectsInputProps<
   { _key: string },
@@ -44,9 +45,7 @@ const CustomCallToActions: React.FC<CustomCallToActionsProps> = (props) => {
   useEffect(() => {
     if (!landingPageId) return;
 
-    const currentPageId = documentId?.startsWith("drafts.")
-      ? documentId.split("drafts.")[1]
-      : documentId;
+    const currentPageId = buildPublishedId(documentId);
 
     const isLanding = landingPageId === currentPageId;
 

--- a/studio/utils/documentUtils.ts
+++ b/studio/utils/documentUtils.ts
@@ -1,9 +1,29 @@
 import type { SanityDocument } from "@sanity/types";
 
+export const DRAFTS_PREFIX = "drafts.";
+
 export function isPublished(document: SanityDocument) {
   return !isDraft(document);
 }
 
 export function isDraft(document: SanityDocument) {
-  return document._id.startsWith("drafts.") || document._rev === undefined;
+  return isDraftId(document._id) || document._rev === undefined;
+}
+
+export function buildDraftId(documentId: string): string {
+  return isDraftId(documentId) ? documentId : `${DRAFTS_PREFIX}${documentId}`;
+}
+
+export function buildPublishedId(documentId: string): string {
+  return isPublishedId(documentId)
+    ? documentId
+    : documentId.slice(DRAFTS_PREFIX.length);
+}
+
+function isPublishedId(documentId: string) {
+  return !isDraftId(documentId);
+}
+
+function isDraftId(documentId: string) {
+  return documentId.startsWith(DRAFTS_PREFIX);
 }


### PR DESCRIPTION
See #696 

The originally approach to prevent slug changes after publication was too naive. It only checked if the current document was a draft or not. This meant that the slug could be changed for a published document by first changing a different field (e.g. the page title), and then change the slug field.

The new approach relies on validation to perform a client fetch to check if a published document exists with the same id (without the `drafts.` prefix) with a different slug. This is less clear than the readonly state, but the readonly property does not seem to allow async.

<img width="680" alt="image" src="https://github.com/user-attachments/assets/b6fe7780-33b7-4c5e-9695-cc4439d20287">


## Checklist

Please ensure that you’ve completed the following checkpoints before submitting your pull request:

- [x] **Documentation**: Relevant documentation has been added or updated (if applicable).
- [x] **Testing**: Have you tested your changes thoroughly?