### PR TITLE
Add a language param to customer case query

### DIFF
--- a/src/customerCases/CustomerCases.tsx
+++ b/src/customerCases/CustomerCases.tsx
@@ -20,7 +20,7 @@ const CustomerCases = async ({ customerCasesPage }: CustomerCasesProps) => {
   const [sharedCustomerCases] = await Promise.all([
     loadSharedQuery<CustomerCase[]>(
       CUSTOMER_CASES_QUERY,
-      { language: "no" },
+      { language: "en" },
       { perspective },
     ), //TODO: Replace hard coded language with selected language
   ]);

--- a/src/customerCases/CustomerCases.tsx
+++ b/src/customerCases/CustomerCases.tsx
@@ -18,7 +18,11 @@ const CustomerCases = async ({ customerCasesPage }: CustomerCasesProps) => {
   const { perspective } = getDraftModeInfo();
 
   const [sharedCustomerCases] = await Promise.all([
-    loadSharedQuery<CustomerCase[]>(CUSTOMER_CASES_QUERY, {}, { perspective }),
+    loadSharedQuery<CustomerCase[]>(
+      CUSTOMER_CASES_QUERY,
+      { language: "no" },
+      { perspective },
+    ), //TODO: Replace hard coded language with selected language
   ]);
 
   return (

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -1,4 +1,4 @@
 import { groq } from "next-sanity";
 
-export const CUSTOMER_CASES_QUERY = groq`*[_type == "customerCase"]
+export const CUSTOMER_CASES_QUERY = groq`*[_type == "customerCase" && language == $language]
 `;


### PR DESCRIPTION
## Short Description

I have added a language param to customer case query in shared studio to be able to retrieve the customer cases to spesific language. The language is hard coded, and need to be replaced. 

## Visual Overview (Image/Video)

<img width="1433" alt="Screenshot 2024-09-26 at 08 59 02" src="https://github.com/user-attachments/assets/7194eca3-80c7-4e76-b9e9-624de3d90d67">

<img width="1309" alt="Screenshot 2024-09-26 at 08 59 44" src="https://github.com/user-attachments/assets/ea569d33-e4c2-498d-8460-e9b1a5b5761a">
