### PR TITLE
v3 - translated slug for dynamic pages

### DIFF
--- a/src/utils/pageData.ts
+++ b/src/utils/pageData.ts
@@ -63,10 +63,18 @@ async function fetchDynamicPage({
   if (!isNonNullQueryResponse(queryResponse)) {
     return null;
   }
+  const pathTranslations =
+    await loadStudioQuery<InternationalizedString | null>(
+      SLUG_FIELD_TRANSLATIONS_FROM_LANGUAGE_QUERY,
+      {
+        slug: path[0],
+        language,
+      },
+    );
   return {
     queryResponse,
     docType: pageBuilderID,
-    pathTranslations: [],
+    pathTranslations: pathTranslations.data ?? [],
   };
 }
 

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -48,6 +48,7 @@ export const SEO_FRAGMENT = groq`
 
 export const PAGE_FRAGMENT = groq`
   ...,
+  "slug": ${translatedFieldFragment("slug")},
   ${LANGUAGE_FIELD_FRAGMENT},
   ${SECTIONS_FRAGMENT},
   ${SEO_FRAGMENT}
@@ -66,16 +67,8 @@ export const PAGES_SITEMAP_QUERY = groq`
   }
 `;
 
-export const PAGE_SEO_QUERY = groq`
-  *[_type == "pageBuilder" && _id == $id][0]{
-      "title": seo.seoTitle,
-      "description": seo.seoDescription,
-      "imageUrl": seo.seoImage.asset->url
-  }
-`;
-
 export const PAGE_BY_SLUG_QUERY = groq`
-  *[_type == "pageBuilder" && slug.current == $slug][0]{
+  *[_type == "pageBuilder" && ${translatedFieldFragment("slug")} == $slug][0]{
     ${PAGE_FRAGMENT}
   }
 `;

--- a/studio/schemas/documents/pageBuilder.ts
+++ b/studio/schemas/documents/pageBuilder.ts
@@ -1,6 +1,7 @@
 import { defineField, defineType } from "sanity";
 
 import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
+import { isInternationalizedString } from "studio/lib/interfaces/global";
 import article from "studio/schemas/objects/sections/article";
 import callout from "studio/schemas/objects/sections/callout";
 import callToAction from "studio/schemas/objects/sections/callToAction";
@@ -11,6 +12,7 @@ import logoSalad from "studio/schemas/objects/sections/logoSalad";
 import testimonals from "studio/schemas/objects/sections/testimonials";
 import seo from "studio/schemas/objects/seo";
 import { pageSlug } from "studio/schemas/schemaTypes/slug";
+import { firstTranslation } from "studio/utils/i18n";
 
 export const pageBuilderID = "pageBuilder";
 
@@ -53,13 +55,17 @@ const pageBuilder = defineType({
   preview: {
     select: {
       title: "page",
-      urlSlug: "slug.current",
+      slug: pageSlug.name,
     },
-    prepare(selection) {
-      const { title, urlSlug } = selection;
+    prepare({ title, slug }) {
+      if (!isInternationalizedString(slug)) {
+        throw new TypeError(
+          `Expected 'slug' to be InternationalizedString, was ${typeof slug}`,
+        );
+      }
       return {
-        title: title,
-        subtitle: urlSlug,
+        title: title ?? undefined,
+        subtitle: firstTranslation(slug) ?? undefined,
       };
     },
   },


### PR DESCRIPTION
This adds support for translated slugs for dynamic pages (aka `pageBuilder`).

This is required to support translation of dynamic pages.