### PR TITLE
V3 customer case field translation

### DIFF
--- a/studioShared/deskStructure.ts
+++ b/studioShared/deskStructure.ts
@@ -1,7 +1,5 @@
 import { StructureResolver } from "sanity/structure";
 
-import { defaultLanguage } from "i18n/supportedLanguages";
-
 import { customerCaseID } from "./schemas/documents/customerCase";
 
 export const deskStructure: StructureResolver = (S) =>
@@ -10,14 +8,5 @@ export const deskStructure: StructureResolver = (S) =>
     .items([
       S.listItem()
         .title("Customer cases")
-        .child(
-          S.documentTypeList(customerCaseID)
-            .title("Customer cases")
-            // only show costumer cases in the base language
-            .filter("_type == $type && language == $lang")
-            .params({
-              type: customerCaseID,
-              lang: defaultLanguage?.id,
-            }),
-        ),
+        .child(S.documentTypeList(customerCaseID).title("Customer cases")),
     ]);

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -1,6 +1,11 @@
 import { groq } from "next-sanity";
 
-export const CUSTOMER_CASES_QUERY = groq`*[_type == "customerCase" && language == $language]
+import { translatedFieldFragment } from "studio/lib/queries/utils/i18n";
+
+export const CUSTOMER_CASES_QUERY = groq`*[_type == "customerCase"]{
+ "language": $language,
+  "basicTitle": ${translatedFieldFragment("basicTitle")},
+   "richText": ${translatedFieldFragment("richText")}}
 `;
 
 export const CUSTOMER_CASE_QUERY = groq`*[_type == "customerCase" && slug.current == $slug && language == $language][0]`;

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -1,11 +1,14 @@
 import { groq } from "next-sanity";
 
+import { LANGUAGE_FIELD_FRAGMENT } from "studio/lib/queries/i18n";
 import { translatedFieldFragment } from "studio/lib/queries/utils/i18n";
 
-export const CUSTOMER_CASES_QUERY = groq`*[_type == "customerCase"]{
- "language": $language,
-  "basicTitle": ${translatedFieldFragment("basicTitle")},
-   "richText": ${translatedFieldFragment("richText")}}
+export const CUSTOMER_CASES_QUERY = groq`
+  *[_type == "customerCase"]{
+    ${LANGUAGE_FIELD_FRAGMENT},
+    "basicTitle": ${translatedFieldFragment("basicTitle")},
+    "richText": ${translatedFieldFragment("richText")}
+  }
 `;
 
 export const CUSTOMER_CASE_QUERY = groq`*[_type == "customerCase" && slug.current == $slug && language == $language][0]`;

--- a/studioShared/schema.ts
+++ b/studioShared/schema.ts
@@ -1,7 +1,9 @@
 import { type SchemaTypeDefinition } from "sanity";
 
+import { richText } from "studio/schemas/fields/text";
+
 import customerCases from "./schemas/documents/customerCase";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [customerCases],
+  types: [customerCases, richText],
 };

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -1,11 +1,9 @@
 import { defineField, defineType } from "sanity";
 
-import languageSchemaField from "i18n/languageSchemaField";
-import { richText, title } from "studio/schemas/fields/text";
-import {
-  isSlugUniqueAcrossDocuments,
-  titleSlug,
-} from "studio/schemas/schemaTypes/slug";
+import { isInternationalizedString } from "studio/lib/interfaces/global";
+import { richTextID, titleID } from "studio/schemas/fields/text";
+import { titleSlug } from "studio/schemas/schemaTypes/slug";
+import { firstTranslation } from "studio/utils/i18n";
 
 export const customerCaseID = "customerCase";
 
@@ -14,27 +12,35 @@ const customerCase = defineType({
   type: "document",
   title: "Customer Case",
   fields: [
-    languageSchemaField,
-    title,
+    {
+      name: titleID.basic,
+      type: "internationalizedArrayString",
+      title: "Customer Case Title",
+    },
     {
       ...titleSlug,
-      options: {
-        ...titleSlug.options,
-        isUnique: (slug, ctx) =>
-          isSlugUniqueAcrossDocuments(slug, ctx, customerCaseID),
-      },
+      type: "internationalizedArrayString",
     },
     defineField({
-      ...richText,
-      description: "Enter the body content of the Customer case.",
+      name: richTextID,
+      title: "Body",
+      type: "internationalizedArrayRichText",
     }),
   ],
   preview: {
     select: {
-      title: "basicTitle",
+      title: titleID.basic,
     },
     prepare({ title }) {
-      return { title, subtitle: "Customer case" };
+      if (!isInternationalizedString(title)) {
+        throw new TypeError(
+          `Expected 'title' to be InternationalizedString, was ${typeof title}`,
+        );
+      }
+      return {
+        title: firstTranslation(title) ?? undefined,
+        subtitle: "Customer case",
+      };
     },
   },
 });

--- a/studioShared/studioConfig.tsx
+++ b/studioShared/studioConfig.tsx
@@ -1,17 +1,15 @@
-import { documentInternationalization } from "@sanity/document-internationalization";
 import { visionTool } from "@sanity/vision";
 import { WorkspaceOptions } from "sanity";
 import { structureTool } from "sanity/structure";
+import { internationalizedArray } from "sanity-plugin-internationalized-array";
 import { media } from "sanity-plugin-media";
 
-import { languageID } from "i18n/languageSchemaField";
-import { defaultLanguage, supportedLanguages } from "i18n/supportedLanguages";
+import { supportedLanguages } from "i18n/supportedLanguages";
 import StudioIcon from "studio/components/studioIcon/StudioIcon";
 
 import { deskStructure } from "./deskStructure";
 import { apiVersion, dataset, projectId } from "./env";
 import { schema } from "./schema";
-import { customerCaseID } from "./schemas/documents/customerCase";
 
 const config: WorkspaceOptions = {
   name: "sharedStudio",
@@ -23,10 +21,6 @@ const config: WorkspaceOptions = {
   dataset,
   schema: {
     ...schema,
-    templates: (prev) =>
-      prev.filter(
-        (template) => template.value.language === defaultLanguage?.id,
-      ),
   },
   plugins: [
     structureTool({
@@ -34,14 +28,9 @@ const config: WorkspaceOptions = {
     }),
     visionTool({ defaultApiVersion: apiVersion }),
     media(),
-    documentInternationalization({
-      supportedLanguages: supportedLanguages,
-      schemaTypes: [customerCaseID],
-      languageField: languageID,
-      apiVersion,
-      // Optional. Adds UI for publishing all translations at once. Requires access to the Scheduling API
-      // https://www.sanity.io/docs/scheduling-api
-      // bulkPublish: true,
+    internationalizedArray({
+      languages: supportedLanguages,
+      fieldTypes: ["string", "richText"],
     }),
   ],
 };


### PR DESCRIPTION
This PR replace document translation with field translation in /shared. As we want to create dynamic customer cases we need to have field translations in order to retain the same structure on the customer cases depending on the language. 

Issue: [#772](https://github.com/varianter/variant.no/issues/772)