### PR TITLE
v3 - highlighted rich text section

### DIFF
--- a/src/components/customerCases/customerCase/sections/richText/RichTextSection.tsx
+++ b/src/components/customerCases/customerCase/sections/richText/RichTextSection.tsx
@@ -10,8 +10,14 @@ export interface RichTextSectionProps {
 export default function RichTextSection({ section }: RichTextSectionProps) {
   return (
     <div className={styles.wrapper}>
-      <div className={styles.content}>
-        <RichText value={section.richText} />
+      <div
+        className={
+          styles.content + (section.highlighted ? ` ${styles.highlighted}` : "")
+        }
+      >
+        <div className={styles.innerContent}>
+          <RichText value={section.richText} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/customerCases/customerCase/sections/richText/richTextSection.module.css
+++ b/src/components/customerCases/customerCase/sections/richText/richTextSection.module.css
@@ -7,3 +7,15 @@
 .content {
   max-width: 960px;
 }
+
+.content.highlighted {
+  border: 2px solid var(--primary-yellow-warning);
+  border-radius: 0.25rem;
+  background-color: var(--primary-yellow-warning);
+}
+
+.highlighted .innerContent {
+  background-color: var(--primary-bg);
+  border-radius: 1.25rem;
+  padding: 1rem;
+}

--- a/studioShared/lib/interfaces/richTextBlock.ts
+++ b/studioShared/lib/interfaces/richTextBlock.ts
@@ -4,4 +4,5 @@ export interface RichTextBlock {
   _key: string;
   _type: "richTextBlock";
   richText: PortableTextBlock[];
+  highlighted?: boolean;
 }

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -31,6 +31,7 @@ export const CUSTOMER_CASES_QUERY = groq`
 export const BASE_SECTIONS_FRAGMENT = groq`
   _type == "richTextBlock" => {
     "richText": ${translatedFieldFragment("richText")},
+    highlighted
   },
   _type == "imageBlock" => {
     "images": images[] {

--- a/studioShared/schemas/objects/richTextBlock.ts
+++ b/studioShared/schemas/objects/richTextBlock.ts
@@ -14,12 +14,20 @@ const richTextBlock = defineField({
       title: "Rich Text",
       type: "internationalizedArrayRichText",
     },
+    {
+      name: "highlighted",
+      title: "Highlighted",
+      type: "boolean",
+      description: "Display the rich text with a highlight frame",
+      initialValue: false,
+    },
   ],
   preview: {
     select: {
       richText: "richText",
+      highlighted: "highlighted",
     },
-    prepare({ richText }) {
+    prepare({ richText, highlighted }) {
       if (!isInternationalizedRichText(richText)) {
         throw new TypeError(
           `Expected 'richText' to be InternationalizedRichText, was ${typeof richText}`,
@@ -30,6 +38,10 @@ const richTextBlock = defineField({
         title:
           translatedRichText !== null
             ? richTextPreview(translatedRichText)
+            : undefined,
+        subtitle:
+          typeof highlighted === "boolean" && highlighted
+            ? "Highlighted"
             : undefined,
       };
     },


### PR DESCRIPTION
See #827 

Added option to highlight a rich text section. When toggled, the rich text will be wrapped in a yellow frame.

**Studio**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/fbe00e93-2a67-4683-b51e-636947611368">
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cbf7670b-1ed9-4061-874b-10773c389d32">



**Customer case**

![highlight](https://github.com/user-attachments/assets/4f6f9350-51c6-46e8-b7d3-6f8a0cef63e0)
