### PR TITLE
v3 - update customer cases interface

### DIFF
--- a/src/components/customerCases/CustomerCases.tsx
+++ b/src/components/customerCases/CustomerCases.tsx
@@ -1,10 +1,9 @@
 import LinkButton from "src/components/linkButton/LinkButton";
-import { RichText } from "src/components/richText/RichText";
 import Text from "src/components/text/Text";
 import { sharedCustomerCasesLink } from "src/components/utils/linkTypes";
 import { getDraftModeInfo } from "src/utils/draftmode";
 import { CustomerCasePage } from "studio/lib/interfaces/specialPages";
-import { CustomerCase } from "studioShared/lib/interfaces/customerCases";
+import { CustomerCaseBase } from "studioShared/lib/interfaces/customerCases";
 import { CUSTOMER_CASES_QUERY } from "studioShared/lib/queries/customerCases";
 import { loadSharedQuery } from "studioShared/lib/store";
 
@@ -18,7 +17,7 @@ const CustomerCases = async ({ customerCasesPage }: CustomerCasesProps) => {
   const { perspective } = getDraftModeInfo();
 
   const [sharedCustomerCases] = await Promise.all([
-    loadSharedQuery<CustomerCase[]>(
+    loadSharedQuery<CustomerCaseBase[]>(
       CUSTOMER_CASES_QUERY,
       { language: customerCasesPage.language },
       { perspective },
@@ -29,11 +28,11 @@ const CustomerCases = async ({ customerCasesPage }: CustomerCasesProps) => {
     <div className={styles.wrapper}>
       <Text type="h1"> {customerCasesPage.basicTitle} </Text>
       {sharedCustomerCases && sharedCustomerCases.data.length > 0 ? (
-        sharedCustomerCases.data.map((customerCase: CustomerCase) => (
+        sharedCustomerCases.data.map((customerCase) => (
           <div key={customerCase._id}>
             <Text type="h2">{customerCase.basicTitle}</Text>
-            {customerCase.richText && (
-              <RichText value={customerCase.richText} />
+            {customerCase.description && (
+              <Text>{customerCase.description}</Text>
             )}
           </div>
         ))

--- a/src/components/customerCases/CustomerCasesPreview.tsx
+++ b/src/components/customerCases/CustomerCasesPreview.tsx
@@ -15,7 +15,7 @@ const CustomerCasesPreview = ({
 }: CustomerCasesPreviewProps) => {
   const { data: customerCases } = useQuery<CustomerCasePage>(
     CUSTOMER_CASES_PAGE_QUERY,
-    { slug: initialCustomerCases.data.slug.current },
+    { slug: initialCustomerCases.data.slug },
     { initial: initialCustomerCases },
   );
 

--- a/studio/lib/interfaces/specialPages.ts
+++ b/studio/lib/interfaces/specialPages.ts
@@ -1,7 +1,5 @@
 import { SeoData } from "src/utils/seo";
 
-import { Slug } from "./global";
-
 export interface CustomerCasePage {
   _createdAt: string;
   _id: string;
@@ -10,7 +8,7 @@ export interface CustomerCasePage {
   _updatedAt: string;
   basicTitle: string;
   page: string;
-  slug: Slug;
+  slug: string;
   language: string;
   seo: SeoData;
 }

--- a/studioShared/lib/interfaces/customerCases.ts
+++ b/studioShared/lib/interfaces/customerCases.ts
@@ -1,13 +1,23 @@
-import { PortableTextBlock, Slug } from "sanity";
+import { PortableTextBlock } from "sanity";
 
-export interface CustomerCase {
-  language: string;
+export interface CustomerCaseProjectInfo {
+  customer: string;
+  name: string;
+  duration: string;
+  sector: string;
+  delivery: string;
+  consultants: string[];
+}
+
+export interface CustomerCaseBase {
   _id: string;
+  language: string;
+  slug: string;
   basicTitle: string;
-  _updatedAt: string;
-  slug: Slug;
-  _createdAt: string;
-  _rev: string;
-  _type: string;
+  description: string;
+}
+
+export interface CustomerCase extends CustomerCaseBase {
   richText: PortableTextBlock[];
+  projectInfo: CustomerCaseProjectInfo;
 }

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -3,20 +3,23 @@ import { groq } from "next-sanity";
 import { LANGUAGE_FIELD_FRAGMENT } from "studio/lib/queries/i18n";
 import { translatedFieldFragment } from "studio/lib/queries/utils/i18n";
 
+const CUSTOMER_CASE_BASE_FRAGMENT = groq`
+  _id,
+  ${LANGUAGE_FIELD_FRAGMENT},
+  "slug": ${translatedFieldFragment("slug")},
+  "basicTitle": ${translatedFieldFragment("basicTitle")},
+  "description": ${translatedFieldFragment("description")}
+`;
+
 export const CUSTOMER_CASES_QUERY = groq`
   *[_type == "customerCase"]{
-    ${LANGUAGE_FIELD_FRAGMENT},
-    "basicTitle": ${translatedFieldFragment("basicTitle")},
-    "richText": ${translatedFieldFragment("richText")}
+    ${CUSTOMER_CASE_BASE_FRAGMENT}
   }
 `;
 
 export const CUSTOMER_CASE_QUERY = groq`
   *[_type == "customerCase" && ${translatedFieldFragment("slug")} == $slug][0] {
-    ${LANGUAGE_FIELD_FRAGMENT},
-    "slug": ${translatedFieldFragment("slug")},
-    "basicTitle": ${translatedFieldFragment("basicTitle")},
-    "description": ${translatedFieldFragment("description")},
+    ${CUSTOMER_CASE_BASE_FRAGMENT},
     "richText": ${translatedFieldFragment("richText")},
     "projectInfo": projectInfo {
       customer,


### PR DESCRIPTION
The interface type for customer cases was not updated when the schema was changed. This was likely because no web changes have been made yet. This PR updates the interface to match the schema. Also defined a base version of the customer case, intended to be used in list views, while the customer case interface includes all fields used on the detail page.