### PR TITLE
V3-translation in customer case page in /studio

### DIFF
--- a/src/app/(main)/[lang]/[...path]/page.tsx
+++ b/src/app/(main)/[lang]/[...path]/page.tsx
@@ -30,8 +30,7 @@ function seoDataFromPageData(
       // TODO
       return null;
     case "customerCasesPage":
-      // TODO
-      return null;
+      return data.queryResponse.data.seo;
     case "pageBuilder":
       // TODO
       return null;

--- a/src/components/customerCases/CustomerCases.tsx
+++ b/src/components/customerCases/CustomerCases.tsx
@@ -20,9 +20,9 @@ const CustomerCases = async ({ customerCasesPage }: CustomerCasesProps) => {
   const [sharedCustomerCases] = await Promise.all([
     loadSharedQuery<CustomerCase[]>(
       CUSTOMER_CASES_QUERY,
-      { language: "en" },
+      { language: customerCasesPage.language },
       { perspective },
-    ), //TODO: Replace hard coded language with selected language
+    ),
   ]);
 
   return (

--- a/src/utils/pageData.ts
+++ b/src/utils/pageData.ts
@@ -149,6 +149,7 @@ async function fetchCustomerCase({
   }
   const customerCasesPageParams = {
     slug: path[0],
+    language,
   };
   const customerCasesPageResult =
     await loadStudioQuery<CustomerCasePage | null>(

--- a/studio/lib/interfaces/specialPages.ts
+++ b/studio/lib/interfaces/specialPages.ts
@@ -1,3 +1,5 @@
+import { SeoData } from "src/utils/seo";
+
 import { Slug } from "./global";
 
 export interface CustomerCasePage {
@@ -9,4 +11,5 @@ export interface CustomerCasePage {
   basicTitle: string;
   page: string;
   slug: Slug;
+  seo: SeoData;
 }

--- a/studio/lib/interfaces/specialPages.ts
+++ b/studio/lib/interfaces/specialPages.ts
@@ -11,5 +11,6 @@ export interface CustomerCasePage {
   basicTitle: string;
   page: string;
   slug: Slug;
+  language: string;
   seo: SeoData;
 }

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -34,7 +34,18 @@ export const COMPENSATIONS_PAGE_SITEMAP_QUERY = groq`
 
 //Customer Cases
 export const CUSTOMER_CASES_PAGE_QUERY = groq`
-  *[_type == "customerCasesPage" && slug.current == $slug][0]`;
+  *[_type == "customerCasesPage" && ${translatedFieldFragment("slug")} == $slug][0]{
+    ...,
+    "language": $language,
+    "slug": ${translatedFieldFragment("slug")},
+    "basicTitle": ${translatedFieldFragment("basicTitle")},
+    "seo": ${translatedFieldFragment("seo")} {
+      "title": seoTitle,
+      "description": seoDescription,
+      "imageUrl": seoImage.asset->url,
+      "keywords": seoKeywords
+    },
+  }`;
 
 export const CUSTOMER_CASES_PAGE_SITEMAP_QUERY = groq`
   *[_type == "customerCasesPage"][0] {

--- a/studio/schemas/documents/specialPages/customerCasesPage.ts
+++ b/studio/schemas/documents/specialPages/customerCasesPage.ts
@@ -1,8 +1,10 @@
 import { defineType } from "sanity";
 
+import { isInternationalizedString } from "studio/lib/interfaces/global";
 import { title } from "studio/schemas/fields/text";
 import seo from "studio/schemas/objects/seo";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
+import { firstTranslation } from "studio/utils/i18n";
 
 export const customerCasesPageID = "customerCasesPage";
 
@@ -23,6 +25,16 @@ const customerCasesPage = defineType({
   preview: {
     select: {
       title: "basicTitle",
+    },
+    prepare({ title }) {
+      if (!isInternationalizedString(title)) {
+        throw new TypeError(
+          `Expected 'title' to be InternationalizedString, was ${typeof title}`,
+        );
+      }
+      return {
+        title: firstTranslation(title) ?? undefined,
+      };
     },
   },
 });

--- a/studio/schemas/documents/specialPages/customerCasesPage.ts
+++ b/studio/schemas/documents/specialPages/customerCasesPage.ts
@@ -1,7 +1,7 @@
 import { defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
-import { title } from "studio/schemas/fields/text";
+import { titleID } from "studio/schemas/fields/text";
 import seo from "studio/schemas/objects/seo";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
 import { firstTranslation } from "studio/utils/i18n";
@@ -14,17 +14,22 @@ const customerCasesPage = defineType({
   title: "Customer Cases",
   fields: [
     {
-      ...title,
+      name: titleID.basic,
+      type: "internationalizedArrayString",
       title: "Customer Case Page Title",
       description:
         "Enter the primary title that will be displayed at the top of the customer cases page. This is what users will see when they visit the page.",
     },
-    titleSlug,
+    {
+      ...titleSlug,
+      type: "internationalizedArrayString",
+    },
     seo,
+    //Todo: add translations for SEO
   ],
   preview: {
     select: {
-      title: "basicTitle",
+      title: titleID.basic,
     },
     prepare({ title }) {
       if (!isInternationalizedString(title)) {

--- a/studio/schemas/documents/specialPages/customerCasesPage.ts
+++ b/studio/schemas/documents/specialPages/customerCasesPage.ts
@@ -2,7 +2,6 @@ import { defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
 import { titleID } from "studio/schemas/fields/text";
-import seo from "studio/schemas/objects/seo";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
 import { firstTranslation } from "studio/utils/i18n";
 
@@ -24,8 +23,10 @@ const customerCasesPage = defineType({
       ...titleSlug,
       type: "internationalizedArrayString",
     },
-    seo,
-    //TODO: add translations for SEO
+    {
+      name: "seo",
+      type: "internationalizedArraySeo",
+    },
   ],
   preview: {
     select: {

--- a/studio/schemas/documents/specialPages/customerCasesPage.ts
+++ b/studio/schemas/documents/specialPages/customerCasesPage.ts
@@ -25,7 +25,7 @@ const customerCasesPage = defineType({
       type: "internationalizedArrayString",
     },
     seo,
-    //Todo: add translations for SEO
+    //TODO: add translations for SEO
   ],
   preview: {
     select: {


### PR DESCRIPTION
This PR adds field translation for the customer case page in /studio. 

Related issue: [#771](https://github.com/varianter/variant.no/issues/771)