### PR TITLE
V3 customer case list styling

### DIFF
--- a/src/components/customerCases/customerCase/sections/CustomerCaseSection.tsx
+++ b/src/components/customerCases/customerCase/sections/CustomerCaseSection.tsx
@@ -1,6 +1,7 @@
 import { CustomerCaseSection as CustomerCaseSectionObject } from "studioShared/lib/interfaces/customerCases";
 
 import ImageSection from "./image/ImageSection";
+import ListBlock from "./list/ListBlock";
 import QuoteBlock from "./quote/QuoteBlock";
 import ResultsBlock from "./results/ResultsBlock";
 import RichTextSection from "./richText/RichTextSection";
@@ -22,5 +23,7 @@ export function CustomerCaseSection({
       return <ImageSection section={section} />;
     case "resultsBlock":
       return <ResultsBlock section={section} />;
+    case "listBlock":
+      return <ListBlock section={section} />;
   }
 }

--- a/src/components/customerCases/customerCase/sections/list/ListBlock.tsx
+++ b/src/components/customerCases/customerCase/sections/list/ListBlock.tsx
@@ -1,0 +1,32 @@
+import Text from "src/components/text/Text";
+import { ListBlock as ListBlockObject } from "studioShared/lib/interfaces/listBlock";
+
+import styles from "./listBlock.module.css";
+
+export interface ListBlockProps {
+  section: ListBlockObject;
+}
+
+export default function ListBlock({ section }: ListBlockProps) {
+  console.log(section);
+  return (
+    section.description && (
+      <div className={styles.wrapper}>
+        <div className={styles.listwrapper}>
+          <Text type="h4">{section.description}</Text>
+          <div className={styles.tagwrapper}>
+            {section.list?.map((listItem) => (
+              <Text
+                type="labelRegular"
+                key={listItem._key}
+                className={styles.tag}
+              >
+                {listItem.text}
+              </Text>
+            ))}
+          </div>
+        </div>
+      </div>
+    )
+  );
+}

--- a/src/components/customerCases/customerCase/sections/list/listBlock.module.css
+++ b/src/components/customerCases/customerCase/sections/list/listBlock.module.css
@@ -1,0 +1,34 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.listwrapper {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+  max-width: 960px;
+}
+
+.tagwrapper {
+  display: flex;
+  align-items: flex-start;
+  align-content: flex-start;
+  gap: 0.5rem 0.5rem;
+  align-self: stretch;
+  flex-wrap: wrap;
+}
+
+.tag {
+  display: flex;
+  height: 2.4375rem;
+  padding: 0.375rem 0.75rem;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid #0e0f0f;
+}

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -38,6 +38,13 @@
   font-weight: 600;
 }
 
+.h4 {
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 120%; /* 1.8rem */
+}
+
 /* TODO: add font variables */
 /* .h4 */
 /* .h5 */

--- a/studioShared/lib/interfaces/customerCases.ts
+++ b/studioShared/lib/interfaces/customerCases.ts
@@ -1,6 +1,7 @@
 import { IImage } from "studio/lib/interfaces/media";
 
 import { ImageBlock } from "./imageBlock";
+import { ListBlock } from "./listBlock";
 import { QuoteBlock } from "./quoteBlock";
 import { ResultsBlock } from "./resultsBlock";
 import { RichTextBlock } from "./richTextBlock";
@@ -34,7 +35,8 @@ export type BaseCustomerCaseSection = RichTextBlock | ImageBlock | QuoteBlock;
 export type CustomerCaseSection =
   | BaseCustomerCaseSection
   | SplitSection
-  | ResultsBlock;
+  | ResultsBlock
+  | ListBlock;
 
 export interface CustomerCase extends CustomerCaseBase {
   projectInfo: CustomerCaseProjectInfo;

--- a/studioShared/lib/interfaces/listBlock.ts
+++ b/studioShared/lib/interfaces/listBlock.ts
@@ -1,0 +1,11 @@
+interface ListItem {
+  _key: string;
+  text: string;
+}
+
+export interface ListBlock {
+  _key: string;
+  _type: "listBlock";
+  description?: string;
+  list: ListItem[];
+}

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -39,12 +39,6 @@ export const BASE_SECTIONS_FRAGMENT = groq`
     },
     fullWidth
   },
-  _type == "listBlock" => {
-    "description": ${translatedFieldFragment("description")},
-    "list": list[] {
-      "text": ${translatedFieldFragment("text")},
-    },
-  }, 
   _type == "quoteBlock" => {
     "quote": ${translatedFieldFragment("quote")},
     "author": ${translatedFieldFragment("author")},
@@ -83,6 +77,13 @@ export const CUSTOMER_CASE_QUERY = groq`
           "description": ${translatedFieldFragment("description")},
           }
         },
+      _type == "listBlock" => {
+        "description": ${translatedFieldFragment("description")},
+        "list": list[] {
+          _key,
+          "text": ${translatedFieldFragment("text")},
+          },
+        }, 
       ${BASE_SECTIONS_FRAGMENT}
     },
     "featuredCases": featuredCases[] -> {

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -8,6 +8,7 @@ import { titleSlug } from "studio/schemas/schemaTypes/slug";
 import { buildDraftId, buildPublishedId } from "studio/utils/documentUtils";
 import { firstTranslation } from "studio/utils/i18n";
 import { customerCaseProjectInfo } from "studioShared/schemas/fields/customerCaseProjectInfo";
+import listBlock from "studioShared/schemas/objects/listBlock";
 import resultsBlock from "studioShared/schemas/objects/resultsBlock";
 import { baseCustomerCaseSections } from "studioShared/schemas/objects/sections";
 import splitSection from "studioShared/schemas/objects/splitSection";
@@ -18,6 +19,7 @@ export const customerCaseSections = [
   ...baseCustomerCaseSections,
   splitSection,
   resultsBlock,
+  listBlock,
 ];
 
 const customerCase = defineType({

--- a/studioShared/schemas/objects/sections.ts
+++ b/studioShared/schemas/objects/sections.ts
@@ -1,11 +1,5 @@
 import imageBlock from "./imageBlock";
-import listBlock from "./listBlock";
 import quoteBlock from "./quoteBlock";
 import richTextBlock from "./richTextBlock";
 
-export const baseCustomerCaseSections = [
-  richTextBlock,
-  imageBlock,
-  listBlock,
-  quoteBlock,
-];
+export const baseCustomerCaseSections = [richTextBlock, imageBlock, quoteBlock];


### PR DESCRIPTION
List block is used to showcase different skills, tools and methods used in a project, now with UI! It can be added in the section part of the studio and consists of a description, which will be the title of the section on the page, and a list where each skill is added as text string.

 On desktop:
<img width="957" alt="Screenshot 2024-11-05 at 14 24 50" src="https://github.com/user-attachments/assets/8769ddfa-ca5c-413b-8cbd-61fec319dc20">

On mobile:
<img width="218" alt="Screenshot 2024-11-05 at 14 25 25" src="https://github.com/user-attachments/assets/355b86bd-8147-4309-a588-9babe323d9ec">

In studio:
<img width="655" alt="Screenshot 2024-11-05 at 14 26 46" src="https://github.com/user-attachments/assets/6bdfd80e-e7a6-43ee-8fdf-60db933a2310">

