### PR TITLE
V3 customer case block results

### DIFF
--- a/src/components/customerCases/customerCase/sections/CustomerCaseSection.tsx
+++ b/src/components/customerCases/customerCase/sections/CustomerCaseSection.tsx
@@ -2,6 +2,7 @@ import { CustomerCaseSection as CustomerCaseSectionObject } from "studioShared/l
 
 import ImageSection from "./image/ImageSection";
 import QuoteBlock from "./quote/QuoteBlock";
+import ResultBlock from "./results/ResultBlock";
 import RichTextSection from "./richText/RichTextSection";
 import SplitSection from "./splitSection/SplitSection";
 
@@ -19,5 +20,7 @@ export function CustomerCaseSection({
       return <QuoteBlock section={section} />;
     case "imageBlock":
       return <ImageSection section={section} />;
+    case "resultBlock":
+      return <ResultBlock section={section} />;
   }
 }

--- a/src/components/customerCases/customerCase/sections/results/ResultBlock.tsx
+++ b/src/components/customerCases/customerCase/sections/results/ResultBlock.tsx
@@ -1,0 +1,32 @@
+import Text from "src/components/text/Text";
+import { ResultBlock as ResultBlockObject } from "studioShared/lib/interfaces/resultBlock";
+
+import styles from "./resultBlock.module.css";
+
+export interface ResultBlockProps {
+  section: ResultBlockObject;
+}
+
+export default function QuoteBlock({ section }: ResultBlockProps) {
+  return (
+    section.resultBlockTitle && (
+      <div className={styles.wrapper}>
+        <div className={styles.resultblock}>
+          <Text type="h4" className={styles.blocktitle}>
+            {section.resultBlockTitle}
+          </Text>
+          <div className={styles.resultrow}>
+            {section.resultList?.map((result) => (
+              <div className={styles.results} key={result._key}>
+                <Text type="h2" className={styles.mainresult}>
+                  {result.result}
+                </Text>
+                <Text type="labelRegular">{result.description}</Text>
+              </div>
+            ))}{" "}
+          </div>
+        </div>
+      </div>
+    )
+  );
+}

--- a/src/components/customerCases/customerCase/sections/results/resultBlock.module.css
+++ b/src/components/customerCases/customerCase/sections/results/resultBlock.module.css
@@ -1,0 +1,46 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.resultblock {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2.25rem;
+    max-width: 960px;
+    width: 100%;
+}
+
+.blocktitle {
+    font-size: 1.5rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 120%;
+}
+
+.resultrow {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    align-self: stretch;
+    text-wrap: wrap;
+}
+
+.results {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    max-width: 20%;
+    align-items: center;
+}
+
+.mainresult{
+    color:  var(--blue-dark);
+    font-size: 3rem;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 120%;
+}

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,14 +1,17 @@
-.desktopLink,
+/*
+---- Declaring color here will overwrite any other color applied later
+:where(.desktopLink,
 .h1,
 .h2,
 .h3,
 .h4,
 .h5,
 .h6,
-.bodyXl {
-  color: var(--primary-black);
+.bodyXl) {
+ color: var(--primary-black);
   font-family: var(--font-britti-sans);
 }
+*/
 
 .bodyBig,
 .bodyNormal,
