### PR TITLE
v3 - customer case slug uniqueness

### DIFF
--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -2,7 +2,10 @@ import { defineField, defineType } from "sanity";
 
 import languageSchemaField from "i18n/languageSchemaField";
 import { richText, title } from "studio/schemas/fields/text";
-import { titleSlug } from "studio/schemas/schemaTypes/slug";
+import {
+  isSlugUniqueAcrossDocuments,
+  titleSlug,
+} from "studio/schemas/schemaTypes/slug";
 
 export const customerCaseID = "customerCase";
 
@@ -13,7 +16,14 @@ const customerCase = defineType({
   fields: [
     languageSchemaField,
     title,
-    titleSlug,
+    {
+      ...titleSlug,
+      options: {
+        ...titleSlug.options,
+        isUnique: (slug, ctx) =>
+          isSlugUniqueAcrossDocuments(slug, ctx, customerCaseID),
+      },
+    },
     defineField({
       ...richText,
       description: "Enter the body content of the Customer case.",


### PR DESCRIPTION
We are planning to place customer cases under a parent slug (e.g. `/kunder`). A consequence of this is that customer cases don't have to be unique across all documents, only across all customer cases. The slug validation has been modified to reflect this.