### PR TITLE
v3 - customer case images block

### DIFF
--- a/studio/schemas/fields/media.ts
+++ b/studio/schemas/fields/media.ts
@@ -1,6 +1,8 @@
 import { StringInputProps, defineField } from "sanity";
 
 import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { isInternationalizedString } from "studio/lib/interfaces/global";
+import { firstTranslation } from "studio/utils/i18n";
 
 export enum ImageAlignment {
   Left = "left",
@@ -30,12 +32,45 @@ const imageAltField = defineField({
   },
 });
 
+const internationalizedImageAltField = defineField({
+  name: "alt",
+  type: "internationalizedArrayString",
+  title: "Alternative Text",
+  description:
+    "Provide a description of the image for accessibility. Leave empty if the image is purely decorative.",
+});
+
 const image = defineField({
   name: "image",
   title: "Image",
   type: "image",
   options: { hotspot: true },
   fields: [imageAltField],
+});
+
+export const internationalizedImage = defineField({
+  name: "image",
+  title: "Image",
+  type: "image",
+  options: { hotspot: true },
+  fields: [internationalizedImageAltField],
+  preview: {
+    select: {
+      alt: "alt",
+      media: "asset",
+    },
+    prepare({ alt, media }) {
+      if (!isInternationalizedString(alt)) {
+        throw new TypeError(
+          `Expected 'alt' to be InternationalizedString, was ${typeof alt}`,
+        );
+      }
+      return {
+        title: firstTranslation(alt) ?? undefined,
+        media,
+      };
+    },
+  },
 });
 
 export const imageExtended = defineField({

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -32,8 +32,13 @@ export const CUSTOMER_CASE_QUERY = groq`
     "sections": sections[] {
       _type,
       _type == "richTextBlock" => {
-        ...,
         "richText": ${translatedFieldFragment("richText")},
+      },
+      _type == "imageBlock" => {
+        "images": images[] {
+          asset,
+          "alt": ${translatedFieldFragment("alt")}
+        } 
       }
     }
   }

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -5,6 +5,7 @@ import { richTextID, titleID } from "studio/schemas/fields/text";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
 import { firstTranslation } from "studio/utils/i18n";
 import { customerCaseProjectInfo } from "studioShared/schemas/fields/customerCaseProjectInfo";
+import imageBlock from "studioShared/schemas/objects/imageBlock";
 import richTextBlock from "studioShared/schemas/objects/richTextBlock";
 
 export const customerCaseID = "customerCase";
@@ -30,13 +31,18 @@ const customerCase = defineType({
       description:
         "Short paragraph displayed at the top of the customer case page",
     }),
-    customerCaseProjectInfo,
+    defineField({
+      ...customerCaseProjectInfo,
+      options: {
+        collapsible: true,
+      },
+    }),
     defineField({
       name: "sections",
       title: "Sections",
       description: "Add sections here",
       type: "array",
-      of: [richTextBlock],
+      of: [richTextBlock, imageBlock],
     }),
     defineField({
       name: richTextID,

--- a/studioShared/schemas/objects/imageBlock.ts
+++ b/studioShared/schemas/objects/imageBlock.ts
@@ -1,0 +1,44 @@
+import { defineField } from "sanity";
+
+import { isInternationalizedString } from "studio/lib/interfaces/global";
+import { internationalizedImage } from "studio/schemas/fields/media";
+import { firstTranslation } from "studio/utils/i18n";
+
+const imageBlock = defineField({
+  name: "imageBlock",
+  title: "Image Block",
+  type: "object",
+  fields: [
+    {
+      name: "images",
+      title: "Images",
+      type: "array",
+      of: [internationalizedImage],
+    },
+  ],
+  preview: {
+    select: {
+      images: "images",
+    },
+    prepare: ({ images }) => {
+      const count = Object.keys(images).length;
+      const firstImage = count > 0 ? images[0] : undefined;
+      let firstImageAlt = null;
+      if (firstImage !== undefined) {
+        const imageAlt = firstImage.alt;
+        if (!isInternationalizedString(imageAlt)) {
+          throw new TypeError(
+            `Expected image 'alt' to be InternationalizedString, was ${typeof firstImage.alt}`,
+          );
+        }
+        firstImageAlt = firstTranslation(imageAlt);
+      }
+      return {
+        title: count > 1 ? `${count} images` : (firstImageAlt ?? undefined),
+        media: firstImage,
+      };
+    },
+  },
+});
+
+export default imageBlock;


### PR DESCRIPTION
Images block type to be used in the customer case sections array.

Allows multiple images to be uploaded into the same block.

No other fields are included, like the proposed `wide` toggle. This can be added later.

### Studio

#### Sections list preview
Shows image alt text (first translation), or number of images if multiple:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ea90cdd9-16d1-4212-8e3e-46fbc63d8999">
#### Images block
Alt text (first translation) as preview title
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e70cd14b-1c78-4ca9-b819-678387744bdc">
#### Individual image
With field-translated alt text
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e70ebc66-144d-424d-b979-fef9c4c15e86">


### Web

No UI yet, but the fetched data looks something like this:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/677ff468-7a5a-461e-bb2f-9ac6618723d5">

