### PR TITLE
removed missing field in cta section

### DIFF
--- a/studio/schemas/objects/sections/callToAction.ts
+++ b/studio/schemas/objects/sections/callToAction.ts
@@ -31,9 +31,6 @@ export const callToAction = defineField({
       validation: (rule) => rule.required(),
     },
   ],
-  initialValue: {
-    theme: "primary",
-  },
   preview: {
     select: {
       title: "basicTitle",


### PR DESCRIPTION
## Short Description

Tiny fix in CTA section. Removed initialvalue that is read as a field. 

## Visual Overview (Image/Video)
<img width="1696" alt="Screenshot 2024-09-25 at 10 52 36" src="https://github.com/user-attachments/assets/d98b9e85-d1b9-4290-9afd-eeb453926596">

after fix: 
<img width="829" alt="Screenshot 2024-09-25 at 10 53 11" src="https://github.com/user-attachments/assets/8bdeab5d-7e26-48a5-9015-369e8506bbba">