### PR TITLE
v3 - proper breadcrumb titles

### DIFF
--- a/src/app/(main)/[lang]/[...path]/page.tsx
+++ b/src/app/(main)/[lang]/[...path]/page.tsx
@@ -98,11 +98,16 @@ async function Page({ params }: Props) {
     return Page404;
   }
 
-  const { queryResponse, docType, pathTranslations } = pageData;
+  const { queryResponse, docType, pathTitles, pathTranslations } = pageData;
 
   return (
     <>
-      <PageHeader language={lang} pathTranslations={pathTranslations} />
+      <PageHeader
+        language={lang}
+        pathTitles={pathTitles}
+        pathTranslations={pathTranslations}
+        showBreadcrumbs={true}
+      />
       <main id={"main"} tabIndex={-1}>
         {(() => {
           switch (docType) {

--- a/src/app/(main)/[lang]/page.tsx
+++ b/src/app/(main)/[lang]/page.tsx
@@ -71,7 +71,12 @@ const Home = async ({ params }: Props) => {
 
   return (
     <>
-      <PageHeader language={params.lang} pathTranslations={pathTranslations} />
+      <PageHeader
+        language={params.lang}
+        pathTranslations={pathTranslations}
+        pathTitles={[]}
+        showBreadcrumbs={false}
+      />
       <main id={"main"} tabIndex={-1}>
         {initialLandingPage.data.sections.map((section, index) => (
           <SectionRenderer

--- a/src/components/navigation/breadCrumbMenu/BreadCrumbMenu.tsx
+++ b/src/components/navigation/breadCrumbMenu/BreadCrumbMenu.tsx
@@ -6,11 +6,13 @@ import styles from "./breadCrumbMenu.module.css";
 
 export interface BreadCrumbProps {
   currentLanguage: string;
+  pathTitles: string[];
   pathname: string;
 }
 
 export const BreadCrumbMenu = ({
   currentLanguage,
+  pathTitles,
   pathname,
 }: BreadCrumbProps) => {
   return (
@@ -18,13 +20,16 @@ export const BreadCrumbMenu = ({
       {/* TODO: "Hjem" should be updated with translation */}
       {[
         "Hjem",
-        ...(pathname.includes("/" + currentLanguage + "/")
+        ...(pathname.includes(`/${currentLanguage}/`)
           ? pathname.split("/").slice(2)
           : pathname.split("/").slice(1)),
       ].map((slug, index, path) => {
-        const href =
-          "/" + currentLanguage + "/" + path.slice(1, index + 1).join("/");
+        const href = `/${currentLanguage}/${path.slice(1, index + 1).join("/")}`;
         const isLast = index === path.length - 1;
+        const title =
+          index === 0 || pathTitles.length < index
+            ? slug
+            : pathTitles[index - 1];
 
         return (
           <li key={index} className={styles.breadCrumb}>
@@ -44,8 +49,7 @@ export const BreadCrumbMenu = ({
                 }
                 type={isLast ? "labelSemibold" : "desktopLink"}
               >
-                {slug.charAt(0).toUpperCase() +
-                  (slug.length > 1 ? slug.slice(1).toLowerCase() : "")}
+                {title}
               </Text>
             </Link>
           </li>

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -24,7 +24,9 @@ export interface IHeader {
   navigation: Navigation;
   assets: BrandAssets;
   currentLanguage: string;
+  pathTitles: string[];
   pathTranslations: InternationalizedString;
+  showBreadcrumbs: boolean;
 }
 
 const filterLinks = (data: ILink[], type: string) =>
@@ -34,7 +36,9 @@ export const Header = ({
   navigation,
   assets,
   currentLanguage,
+  pathTitles,
   pathTranslations,
+  showBreadcrumbs,
 }: IHeader) => {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
@@ -124,8 +128,12 @@ export const Header = ({
           </nav>
         </header>
       </FocusOn>
-      {pathname !== "/" && pathname !== "/" + currentLanguage && (
-        <BreadCrumbMenu currentLanguage={currentLanguage} pathname={pathname} />
+      {showBreadcrumbs && (
+        <BreadCrumbMenu
+          currentLanguage={currentLanguage}
+          pathTitles={pathTitles}
+          pathname={pathname}
+        />
       )}
     </>
   );

--- a/src/components/navigation/header/HeaderPreview.tsx
+++ b/src/components/navigation/header/HeaderPreview.tsx
@@ -12,12 +12,16 @@ export default function HeaderPreview({
   initialNav,
   initialBrandAssets,
   currentLanguage,
+  pathTitles,
   pathTranslations,
+  showBreadcrumbs,
 }: {
   initialNav: QueryResponseInitial<Navigation>;
   initialBrandAssets: QueryResponseInitial<BrandAssets>;
   currentLanguage: string;
+  pathTitles: string[];
   pathTranslations: InternationalizedString;
+  showBreadcrumbs: boolean;
 }) {
   const { data: newNav } = useQuery<Navigation | null>(
     NAV_QUERY,
@@ -37,7 +41,9 @@ export default function HeaderPreview({
         navigation={newNav}
         assets={newBrandAssets}
         currentLanguage={currentLanguage}
+        pathTitles={pathTitles}
         pathTranslations={pathTranslations}
+        showBreadcrumbs={showBreadcrumbs}
       />
     )
   );

--- a/src/components/navigation/header/PageHeader.tsx
+++ b/src/components/navigation/header/PageHeader.tsx
@@ -10,12 +10,16 @@ import HeaderPreview from "./HeaderPreview";
 
 interface PageHeaderProps {
   language: string;
+  pathTitles: string[];
   pathTranslations: InternationalizedString;
+  showBreadcrumbs: boolean;
 }
 
 export default async function PageHeader({
   language,
+  pathTitles,
   pathTranslations,
+  showBreadcrumbs,
 }: PageHeaderProps) {
   const { perspective, isDraftMode } = getDraftModeInfo();
 
@@ -45,14 +49,18 @@ export default async function PageHeader({
           data: initialBrandAssets.data,
         }}
         currentLanguage={language}
+        pathTitles={pathTitles}
         pathTranslations={pathTranslations}
+        showBreadcrumbs={showBreadcrumbs}
       />
     ) : (
       <Header
         navigation={initialNav.data}
         assets={initialBrandAssets.data}
         currentLanguage={language}
+        pathTitles={pathTitles}
         pathTranslations={pathTranslations}
+        showBreadcrumbs={showBreadcrumbs}
       />
     ))
   );

--- a/studio/lib/queries/siteSettings.ts
+++ b/studio/lib/queries/siteSettings.ts
@@ -60,6 +60,13 @@ export const EMPLOYEE_PAGE_SLUG_QUERY = groq`
   }
 `;
 
+export const EMPLOYEE_PAGE_SLUG_AND_TITLE_QUERY = groq`
+  *[_type == "navigationManager"][0].employeesPage -> {
+    "slug": ${translatedFieldFragment("slug")},
+    "basicTitle": ${translatedFieldFragment("basicTitle")}
+  }
+`;
+
 //Social Media Profiles
 export const SOME_PROFILES_QUERY = groq`
   *[_type == "soMeLinksID" && _id == "soMeLinksID"][0]


### PR DESCRIPTION
See #842 

Extended page data to include an array of page titles. This is then used to display the actual page titles for each segment in the breadcrumb trail.

Before | After
--- | ---
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/2de7c6e4-e794-411b-89bb-cb676e8410ec"> | <img width="1500" alt="image" src="https://github.com/user-attachments/assets/1ed8acea-30ef-4707-b714-ebafb276077f">
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/a26fe944-4f5d-4fd3-b9b5-1635381bb80a"> | <img width="1500" alt="image" src="https://github.com/user-attachments/assets/3adefa31-70f3-4354-99b0-b27fdfd7f77e">
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/bed5fc32-e4ae-4ca7-b0bc-ee519a6ada71"> | <img width="1500" alt="image" src="https://github.com/user-attachments/assets/f5e672a6-d4d2-44c1-a097-833018387d8e">
