### PR TITLE
v3 - announcement banner

### DIFF
--- a/src/components/link/CustomLink.tsx
+++ b/src/components/link/CustomLink.tsx
@@ -13,6 +13,7 @@ interface ICustomLink {
   link: ILink;
   isSelected?: boolean;
   size?: "normal" | "small";
+  color?: "dark" | "light";
 }
 
 const CustomLink = ({
@@ -20,6 +21,7 @@ const CustomLink = ({
   link,
   isSelected,
   size = "normal",
+  color = "dark",
 }: ICustomLink) => {
   const href = getHref(link);
   const newTab = link.newTab;
@@ -35,7 +37,9 @@ const CustomLink = ({
     (type === "link" ? (
       <div
         className={
-          styles.wrapper + (size === "small" ? ` ${styles.sizeSmall}` : "")
+          styles.wrapper +
+          (size === "small" ? ` ${styles.sizeSmall}` : "") +
+          (color === "light" ? ` ${styles.colorLight}` : "")
         }
       >
         <Link

--- a/src/components/link/link.module.css
+++ b/src/components/link/link.module.css
@@ -7,10 +7,22 @@
   border-radius: 1.5625rem;
 }
 
+.sizeSmall.wrapper {
+  gap: 0;
+}
+
 .underline {
   width: 100%;
   height: 0.0625rem;
   background-color: var(--primary-black);
+}
+
+.colorLight .underline {
+  background-color: var(--primary-white);
+}
+
+.sizeSmall .underline {
+  margin-top: -0.125rem;
 }
 
 .link {
@@ -45,6 +57,14 @@
     -webkit-mask-size: cover;
     background-color: var(--primary-black);
     -webkit-mask: url("/_assets/arrow.svg") no-repeat 50% 50%;
+  }
+}
+
+.colorLight .link {
+  color: var(--primary-white);
+
+  &::after {
+    background-color: var(--primary-white);
   }
 }
 

--- a/src/components/navigation/header/Header.stories.tsx
+++ b/src/components/navigation/header/Header.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import { defaultLanguage } from "i18n/supportedLanguages";
 import {
+  mockAnnouncement,
   mockLogo,
   mockNavigation,
   mockPathTranslations,
@@ -30,6 +31,7 @@ export const Default: Story = {
   args: {
     navigation: mockNavigation,
     assets: mockLogo,
+    announcement: mockAnnouncement,
     currentLanguage: defaultLanguage?.id ?? "en",
     pathTranslations: mockPathTranslations,
   },

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -11,7 +11,9 @@ import LanguageSwitcher from "src/components/languageSwitcher/LanguageSwitcher";
 import CustomLink from "src/components/link/CustomLink";
 import LinkButton from "src/components/linkButton/LinkButton";
 import { BreadCrumbMenu } from "src/components/navigation/breadCrumbMenu/BreadCrumbMenu";
+import Text from "src/components/text/Text";
 import { getHref } from "src/utils/link";
+import { Announcement } from "studio/lib/interfaces/announcement";
 import { BrandAssets } from "studio/lib/interfaces/brandAssets";
 import { InternationalizedString } from "studio/lib/interfaces/global";
 import { ILink, Navigation } from "studio/lib/interfaces/navigation";
@@ -23,6 +25,7 @@ import styles from "./header.module.css";
 export interface IHeader {
   navigation: Navigation;
   assets: BrandAssets;
+  announcement: Announcement | null;
   currentLanguage: string;
   pathTitles: string[];
   pathTranslations: InternationalizedString;
@@ -35,6 +38,7 @@ const filterLinks = (data: ILink[], type: string) =>
 export const Header = ({
   navigation,
   assets,
+  announcement,
   currentLanguage,
   pathTitles,
   pathTranslations,
@@ -71,6 +75,11 @@ export const Header = ({
       window.removeEventListener("resize", handleResize);
     };
   }, []);
+
+  const showAnnouncement =
+    announcement !== null &&
+    announcement.text.length > 0 &&
+    (!announcement.hideAfter || new Date(announcement.hideAfter) > new Date());
 
   return (
     <>
@@ -126,6 +135,22 @@ export const Header = ({
               </div>
             )}
           </nav>
+          {showAnnouncement && (
+            <div className={styles.announcementWrapper}>
+              <div className={styles.announcementContent}>
+                <Text type={"bodySmall"}>{announcement.text}</Text>
+                {announcement.link && announcement.link.linkTitle && (
+                  <div>
+                    <CustomLink
+                      link={announcement.link}
+                      size={"small"}
+                      color={"light"}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
         </header>
       </FocusOn>
       {showBreadcrumbs && (

--- a/src/components/navigation/header/HeaderPreview.tsx
+++ b/src/components/navigation/header/HeaderPreview.tsx
@@ -1,16 +1,22 @@
 "use client";
 import { QueryResponseInitial, useQuery } from "@sanity/react-loader";
 
+import { Announcement } from "studio/lib/interfaces/announcement";
 import { BrandAssets } from "studio/lib/interfaces/brandAssets";
 import { InternationalizedString } from "studio/lib/interfaces/global";
 import { Navigation } from "studio/lib/interfaces/navigation";
-import { BRAND_ASSETS_QUERY, NAV_QUERY } from "studio/lib/queries/siteSettings";
+import {
+  ANNOUNCEMENT_QUERY,
+  BRAND_ASSETS_QUERY,
+  NAV_QUERY,
+} from "studio/lib/queries/siteSettings";
 
 import { Header } from "./Header";
 
 export default function HeaderPreview({
   initialNav,
   initialBrandAssets,
+  initialAnnouncement,
   currentLanguage,
   pathTitles,
   pathTranslations,
@@ -18,6 +24,7 @@ export default function HeaderPreview({
 }: {
   initialNav: QueryResponseInitial<Navigation>;
   initialBrandAssets: QueryResponseInitial<BrandAssets>;
+  initialAnnouncement: QueryResponseInitial<Announcement | null>;
   currentLanguage: string;
   pathTitles: string[];
   pathTranslations: InternationalizedString;
@@ -25,13 +32,18 @@ export default function HeaderPreview({
 }) {
   const { data: newNav } = useQuery<Navigation | null>(
     NAV_QUERY,
-    { language: initialNav.data.language },
+    { language: currentLanguage },
     { initial: initialNav },
   );
   const { data: newBrandAssets } = useQuery<BrandAssets | null>(
     BRAND_ASSETS_QUERY,
     {},
     { initial: initialBrandAssets },
+  );
+  const { data: newAnnouncement } = useQuery<Announcement | null>(
+    ANNOUNCEMENT_QUERY,
+    { language: currentLanguage },
+    { initial: initialAnnouncement },
   );
 
   return (
@@ -40,6 +52,7 @@ export default function HeaderPreview({
       <Header
         navigation={newNav}
         assets={newBrandAssets}
+        announcement={newAnnouncement}
         currentLanguage={currentLanguage}
         pathTitles={pathTitles}
         pathTranslations={pathTranslations}

--- a/src/components/navigation/header/PageHeader.tsx
+++ b/src/components/navigation/header/PageHeader.tsx
@@ -1,8 +1,14 @@
 import { getDraftModeInfo } from "src/utils/draftmode";
+import { isNonNullQueryResponse } from "src/utils/queryResponse";
+import { Announcement } from "studio/lib/interfaces/announcement";
 import { BrandAssets } from "studio/lib/interfaces/brandAssets";
 import { InternationalizedString } from "studio/lib/interfaces/global";
 import { Navigation } from "studio/lib/interfaces/navigation";
-import { BRAND_ASSETS_QUERY, NAV_QUERY } from "studio/lib/queries/siteSettings";
+import {
+  ANNOUNCEMENT_QUERY,
+  BRAND_ASSETS_QUERY,
+  NAV_QUERY,
+} from "studio/lib/queries/siteSettings";
 import { loadStudioQuery } from "studio/lib/store";
 
 import { Header } from "./Header";
@@ -35,19 +41,20 @@ export default async function PageHeader({
     { perspective },
   );
 
+  const initialAnnouncement = await loadStudioQuery<Announcement | null>(
+    ANNOUNCEMENT_QUERY,
+    { language },
+    { perspective },
+  );
+
   return (
-    initialBrandAssets.data !== null &&
-    initialNav.data !== null &&
+    isNonNullQueryResponse(initialBrandAssets) &&
+    isNonNullQueryResponse(initialNav) &&
     (isDraftMode ? (
       <HeaderPreview
-        initialNav={{
-          ...initialNav,
-          data: initialNav.data,
-        }}
-        initialBrandAssets={{
-          ...initialBrandAssets,
-          data: initialBrandAssets.data,
-        }}
+        initialNav={initialNav}
+        initialBrandAssets={initialBrandAssets}
+        initialAnnouncement={initialAnnouncement}
         currentLanguage={language}
         pathTitles={pathTitles}
         pathTranslations={pathTranslations}
@@ -57,6 +64,7 @@ export default async function PageHeader({
       <Header
         navigation={initialNav.data}
         assets={initialBrandAssets.data}
+        announcement={initialAnnouncement.data}
         currentLanguage={language}
         pathTitles={pathTitles}
         pathTranslations={pathTranslations}

--- a/src/components/navigation/header/header.module.css
+++ b/src/components/navigation/header/header.module.css
@@ -145,3 +145,27 @@
   composes: button;
   background: url("/_assets/menu-close.svg") no-repeat 50% 50%;
 }
+
+.announcementWrapper {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem;
+  background-color: var(--primary-bg-blue);
+  align-items: center;
+}
+
+.announcementContent {
+  display: flex;
+  gap: 2rem;
+
+  @media (max-width: 1024px) {
+    align-items: center;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
+.announcementContent p {
+  font-weight: 600;
+  color: var(--primary-white);
+}

--- a/src/components/navigation/mockData.ts
+++ b/src/components/navigation/mockData.ts
@@ -1,5 +1,6 @@
 import primaryLogoFile from "src/stories/assets/energiai-primary-logo.svg";
 import secondaryLogoFile from "src/stories/assets/energiai-secondary-logo.svg";
+import { Announcement } from "studio/lib/interfaces/announcement";
 import { InternationalizedString } from "studio/lib/interfaces/global";
 import {
   LinkType,
@@ -129,6 +130,14 @@ export const mockLogo = {
     alt: "Secondary Logo",
   },
   favicon: {},
+};
+
+export const mockAnnouncement: Announcement = {
+  language: "no",
+  text: "Mandag 21.10. er det TDC! Møt oss der!",
+  hideAfter: new Date(
+    new Date().setMonth(new Date().getMonth() + 1),
+  ).toISOString(),
 };
 
 // Mock Social Media Profiles

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,7 @@ html {
   --primary-light: #f5a4c4;
   --primary-bg: #f2f2f2;
   --primary-bg-dark: #d9d9d9;
+  --primary-bg-blue: #0014cd;
 
   --primary-white-bright: #ffffff;
   --primary-white: #faf8f5;

--- a/studio/deskStructure.ts
+++ b/studio/deskStructure.ts
@@ -1,6 +1,7 @@
 import {
   CaseIcon,
   CogIcon,
+  ConfettiIcon,
   EarthGlobeIcon,
   HeartIcon,
   ImagesIcon,
@@ -22,6 +23,7 @@ import { legalDocumentID } from "./schemas/documents/admin/legalDocuments";
 import { compensationsId } from "./schemas/documents/compensations";
 import { languageSettingsID } from "./schemas/documents/languageSettings";
 import { pageBuilderID } from "./schemas/documents/pageBuilder";
+import { announcementID } from "./schemas/documents/siteSettings/announcement";
 import { brandAssetsID } from "./schemas/documents/siteSettings/brandAssets";
 import { localeID } from "./schemas/documents/siteSettings/locale";
 import { soMeLinksID } from "./schemas/documents/siteSettings/socialMediaProfiles";
@@ -119,6 +121,15 @@ const siteSettingSection = (S: StructureBuilder) =>
                 .schemaType(defaultSeoID)
                 .documentId(defaultSeoID)
                 .title("Default SEO"),
+            ),
+          S.listItem()
+            .title("Announcement")
+            .icon(ConfettiIcon)
+            .child(
+              S.document()
+                .schemaType(announcementID)
+                .documentId(announcementID)
+                .title("Announcement"),
             ),
         ]),
     );

--- a/studio/lib/interfaces/announcement.ts
+++ b/studio/lib/interfaces/announcement.ts
@@ -1,0 +1,8 @@
+import { ILink } from "./navigation";
+
+export interface Announcement {
+  language: string;
+  text: string;
+  link?: ILink;
+  hideAfter?: string;
+}

--- a/studio/lib/queries/siteSettings.ts
+++ b/studio/lib/queries/siteSettings.ts
@@ -87,3 +87,16 @@ export const DEFAULT_SEO_QUERY = groq`
     ${SEO_FRAGMENT}
   }
 `;
+
+// Announcement
+export const ANNOUNCEMENT_QUERY = groq`
+  *[_type == "announcement"][0]{
+    ${LANGUAGE_FIELD_FRAGMENT},
+    "text": ${translatedFieldFragment("text")},
+    "link": link {
+      ...,
+      ${TRANSLATED_LINK_FRAGMENT}
+    },
+    hideAfter
+  }
+`;

--- a/studio/schema.ts
+++ b/studio/schema.ts
@@ -7,6 +7,7 @@ import legalDocument from "./schemas/documents/admin/legalDocuments";
 import compensations from "./schemas/documents/compensations";
 import languageSettings from "./schemas/documents/languageSettings";
 import pageBuilder from "./schemas/documents/pageBuilder";
+import announcement from "./schemas/documents/siteSettings/announcement";
 import brandAssets from "./schemas/documents/siteSettings/brandAssets";
 import locale from "./schemas/documents/siteSettings/locale";
 import navigationManager from "./schemas/documents/siteSettings/navigationManager";
@@ -41,5 +42,6 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     locale,
     richText,
     seo,
+    announcement,
   ],
 };

--- a/studio/schemas/documents/siteSettings/announcement.ts
+++ b/studio/schemas/documents/siteSettings/announcement.ts
@@ -1,0 +1,36 @@
+import { defineField, defineType } from "sanity";
+
+import { link } from "studio/schemas/objects/link";
+
+export const announcementID = "announcement";
+
+const announcement = defineType({
+  name: announcementID,
+  type: "document",
+  title: "Announcement",
+  description: "Message displayed in a banner at the top of each page.",
+  fields: [
+    defineField({
+      name: "text",
+      type: "internationalizedArrayString",
+      title: "Text",
+    }),
+    link,
+    defineField({
+      name: "hideAfter",
+      type: "datetime",
+      title: "Hide After",
+      description:
+        "The announcement will be hidden after the specified date and time.",
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: "Announcement",
+      };
+    },
+  },
+});
+
+export default announcement;


### PR DESCRIPTION
See #819 

Adds a site setting for defining a page announcement, displayed in the header of each page. In addition to a required text, an optional link and "expiration date" can be added. If no date is specified, the announcement is always displayed, otherwise the date is compared to the current time.

To remove the announcement manually, the document can simply be unpublished or deleted.

**with link**

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/e2730252-9541-466d-97ce-9f2a479e5372">

<img width="429" alt="image" src="https://github.com/user-attachments/assets/43a30a72-9e36-4d84-92b6-95e7dec28b0b">

**without link**

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/35c93766-460e-4660-adb6-2cf40f10114f">

<img width="465" alt="image" src="https://github.com/user-attachments/assets/748f7445-f2e0-4874-827f-993f04fca8a7">

**Studio**

<img width="718" alt="image" src="https://github.com/user-attachments/assets/5aad7d2e-4234-406b-904b-1090790e4047">

