### PR TITLE
v3 - add missing "use client"

### DIFF
--- a/studio/components/AnchorSelect.tsx
+++ b/studio/components/AnchorSelect.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button, Select, Stack } from "@sanity/ui";
 import React, { useEffect, useState } from "react";
 import { PatchEvent, StringInputProps, set, unset, useFormValue } from "sanity";

--- a/studio/components/ClearLinkFieldsButton.tsx
+++ b/studio/components/ClearLinkFieldsButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@sanity/ui";
 import { useFormValue } from "sanity";
 

--- a/studio/components/CustomCallToActions.tsx
+++ b/studio/components/CustomCallToActions.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Card, Text } from "@sanity/ui";
 import React, { useEffect, useState } from "react";
 import {

--- a/studio/components/LinkTypeSelector.tsx
+++ b/studio/components/LinkTypeSelector.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, Card, Flex, Grid, Text } from "@sanity/ui";
 import React from "react";
 import { PatchEvent, set } from "sanity";

--- a/studio/components/NewTabSelector.tsx
+++ b/studio/components/NewTabSelector.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Box, Card, Flex, Grid, Stack, Text } from "@sanity/ui";
 import React from "react";
 import { PatchEvent, set } from "sanity";

--- a/studio/components/salariesInput/SalariesInput.tsx
+++ b/studio/components/salariesInput/SalariesInput.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Inline, Stack, Text, useToast } from "@sanity/ui";
 import { useState } from "react";
 import { StringInputProps, set } from "sanity";


### PR DESCRIPTION
Added "use client", marking a component as a Client Component, where required to avoid page crash.