### PR TITLE
V3-customer-case-top-section

### DIFF
--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -11,7 +11,23 @@ export const CUSTOMER_CASES_QUERY = groq`
   }
 `;
 
-export const CUSTOMER_CASE_QUERY = groq`*[_type == "customerCase" && slug.current == $slug && language == $language][0]`;
+export const CUSTOMER_CASE_QUERY = groq`
+  *[_type == "customerCase" && ${translatedFieldFragment("slug")} == $slug][0] {
+    ${LANGUAGE_FIELD_FRAGMENT},
+    "slug": ${translatedFieldFragment("slug")},
+    "basicTitle": ${translatedFieldFragment("basicTitle")},
+    "description": ${translatedFieldFragment("description")},
+    "richText": ${translatedFieldFragment("richText")},
+    "projectInfo": projectInfo {
+      customer,
+      "name": ${translatedFieldFragment("name")},
+      "duration": ${translatedFieldFragment("duration")},
+      "sector": ${translatedFieldFragment("sector")},
+      "delivery": ${translatedFieldFragment("delivery")},
+      consultants
+    }
+  }
+`;
 
 export const CUSTOMER_CASES_SITEMAP_QUERY = groq`
   *[_type == "customerCase"] {

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -4,6 +4,7 @@ import { isInternationalizedString } from "studio/lib/interfaces/global";
 import { richTextID, titleID } from "studio/schemas/fields/text";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
 import { firstTranslation } from "studio/utils/i18n";
+import { customerCaseProjectInfo } from "studioShared/schemas/fields/customerCaseProjectInfo";
 
 export const customerCaseID = "customerCase";
 
@@ -12,15 +13,24 @@ const customerCase = defineType({
   type: "document",
   title: "Customer Case",
   fields: [
-    {
-      name: titleID.basic,
-      type: "internationalizedArrayString",
-      title: "Customer Case Title",
-    },
-    {
+    defineField({
       ...titleSlug,
       type: "internationalizedArrayString",
-    },
+    }),
+    defineField({
+      name: titleID.basic,
+      type: "internationalizedArrayString",
+      title: "Title",
+    }),
+    defineField({
+      name: "description",
+      type: "internationalizedArrayText",
+      title: "Description",
+      description:
+        "Short paragraph displayed at the top of the customer case page",
+    }),
+    customerCaseProjectInfo,
+    //TODO: Block section
     defineField({
       name: richTextID,
       title: "Body",

--- a/studioShared/schemas/fields/customerCaseProjectInfo.ts
+++ b/studioShared/schemas/fields/customerCaseProjectInfo.ts
@@ -1,0 +1,44 @@
+import { defineField } from "sanity";
+
+export const customerCaseProjectInfo = defineField({
+  name: "projectInfo",
+  title: "Project Info",
+  description: "General information about the project",
+  type: "object",
+  fields: [
+    defineField({
+      name: "customer",
+      description: "The customer for the project",
+      type: "string",
+    }),
+    defineField({
+      name: "name",
+      description: "The name of the project",
+      type: "internationalizedArrayString",
+    }),
+    defineField({
+      name: "duration",
+      description: "The duration of the project (e.g. 'Q2 2023 – Q1 2024')",
+      type: "internationalizedArrayString",
+    }),
+    defineField({
+      // TODO: pick from global sector tags
+      name: "sector",
+      description: "The sector of the project",
+      type: "internationalizedArrayString",
+    }),
+    defineField({
+      // TODO: pick from global delivery tags
+      name: "delivery",
+      description: "The delivery of the project",
+      type: "internationalizedArrayString",
+    }),
+    defineField({
+      // TODO: We should be able to select the consultants from a list
+      name: "consultants",
+      description: "The consultants for the project",
+      type: "array",
+      of: [{ type: "string" }],
+    }),
+  ],
+});

--- a/studioShared/studioConfig.tsx
+++ b/studioShared/studioConfig.tsx
@@ -30,7 +30,7 @@ const config: WorkspaceOptions = {
     media(),
     internationalizedArray({
       languages: supportedLanguages,
-      fieldTypes: ["string", "richText"],
+      fieldTypes: ["string", "richText", "text"],
     }),
   ],
 };


### PR DESCRIPTION
Expanded customer case document schema to include common details for a customer case project. This will be displayed in the top section of each customer case, separate from the main block-based content.

<img height="200" alt="image" src="https://github.com/user-attachments/assets/d5fa31b5-433d-4732-82ea-9fe6176894e6">

<img height="200" alt="image" src="https://github.com/user-attachments/assets/eeffcff8-dc49-44f2-9b1d-6b5aec8f1c8f">

<img height="200" alt="image" src="https://github.com/user-attachments/assets/17e1196d-4c09-4e45-890d-df1a22ba273b">

  

Based on the follow Figma sketch

<img width="300" alt="image" src="https://github.com/user-attachments/assets/19c70231-1ae8-45a2-acfc-01f5a33ee76f">