@@ -24,8 +27,8 @@
 .bodyNormal,
 .bodyBig,
 .list {
-  color: var(--primary-black);
-  font-family: var(--font-britti-sans);
+  /*color: var(--primary-black);
+  font-family: var(--font-britti-sans);*/
   line-height: 140%;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,6 +27,8 @@ html {
 
   --focus-color: #8b0f40;
 
+  --blue-dark: #0014CD;
+
   /* TODO: upgrade color-scheme with correct colors */
   --secondary-red: #f0503f;
 
@@ -47,6 +49,7 @@ body {
   width: 100vw;
   background-color: var(--primary-bg);
   font-family: var(--font-britti-sans);
+  color: var(--primary-black);
 }
 
 h1,

--- a/studioShared/lib/interfaces/customerCases.ts
+++ b/studioShared/lib/interfaces/customerCases.ts
@@ -29,13 +29,12 @@ export interface CustomerCaseBase {
   image: IImage;
 }
 
-export type BaseCustomerCaseSection =
-  | RichTextBlock
-  | ImageBlock
-  | QuoteBlock
-  | ResultBlock;
+export type BaseCustomerCaseSection = RichTextBlock | ImageBlock | QuoteBlock;
 
-export type CustomerCaseSection = BaseCustomerCaseSection | SplitSection;
+export type CustomerCaseSection =
+  | BaseCustomerCaseSection
+  | SplitSection
+  | ResultBlock;
 
 export interface CustomerCase extends CustomerCaseBase {
   projectInfo: CustomerCaseProjectInfo;

--- a/studioShared/lib/interfaces/customerCases.ts
+++ b/studioShared/lib/interfaces/customerCases.ts
@@ -2,6 +2,7 @@ import { IImage } from "studio/lib/interfaces/media";
 
 import { ImageBlock } from "./imageBlock";
 import { QuoteBlock } from "./quoteBlock";
+import { ResultBlock } from "./resultBlock";
 import { RichTextBlock } from "./richTextBlock";
 
 export interface CustomerCaseProjectInfo {
@@ -27,7 +28,12 @@ export interface CustomerCaseBase {
   image: IImage;
 }
 
-export type CustomerCaseSections = (RichTextBlock | ImageBlock | QuoteBlock)[];
+export type CustomerCaseSections = (
+  | RichTextBlock
+  | ImageBlock
+  | QuoteBlock
+  | ResultBlock
+)[];
 
 export interface CustomerCase extends CustomerCaseBase {
   projectInfo: CustomerCaseProjectInfo;

--- a/studioShared/lib/interfaces/resultBlock.ts
+++ b/studioShared/lib/interfaces/resultBlock.ts
@@ -1,6 +1,7 @@
 interface ResultListItem {
   result: string;
   description: string;
+  _key: string;
 }
 
 export interface ResultBlock {

--- a/studioShared/lib/interfaces/resultBlock.ts
+++ b/studioShared/lib/interfaces/resultBlock.ts
@@ -1,0 +1,11 @@
+interface ResultListItem {
+  result: string;
+  description: string;
+}
+
+export interface ResultBlock {
+  _key: string;
+  _type: "resultBlock";
+  resultBlockTitle?: string;
+  resultList?: ResultListItem[];
+}

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -62,6 +62,13 @@ export const CUSTOMER_CASE_QUERY = groq`
         "quote": ${translatedFieldFragment("quote")},
         "author": ${translatedFieldFragment("author")},
       },
+      _type == "resultBlock" => {
+        "resultBlockTitle": ${translatedFieldFragment("resultBlockTitle")},
+        "resultList": resultList[] {
+          result,
+          "description": ${translatedFieldFragment("description")},
+          }
+        }
     }
   }
 `;

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -48,13 +48,6 @@ export const BASE_SECTIONS_FRAGMENT = groq`
     "quote": ${translatedFieldFragment("quote")},
     "author": ${translatedFieldFragment("author")},
   },
-  _type == "resultBlock" => {
-        "resultBlockTitle": ${translatedFieldFragment("resultBlockTitle")},
-        "resultList": resultList[] {
-          result,
-          "description": ${translatedFieldFragment("description")},
-          }
-        }
 `;
 
 export const CUSTOMER_CASE_QUERY = groq`
@@ -81,6 +74,14 @@ export const CUSTOMER_CASE_QUERY = groq`
           ${BASE_SECTIONS_FRAGMENT}
         }
       },
+      _type == "resultBlock" => {
+        "resultBlockTitle": ${translatedFieldFragment("resultBlockTitle")},
+        "resultList": resultList[] {
+          _key,
+          result,
+          "description": ${translatedFieldFragment("description")},
+          }
+        },
       ${BASE_SECTIONS_FRAGMENT}
     },
     "featuredCases": featuredCases[] -> {

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -9,6 +9,7 @@ import { customerCaseProjectInfo } from "studioShared/schemas/fields/customerCas
 import imageBlock from "studioShared/schemas/objects/imageBlock";
 import listBlock from "studioShared/schemas/objects/listBlock";
 import quoteBlock from "studioShared/schemas/objects/quoteBlock";
+import resultBlock from "studioShared/schemas/objects/resultBlock";
 import richTextBlock from "studioShared/schemas/objects/richTextBlock";
 
 export const customerCaseID = "customerCase";
@@ -71,7 +72,7 @@ const customerCase = defineType({
       title: "Sections",
       description: "Add sections here",
       type: "array",
-      of: [richTextBlock, imageBlock, listBlock, quoteBlock],
+      of: [richTextBlock, imageBlock, listBlock, quoteBlock, resultBlock],
     }),
   ],
   preview: {

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -8,12 +8,17 @@ import { titleSlug } from "studio/schemas/schemaTypes/slug";
 import { buildDraftId, buildPublishedId } from "studio/utils/documentUtils";
 import { firstTranslation } from "studio/utils/i18n";
 import { customerCaseProjectInfo } from "studioShared/schemas/fields/customerCaseProjectInfo";
+import resultBlock from "studioShared/schemas/objects/resultBlock";
 import { baseCustomerCaseSections } from "studioShared/schemas/objects/sections";
 import splitSection from "studioShared/schemas/objects/splitSection";
 
 export const customerCaseID = "customerCase";
 
-export const customerCaseSections = [...baseCustomerCaseSections, splitSection];
+export const customerCaseSections = [
+  ...baseCustomerCaseSections,
+  splitSection,
+  resultBlock,
+];
 
 const customerCase = defineType({
   name: customerCaseID,

--- a/studioShared/schemas/objects/resultBlock.ts
+++ b/studioShared/schemas/objects/resultBlock.ts
@@ -44,8 +44,9 @@ const resultBlock = defineField({
           preview: {
             select: {
               item: "description",
+              subtitle: "result",
             },
-            prepare({ item }) {
+            prepare({ item, subtitle }) {
               if (item !== undefined && !isInternationalizedString(item)) {
                 throw new TypeError(
                   `Expected 'title' to be InternationalizedString, was ${typeof item}`,
@@ -56,6 +57,7 @@ const resultBlock = defineField({
                   item !== undefined
                     ? (firstTranslation(item) ?? undefined)
                     : undefined,
+                subtitle: subtitle,
               };
             },
           },

--- a/studioShared/schemas/objects/resultBlock.ts
+++ b/studioShared/schemas/objects/resultBlock.ts
@@ -1,30 +1,84 @@
 import { defineField } from "sanity";
 
+import { isInternationalizedString } from "studio/lib/interfaces/global";
 import { firstTranslation } from "studio/utils/i18n";
 
 const resultBlock = defineField({
   name: "resultBlock",
   type: "object",
   title: "Result Block",
+  description: "This block can be used to add some results from the project.",
   fields: [
     {
-      name: "result",
-      type: "string",
-      title: "Result",
-      description: "Add result, eg. '+ 72%'",
+      name: "resultBlockTitle",
+      title: "Result Block Title",
+      description:
+        "Please provide a title for the result block, for example: 'These are the results from the project'",
+      type: "internationalizedArrayString",
     },
     {
-      name: "description",
-      type: "internationalizedArrayText",
-      title: "Description of the result, eg. 'Satisfied users'",
+      name: "resultList",
+      title: "List of results",
+      description: "Add up to five results to be included in this list",
+      type: "array",
+      validation: (rule) =>
+        rule.max(5).error("You can add a maximum of five results"),
+      of: [
+        {
+          type: "object",
+          title: "Result List Item",
+          name: "resultlistitem",
+          fields: [
+            {
+              name: "result",
+              type: "string",
+              title: "Result",
+              description: "Add result, for example '+ 72%'",
+            },
+            {
+              name: "description",
+              type: "internationalizedArrayString",
+              title: "Description of the result, for example 'Satisfied users'",
+            },
+          ],
+          preview: {
+            select: {
+              item: "description",
+            },
+            prepare({ item }) {
+              if (item !== undefined && !isInternationalizedString(item)) {
+                throw new TypeError(
+                  `Expected 'title' to be InternationalizedString, was ${typeof item}`,
+                );
+              }
+              return {
+                title:
+                  item !== undefined
+                    ? (firstTranslation(item) ?? undefined)
+                    : undefined,
+              };
+            },
+          },
+        },
+      ],
     },
   ],
   preview: {
     select: {
-      title: "description",
+      title: "resultBlockTitle",
     },
     prepare({ title }) {
-      return { title: firstTranslation(title) ?? undefined };
+      if (title !== undefined && !isInternationalizedString(title)) {
+        throw new TypeError(
+          `Expected 'title' to be InternationalizedString, was ${typeof title}`,
+        );
+      }
+      return {
+        title:
+          title !== undefined
+            ? (firstTranslation(title) ?? undefined)
+            : undefined,
+      };
     },
   },
 });

--- a/studioShared/schemas/objects/resultBlock.ts
+++ b/studioShared/schemas/objects/resultBlock.ts
@@ -1,0 +1,32 @@
+import { defineField } from "sanity";
+
+import { firstTranslation } from "studio/utils/i18n";
+
+const resultBlock = defineField({
+  name: "resultBlock",
+  type: "object",
+  title: "Result Block",
+  fields: [
+    {
+      name: "result",
+      type: "string",
+      title: "Result",
+      description: "Add result, eg. '+ 72%'",
+    },
+    {
+      name: "description",
+      type: "internationalizedArrayText",
+      title: "Description of the result, eg. 'Satisfied users'",
+    },
+  ],
+  preview: {
+    select: {
+      title: "description",
+    },
+    prepare({ title }) {
+      return { title: firstTranslation(title) ?? undefined };
+    },
+  },
+});
+
+export default resultBlock;

--- a/studioShared/schemas/objects/sections.ts
+++ b/studioShared/schemas/objects/sections.ts
@@ -1,7 +1,6 @@
 import imageBlock from "./imageBlock";
 import listBlock from "./listBlock";
 import quoteBlock from "./quoteBlock";
-import resultBlock from "./resultBlock";
 import richTextBlock from "./richTextBlock";
 
 export const baseCustomerCaseSections = [
@@ -9,5 +8,4 @@ export const baseCustomerCaseSections = [
   imageBlock,
   listBlock,
   quoteBlock,
-  resultBlock,
 ];


### PR DESCRIPTION
Added result block to Customer Case Page sections ref #817. It includes a block title, and a list of up to five results, each result with a field for result and description. This block cannot be used with split sections. 
<img width="1225" alt="Screenshot 2024-11-04 at 14 03 00" src="https://github.com/user-attachments/assets/8d5ebece-321f-482d-ac40-b31ce97ae160">

<img width="660" alt="Screenshot 2024-11-04 at 14 04 09" src="https://github.com/user-attachments/assets/e18e69b6-01ee-4f9c-b7d5-a0ce981f602a">
