### PR TITLE
v3 - featured customer cases

### DIFF
--- a/src/app/(main)/[lang]/[...path]/page.tsx
+++ b/src/app/(main)/[lang]/[...path]/page.tsx
@@ -123,7 +123,12 @@ async function Page({ params }: Props) {
                 <CustomerCases customerCasesPage={queryResponse.data} />
               );
             case "customerCase":
-              return <CustomerCase customerCase={queryResponse.data} />;
+              return (
+                <CustomerCase
+                  customerCase={queryResponse.customerCase.data}
+                  customerCasesPagePath={queryResponse.customerCasesPagePath}
+                />
+              );
             case "legalDocument":
               return isDraftMode ? (
                 <LegalPreview initialDocument={queryResponse} />

--- a/src/components/customerCases/customerCase/CustomerCase.tsx
+++ b/src/components/customerCases/customerCase/CustomerCase.tsx
@@ -7,6 +7,7 @@ import {
 } from "studioShared/lib/interfaces/customerCases";
 
 import styles from "./customerCase.module.css";
+import FeaturedCases from "./featuredCases/FeaturedCases";
 import ImageSection from "./sections/image/ImageSection";
 import RichTextSection from "./sections/richText/RichTextSection";
 
@@ -129,6 +130,7 @@ export default function CustomerCase({ customerCase }: CustomerCaseProps) {
             <CustomerCaseSection key={section._key} section={section} />
           ))}
         </div>
+        <FeaturedCases featuredCases={customerCase.featuredCases} />
       </div>
     </div>
   );

--- a/src/components/customerCases/customerCase/CustomerCase.tsx
+++ b/src/components/customerCases/customerCase/CustomerCase.tsx
@@ -11,10 +11,6 @@ import FeaturedCases from "./featuredCases/FeaturedCases";
 import ImageSection from "./sections/image/ImageSection";
 import RichTextSection from "./sections/richText/RichTextSection";
 
