### PR TITLE
V3 fix render issue in legal documents

### DIFF
--- a/src/blog/components/legal/Legal.tsx
+++ b/src/blog/components/legal/Legal.tsx
@@ -21,7 +21,6 @@ const extractHeadings = (blocks: PortableTextBlock[]) => {
 };
 
 const Legal = ({ document }: { document: LegalDocument }) => {
-  console.log(document.richText);
   const headings = extractHeadings(document.richText ?? []);
 
   const link: ILink = {

--- a/src/blog/components/legal/Legal.tsx
+++ b/src/blog/components/legal/Legal.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 import { PortableTextBlock } from "sanity";
 
+import LinkButton from "src/components/linkButton/LinkButton";
 import { RichText } from "src/components/richText/RichText";
 import Text from "src/components/text/Text";
 import { LegalDocument } from "studio/lib/interfaces/legalDocuments";
+import { ILink, LinkType } from "studio/lib/interfaces/navigation";
 
 import styles from "./legal.module.css";
 
@@ -19,7 +21,18 @@ const extractHeadings = (blocks: PortableTextBlock[]) => {
 };
 
 const Legal = ({ document }: { document: LegalDocument }) => {
-  const headings = extractHeadings(document.richText);
+  console.log(document.richText);
+  const headings = extractHeadings(document.richText ?? []);
+
+  const link: ILink = {
+    _key: "string",
+    _type: "internalLink",
+    linkTitle: "Add legal data",
+    linkType: LinkType.Internal,
+    internalLink: {
+      _ref: `studio/structure/admin;legalDocuments;${document._id}`,
+    },
+  };
 
   return (
     <div>
@@ -51,7 +64,18 @@ const Legal = ({ document }: { document: LegalDocument }) => {
             </ul>
           </div>
           <div className={styles.document}>
-            <RichText value={document.richText} />
+            {document.richText ? (
+              <RichText value={document.richText} />
+            ) : (
+              <section className={styles.document}>
+                <Text type="body">
+                  It appears that this legal document is missing some
+                  information. Please visit the studio to add the necessary
+                  details.
+                </Text>
+                <LinkButton link={link} />
+              </section>
+            )}
           </div>
         </div>
       </div>

--- a/studio/schemas/documents/admin/legalDocuments.ts
+++ b/studio/schemas/documents/admin/legalDocuments.ts
@@ -11,7 +11,18 @@ const legalDocument = defineField({
   name: legalDocumentID,
   type: "document",
   title: "Legal Document",
-  fields: [languageSchemaField, title, titleSlug, richText],
+  fields: [
+    languageSchemaField,
+    title,
+    titleSlug,
+    {
+      ...richText,
+      validation: (Rule) =>
+        Rule.required().error(
+          "Content is required. Please add the necessary information to the legal document.",
+        ),
+    },
+  ],
   preview: {
     select: {
       title: "basicTitle",


### PR DESCRIPTION
## Short Description

I’ve added a check to determine if the rich text is undefined. If it is, the user will be informed that it is empty, and added a redirectbutton to the given document. Additionally, I’ve made the rich text field in the legal document required.

## Visual Overview (Image/Video)

<img width="1490" alt="Screenshot 2024-09-26 at 11 07 14" src="https://github.com/user-attachments/assets/f9de401b-5abf-40ac-bb2d-7b3ca1903461">

<img width="1081" alt="Screenshot 2024-09-26 at 11 07 24" src="https://github.com/user-attachments/assets/de66c138-e4ff-496b-b9c0-a3a219f6d1fc">