### PR TITLE
v3 - dynamic page basic title

### DIFF
--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -105,7 +105,7 @@ export interface PageBuilder {
   _type: string;
   _updatedAt: string;
   language: string;
-  page: string;
+  basicTitle: string;
   sections: Section[];
   slug: Slug;
   seo: SeoData;

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -52,6 +52,7 @@ export const SEO_FRAGMENT = groq`
 export const PAGE_FRAGMENT = groq`
   ...,
   "slug": ${translatedFieldFragment("slug")},
+  "basicTitle": ${translatedFieldFragment("basicTitle")},
   ${LANGUAGE_FIELD_FRAGMENT},
   ${SECTIONS_FRAGMENT},
   ${SEO_FRAGMENT}

--- a/studio/schemas/documents/pageBuilder.ts
+++ b/studio/schemas/documents/pageBuilder.ts
@@ -1,7 +1,7 @@
 import { defineField, defineType } from "sanity";
 
-import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
 import { isInternationalizedString } from "studio/lib/interfaces/global";
+import { titleID } from "studio/schemas/fields/text";
 import article from "studio/schemas/objects/sections/article";
 import callout from "studio/schemas/objects/sections/callout";
 import callToAction from "studio/schemas/objects/sections/callToAction";
@@ -12,7 +12,7 @@ import imageSection from "studio/schemas/objects/sections/image";
 import logoSalad from "studio/schemas/objects/sections/logoSalad";
 import testimonals from "studio/schemas/objects/sections/testimonials";
 import seo from "studio/schemas/objects/seo";
-import { pageSlug } from "studio/schemas/schemaTypes/slug";
+import { titleSlug } from "studio/schemas/schemaTypes/slug";
 import { firstTranslation } from "studio/utils/i18n";
 
 export const pageBuilderID = "pageBuilder";
@@ -22,20 +22,15 @@ const pageBuilder = defineType({
   type: "document",
   title: "Dynamic pages",
   fields: [
-    defineField({
-      name: "page",
-      title: "Page name",
-      description:
-        "Enter a distinctive name for the dynamic page to help content editors easily identify and manage it. This name is used internally and is not visible on your website.",
-      type: "string",
-      validation: (rule) => rule.required().max(30),
-      components: {
-        input: (props) =>
-          StringInputWithCharacterCount({ ...props, maxCount: 30 }),
-      },
-    }),
     {
-      ...pageSlug,
+      name: titleID.basic,
+      type: "internationalizedArrayString",
+      title: "Page Title",
+      description:
+        "Enter the primary title that will be displayed in Sanity and the breadcrumb trail at the top of the page.",
+    },
+    {
+      ...titleSlug,
       type: "internationalizedArrayString",
     },
     seo,
@@ -59,17 +54,22 @@ const pageBuilder = defineType({
   ],
   preview: {
     select: {
-      title: "page",
-      slug: pageSlug.name,
+      title: titleID.basic,
+      slug: titleSlug.name,
     },
     prepare({ title, slug }) {
+      if (!isInternationalizedString(title)) {
+        throw new TypeError(
+          `Expected 'title' to be InternationalizedString, was ${typeof title}`,
+        );
+      }
       if (!isInternationalizedString(slug)) {
         throw new TypeError(
           `Expected 'slug' to be InternationalizedString, was ${typeof slug}`,
         );
       }
       return {
-        title: title ?? undefined,
+        title: firstTranslation(title) ?? undefined,
         subtitle: firstTranslation(slug) ?? undefined,
       };
     },


### PR DESCRIPTION
Changed dynamic pages schema (aka pageBuilder) to use i18n title. 

This is to prepare for proper breadcrumb titles.

<img width="710" alt="image" src="https://github.com/user-attachments/assets/21b0be5f-f5be-4305-99a6-8927643c3a66">
