### PR TITLE
V3-hotfix-imagerendering

### DIFF
--- a/src/components/customerCases/customerCase/CustomerCase.tsx
+++ b/src/components/customerCases/customerCase/CustomerCase.tsx
@@ -69,7 +69,7 @@ export default function CustomerCase({ customerCase }: CustomerCaseProps) {
                 <RichText value={section.richText} />
               ) : (
                 <div className={styles.imageBlockWrapper}>
-                  {section.images.map((image) => (
+                  {section.images?.map((image) => (
                     <div
                       key={image._key}
                       className={styles.imageBlockImageWrapper}


### PR DESCRIPTION
The customer case collapses because the system attempts to map image blocks that contain no images. This issue occurs when image data is missing or not properly handled. 