### PR TITLE
v3 - customer cases link

### DIFF
--- a/src/components/customerCases/CustomerCases.tsx
+++ b/src/components/customerCases/CustomerCases.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
 import { sharedCustomerCasesLink } from "src/components/utils/linkTypes";
@@ -30,7 +32,9 @@ const CustomerCases = async ({ customerCasesPage }: CustomerCasesProps) => {
       {sharedCustomerCases && sharedCustomerCases.data.length > 0 ? (
         sharedCustomerCases.data.map((customerCase) => (
           <div key={customerCase._id}>
-            <Text type="h2">{customerCase.basicTitle}</Text>
+            <Link href={`${customerCasesPage.slug}/${customerCase.slug}`}>
+              <Text type="h2">{customerCase.basicTitle}</Text>
+            </Link>
             {customerCase.description && (
               <Text>{customerCase.description}</Text>
             )}


### PR DESCRIPTION
Added `Link` to customer case titles in the customer case landing page. 

The user can then easily navigate to individual customer case detail pages (even though they are not implemented yet)

<img width="352" alt="image" src="https://github.com/user-attachments/assets/db800ee4-8022-4ba2-baec-59c44b74daf1">