-export interface CustomerCaseProps {
-  customerCase: CustomerCaseDocument;
-}
-
 function CustomerCaseSection({
   section,
 }: {
@@ -37,7 +33,15 @@ function CustomerCaseSection({
   }
 }
 
-export default function CustomerCase({ customerCase }: CustomerCaseProps) {
+export interface CustomerCaseProps {
+  customerCase: CustomerCaseDocument;
+  customerCasesPagePath: string[];
+}
+
+export default function CustomerCase({
+  customerCase,
+  customerCasesPagePath,
+}: CustomerCaseProps) {
   return (
     <div className={styles.wrapper}>
       <div className={styles.content}>
@@ -130,7 +134,13 @@ export default function CustomerCase({ customerCase }: CustomerCaseProps) {
             <CustomerCaseSection key={section._key} section={section} />
           ))}
         </div>
-        <FeaturedCases featuredCases={customerCase.featuredCases} />
+        {customerCase.featuredCases &&
+          customerCase.featuredCases.length > 0 && (
+            <FeaturedCases
+              featuredCases={customerCase.featuredCases}
+              customerCasesPath={customerCasesPagePath}
+            />
+          )}
       </div>
     </div>
   );

--- a/src/components/customerCases/customerCase/customerCase.module.css
+++ b/src/components/customerCases/customerCase/customerCase.module.css
@@ -1,11 +1,11 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  margin: 4rem 0;
+  margin: 4rem 2rem;
   align-items: center;
 
   @media (max-width: 1024px) {
-    margin: 2rem 0;
+    margin: 2rem 1rem;
   }
 }
 

--- a/src/components/customerCases/customerCase/featuredCases/FeaturedCases.tsx
+++ b/src/components/customerCases/customerCase/featuredCases/FeaturedCases.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { SanitySharedImage } from "src/components/image/SanityImage";
 import Text from "src/components/text/Text";
 import { CustomerCaseBase } from "studioShared/lib/interfaces/customerCases";
@@ -6,25 +8,35 @@ import styles from "./featuredCases.module.css";
 
 export interface FeaturedCasesProps {
   featuredCases: CustomerCaseBase[];
+  customerCasesPath: string[];
 }
 
-export default function FeaturedCases({ featuredCases }: FeaturedCasesProps) {
+export default function FeaturedCases({
+  featuredCases,
+  customerCasesPath,
+}: FeaturedCasesProps) {
   return (
-    <div className={styles.wrapper}>
-      <Text type={"h3"}>Lignende prosjekter</Text>
-      <div className={styles.content}>
-        {featuredCases.map((featuredCase) => (
-          <div key={featuredCase._id} className={styles.caseWrapper}>
-            <div className={styles.caseImageWrapper}>
-              <SanitySharedImage image={featuredCase.image} />
+    featuredCases.length > 0 && (
+      <div className={styles.wrapper}>
+        <Text type={"h3"}>Lignende prosjekter</Text>
+        <div className={styles.content}>
+          {featuredCases.map((featuredCase) => (
+            <div key={featuredCase._id} className={styles.caseWrapper}>
+              <div className={styles.caseImageWrapper}>
+                <SanitySharedImage image={featuredCase.image} />
+              </div>
+              <div>
+                <Link
+                  href={`/${[...customerCasesPath, featuredCase.slug].join("/")}`}
+                >
+                  <Text type={"bodyBig"}>{featuredCase.basicTitle}</Text>
+                </Link>
+                <Text type={"bodySmall"}>{featuredCase.description}</Text>
+              </div>
             </div>
-            <div>
-              <Text type={"bodyBig"}>{featuredCase.basicTitle}</Text>
-              <Text type={"bodySmall"}>{featuredCase.description}</Text>
-            </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
-    </div>
+    )
   );
 }

--- a/src/components/customerCases/customerCase/featuredCases/FeaturedCases.tsx
+++ b/src/components/customerCases/customerCase/featuredCases/FeaturedCases.tsx
@@ -1,0 +1,30 @@
+import { SanitySharedImage } from "src/components/image/SanityImage";
+import Text from "src/components/text/Text";
+import { CustomerCaseBase } from "studioShared/lib/interfaces/customerCases";
+
+import styles from "./featuredCases.module.css";
+
+export interface FeaturedCasesProps {
+  featuredCases: CustomerCaseBase[];
+}
+
+export default function FeaturedCases({ featuredCases }: FeaturedCasesProps) {
+  return (
+    <div className={styles.wrapper}>
+      <Text type={"h3"}>Lignende prosjekter</Text>
+      <div className={styles.content}>
+        {featuredCases.map((featuredCase) => (
+          <div key={featuredCase._id} className={styles.caseWrapper}>
+            <div className={styles.caseImageWrapper}>
+              <SanitySharedImage image={featuredCase.image} />
+            </div>
+            <div>
+              <Text type={"bodyBig"}>{featuredCase.basicTitle}</Text>
+              <Text type={"bodySmall"}>{featuredCase.description}</Text>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/customerCases/customerCase/featuredCases/featuredCases.module.css
+++ b/src/components/customerCases/customerCase/featuredCases/featuredCases.module.css
@@ -1,0 +1,34 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 4rem 0;
+}
+
+.content {
+  display: flex;
+  gap: 5rem;
+
+  @media (max-width: 1024px) {
+    flex-direction: column;
+  }
+}
+
+.caseWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 500px;
+  flex-grow: 1;
+  flex-basis: 0;
+}
+
+.caseImageWrapper {
+  width: 100%;
+  height: 200px;
+}
+
+.caseImageWrapper img {
+  border-radius: 0.75rem;
+  width: 100% !important;
+}

--- a/src/utils/pageData.ts
+++ b/src/utils/pageData.ts
@@ -148,7 +148,13 @@ async function fetchCustomerCase({
   perspective,
 }: PageDataParams): Promise<
   | PageFromParams<QueryResponseInitial<CustomerCasePage>, "customerCasesPage">
-  | PageFromParams<QueryResponseInitial<CustomerCase>, "customerCase">
+  | PageFromParams<
+      {
+        customerCase: QueryResponseInitial<CustomerCase>;
+        customerCasesPagePath: string[];
+      },
+      "customerCase"
+    >
   | null
 > {
   if (path.length === 0) {
@@ -204,7 +210,10 @@ async function fetchCustomerCase({
       },
     );
   return {
-    queryResponse: customerCaseResult,
+    queryResponse: {
+      customerCase: customerCaseResult,
+      customerCasesPagePath: [language, customerCasesPageResult.data.slug],
+    },
     docType: customerCaseID,
     pathTranslations:
       casePathTranslations.data?.reduce<InternationalizedString>(

--- a/studioShared/lib/interfaces/customerCases.ts
+++ b/studioShared/lib/interfaces/customerCases.ts
@@ -32,4 +32,5 @@ export type CustomerCaseSection = RichTextBlock | ImageBlock | QuoteBlock;
 export interface CustomerCase extends CustomerCaseBase {
   projectInfo: CustomerCaseProjectInfo;
   sections: CustomerCaseSection[];
+  featuredCases: CustomerCaseBase[];
 }

--- a/studioShared/lib/interfaces/customerCases.ts
+++ b/studioShared/lib/interfaces/customerCases.ts
@@ -32,5 +32,5 @@ export type CustomerCaseSection = RichTextBlock | ImageBlock | QuoteBlock;
 export interface CustomerCase extends CustomerCaseBase {
   projectInfo: CustomerCaseProjectInfo;
   sections: CustomerCaseSection[];
-  featuredCases: CustomerCaseBase[];
+  featuredCases?: CustomerCaseBase[] | null;
 }

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -63,6 +63,9 @@ export const CUSTOMER_CASE_QUERY = groq`
         "quote": ${translatedFieldFragment("quote")},
         "author": ${translatedFieldFragment("author")},
       },
+    },
+    "featuredCases": featuredCases[] -> {
+      ${CUSTOMER_CASE_BASE_FRAGMENT}
     }
   }
 `;

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -1,9 +1,11 @@
-import { defineField, defineType } from "sanity";
+import { groq } from "next-sanity";
+import { Reference, defineField, defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
 import { internationalizedImage } from "studio/schemas/fields/media";
 import { titleID } from "studio/schemas/fields/text";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
+import { buildDraftId, buildPublishedId } from "studio/utils/documentUtils";
 import { firstTranslation } from "studio/utils/i18n";
 import { customerCaseProjectInfo } from "studioShared/schemas/fields/customerCaseProjectInfo";
 import imageBlock from "studioShared/schemas/objects/imageBlock";
@@ -72,6 +74,51 @@ const customerCase = defineType({
       description: "Add sections here",
       type: "array",
       of: [richTextBlock, imageBlock, listBlock, quoteBlock],
+    }),
+    defineField({
+      name: "featuredCases",
+      title: "Featured Cases",
+      description:
+        "List of Customer Cases that should be displayed at the bottom of this Customer Case",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: customerCaseID }],
+          validation: (rule) =>
+            rule.custom((value: Reference, context) => {
+              if (
+                context.document !== undefined &&
+                buildPublishedId(value._ref) ===
+                  buildPublishedId(context.document._id)
+              ) {
+                return "Can not feature itself";
+              }
+              return true;
+            }),
+          options: {
+            disableNew: true,
+            filter: ({ document, parent }) => ({
+              // hide current and already featured customer cases
+              filter: groq`!(_id in $forbiddenIds)`,
+              params: {
+                forbiddenIds: [
+                  buildPublishedId(document._id),
+                  buildDraftId(document._id),
+                  ...(Array.isArray(parent)
+                    ? parent.flatMap((r) =>
+                        typeof r._ref === "string"
+                          ? [buildPublishedId(r._ref), buildDraftId(r._ref)]
+                          : undefined,
+                      )
+                    : []),
+                ],
+              },
+            }),
+          },
+        },
+      ],
+      validation: (rule) => rule.max(3).unique(),
     }),
   ],
   preview: {


### PR DESCRIPTION
See #816 

Adds a field to customer cases with a list of customer case reference, used to display a "similar projects" section at the bottom of each customer case. Currently set to a max of three featured cases.

# Sanity reference array field

<img width="665" alt="image" src="https://github.com/user-attachments/assets/cb6254b5-9ab1-4c22-9fe1-e8bed6cac023">

> the reference picker is filtered to prevent a case from featuring itself, as well as featuring a case more than once. This is just to help the user, while the validation function actually enforces these rules.

### Desktop (3 cases)
<img width="1527" alt="image" src="https://github.com/user-attachments/assets/af682974-3909-4064-819d-f3d2d8b65991">

### Mobile
<img width="456" alt="image" src="https://github.com/user-attachments/assets/d015e498-8f0f-4496-9ccb-8aeb54d96c0c">

### Desktop (2 cases)
<img width="1893" alt="image" src="https://github.com/user-attachments/assets/7ae7be9d-343d-4d5b-a29d-a0b5fb05b76c">

### Desktop (1 case)
<img width="1892" alt="image" src="https://github.com/user-attachments/assets/7e120e36-8590-4bbf-94d4-a66d0f1383a3">
