### PR TITLE
v3 - initial employees page

### DIFF
--- a/src/components/sections/callToAction/mockData.ts
+++ b/src/components/sections/callToAction/mockData.ts
@@ -1,6 +1,7 @@
 import { LinkType } from "studio/lib/interfaces/navigation";
+import { CallToActionSection } from "studio/lib/interfaces/pages";
 
-export const ctaMockData = {
+export const ctaMockData: CallToActionSection = {
   _key: "9410f9860a00",
   _type: "ctaSection",
   basicTitle: "Ready to begin your climate journey?",
@@ -18,7 +19,6 @@ export const ctaMockData = {
       _key: "8aba2dc3497b",
       internalLink: {
         _ref: "696ab97f-4830-4812-9aa3-4050196fab58",
-        _type: "reference",
       },
       linkTitle: "Book a demo",
       linkType: LinkType.Internal,
@@ -29,7 +29,6 @@ export const ctaMockData = {
       _key: "0a6e47ebca0e",
       internalLink: {
         _ref: "696ab97f-4830-4812-9aa3-4050196fab58",
-        _type: "reference",
       },
       linkTitle: "Partner with us",
       linkType: LinkType.Internal,

--- a/src/components/sections/callout/mockData.ts
+++ b/src/components/sections/callout/mockData.ts
@@ -1,6 +1,7 @@
 import { PortableTextBlock } from "sanity";
 
 import { LinkType } from "studio/lib/interfaces/navigation";
+import { CalloutSection } from "studio/lib/interfaces/pages";
 
 const RichTextMock: PortableTextBlock[] = [
   {
@@ -42,7 +43,7 @@ const RichTextMock: PortableTextBlock[] = [
   },
 ];
 
-export const calloutMockData = {
+export const calloutMockData: CalloutSection = {
   _key: "3d99dad2f909",
   _type: "callout",
   link: {

--- a/src/components/sections/grid/mockdata.ts
+++ b/src/components/sections/grid/mockdata.ts
@@ -1,6 +1,7 @@
 import { PortableTextBlock } from "sanity";
 
 import placeholder from "src/stories/assets/image-placeholder.png";
+import { GridSection } from "studio/lib/interfaces/pages";
 
 const commonRichText: PortableTextBlock[] = [
   {
@@ -29,7 +30,7 @@ const item = {
   richText: commonRichText,
 };
 
-export const mockGrid = {
+export const mockGrid: GridSection = {
   _type: "grid",
   _key: "8f79f85866cb",
   basicTitle: "The team",

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -166,7 +166,7 @@ const SectionRenderer = ({
   switch (section._type) {
     case "hero":
       return renderHeroSection(
-        section as HeroSection,
+        section,
         sectionIndex,
         isDraftMode,
         initialData,
@@ -174,53 +174,48 @@ const SectionRenderer = ({
       );
     case "logoSalad":
       return renderLogoSaladSection(
-        section as LogoSaladSection,
+        section,
         sectionIndex,
         isDraftMode,
         initialData,
       );
     case "article":
       return renderArticleSection(
-        section as ArticleSection,
+        section,
         sectionIndex,
         isDraftMode,
         initialData,
       );
     case "callout":
       return renderCalloutSection(
-        section as CalloutSection,
+        section,
         sectionIndex,
         isDraftMode,
         initialData,
       );
     case "ctaSection":
       return renderCallToActionSection(
-        section as CallToActionSection,
+        section,
         sectionIndex,
         isDraftMode,
         initialData,
       );
     case "testimonials":
       return renderTestimonialsSection(
-        section as TestimonialsSection,
+        section,
         sectionIndex,
         isDraftMode,
         initialData,
       );
     case "imageSection":
       return renderImageSection(
-        section as ImageSection,
+        section,
         sectionIndex,
         isDraftMode,
         initialData,
       );
     case "grid":
-      return renderGridSection(
-        section as GridSection,
-        sectionIndex,
-        isDraftMode,
-        initialData,
-      );
+      return renderGridSection(section, sectionIndex, isDraftMode, initialData);
     case "employees":
       return (
         <pre

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -221,6 +221,18 @@ const SectionRenderer = ({
         isDraftMode,
         initialData,
       );
+    case "employees":
+      return (
+        <pre
+          style={{
+            background: "hotpink",
+            padding: "3rem",
+            margin: 0,
+          }}
+        >
+          {JSON.stringify(section, null, 2)}
+        </pre>
+      );
     default:
       return null;
   }

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -218,6 +218,7 @@ const SectionRenderer = ({
       return renderGridSection(section, sectionIndex, isDraftMode, initialData);
     case "employees":
       return (
+        // TODO: implement employees section
         <pre
           style={{
             background: "hotpink",

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -81,12 +81,19 @@ export interface GridSection {
   }[];
 }
 
+export interface EmployeesSection {
+  _type: "employees";
+  _key: string;
+  basicTitle: string;
+}
+
 export type Section =
   | HeroSection
   | LogoSaladSection
   | ArticleSection
   | CalloutSection
-  | CallToActionSection;
+  | CallToActionSection
+  | EmployeesSection;
 
 export interface PageBuilder {
   _createdAt: string;

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -7,24 +7,24 @@ import { IImage, ImageExtendedProps } from "./media";
 import { ILink } from "./navigation";
 
 export interface HeroSection {
+  _type: "hero";
   _key: string;
-  _type: string;
   basicTitle: string;
   callToActions: ILink[];
   description: string;
 }
 
 export interface LogoSaladSection {
+  _type: "logoSalad";
   _key: string;
-  _type: string;
   logos: IImage[];
   richText?: PortableTextBlock[];
   supporting: string;
 }
 
 export interface ArticleSection {
+  _type: "article";
   _key: string;
-  _type: string;
   tag?: string;
   basicTitle: string;
   richText?: PortableTextBlock[];
@@ -33,22 +33,22 @@ export interface ArticleSection {
 }
 
 export interface CalloutSection {
+  _type: "callout";
   _key: string;
-  _type: string;
   richText?: PortableTextBlock[];
   link?: ILink;
 }
 
 export interface CallToActionSection {
+  _type: "ctaSection";
   _key: string;
-  _type: string;
   basicTitle?: string;
   callToActions?: ILink[];
 }
 
 export interface TestimonialsSection {
+  _type: "testimonials";
   _key: string;
-  _type: string;
   basicTitle?: string;
   imagesAsCircles: boolean;
   listOfTestimonials: {
@@ -62,15 +62,15 @@ export interface TestimonialsSection {
 }
 
 export interface ImageSection {
+  _type: "imageSection";
   _key: string;
-  _type: string;
   basicTitle: string;
   image: IImage;
 }
 
 export interface GridSection {
+  _type: "grid";
   _key: string;
-  _type: string;
   basicTitle: string;
   items: {
     _key: string;
@@ -93,6 +93,9 @@ export type Section =
   | ArticleSection
   | CalloutSection
   | CallToActionSection
+  | TestimonialsSection
+  | ImageSection
+  | GridSection
   | EmployeesSection;
 
 export interface PageBuilder {

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -33,6 +33,9 @@ const SECTIONS_FRAGMENT = groq`
         ...,
         ${TRANSLATED_LINK_FRAGMENT}
       }
+    },
+    _type == "employees" => {
+      "basicTitle": ${translatedFieldFragment("basicTitle")}
     }
   }
 `;

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -1,12 +1,13 @@
 import { groq } from "next-sanity";
 
+import { LANGUAGE_FIELD_FRAGMENT } from "./i18n";
 import { translatedFieldFragment } from "./utils/i18n";
 
 //Compensations
 export const COMPENSATIONS_PAGE_BY_SLUG_QUERY = groq`
   *[_type == "compensations" && ${translatedFieldFragment("slug")} == $slug][0] {
     ...,
-    "language": $language,
+    ${LANGUAGE_FIELD_FRAGMENT},
     "slug": ${translatedFieldFragment("slug")},
     "basicTitle": ${translatedFieldFragment("basicTitle")},
     "benefitsByLocation": benefitsByLocation[] {

--- a/studio/schemas/documents/pageBuilder.ts
+++ b/studio/schemas/documents/pageBuilder.ts
@@ -5,6 +5,7 @@ import { isInternationalizedString } from "studio/lib/interfaces/global";
 import article from "studio/schemas/objects/sections/article";
 import callout from "studio/schemas/objects/sections/callout";
 import callToAction from "studio/schemas/objects/sections/callToAction";
+import { employees } from "studio/schemas/objects/sections/employees";
 import grid from "studio/schemas/objects/sections/grid";
 import hero from "studio/schemas/objects/sections/hero";
 import imageSection from "studio/schemas/objects/sections/image";
@@ -52,6 +53,7 @@ const pageBuilder = defineType({
         testimonals,
         imageSection,
         grid,
+        employees,
       ],
     }),
   ],

--- a/studio/schemas/objects/sections/employees.ts
+++ b/studio/schemas/objects/sections/employees.ts
@@ -1,0 +1,27 @@
+import { defineField } from "sanity";
+
+import { titleID } from "studio/schemas/fields/text";
+
+export const employeesID = "employees";
+
+export const employees = defineField({
+  name: employeesID,
+  title: "Employees",
+  type: "object",
+  fields: [
+    {
+      name: titleID.basic,
+      type: "internationalizedArrayString",
+      title: "Title",
+      description:
+        "Enter the primary title that will be displayed at the top of the employees section.",
+    },
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: "Employees",
+      };
+    },
+  },
+});


### PR DESCRIPTION
Initial setup for having a dynamic page section for showcasing all our employees.

In case it is not obvious from the last screenshot, only the skeleton setup has been implemented (i.e. section schema, TS types and page fetching). Actually fetching and displaying employees data is left for #767.

<img width="634" alt="image" src="https://github.com/user-attachments/assets/b6a82a6f-dc68-4786-95a0-4f02589b7222">

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/4fcea204-08d4-4248-a777-d01b466de426">
