### PR TITLE
Add icons to shared studio

### DIFF
--- a/studioShared/deskStructure.ts
+++ b/studioShared/deskStructure.ts
@@ -1,3 +1,4 @@
+import { ProjectsIcon } from "@sanity/icons";
 import { StructureResolver } from "sanity/structure";
 
 import { customerCaseID } from "./schemas/documents/customerCase";
@@ -8,5 +9,6 @@ export const deskStructure: StructureResolver = (S) =>
     .items([
       S.listItem()
         .title("Customer cases")
+        .icon(ProjectsIcon)
         .child(S.documentTypeList(customerCaseID).title("Customer cases")),
     ]);

--- a/studioShared/schemas/documents/customerCase.ts
+++ b/studioShared/schemas/documents/customerCase.ts
@@ -1,3 +1,4 @@
+import { DocumentTextIcon } from "@sanity/icons";
 import { groq } from "next-sanity";
 import { Reference, defineField, defineType } from "sanity";
 
@@ -26,6 +27,7 @@ const customerCase = defineType({
   name: customerCaseID,
   type: "document",
   title: "Customer Case",
+  icon: DocumentTextIcon,
   fields: [
     defineField({
       ...titleSlug,

--- a/studioShared/schemas/fields/customerCaseProjectInfo.ts
+++ b/studioShared/schemas/fields/customerCaseProjectInfo.ts
@@ -1,3 +1,4 @@
+import { UlistIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
@@ -40,6 +41,7 @@ export const customerCaseProjectInfo = defineField({
           type: "object",
           title: "List Item",
           name: "listItem",
+          icon: UlistIcon,
           fields: [
             {
               name: "delivery",

--- a/studioShared/schemas/objects/emptySection.ts
+++ b/studioShared/schemas/objects/emptySection.ts
@@ -1,3 +1,4 @@
+import { SquareIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import EmptySectionInput from "studioShared/components/EmptySectionInput";
@@ -7,6 +8,7 @@ const emptySection = defineField({
   title: "Blank Space",
   description: "Displays as blank space on the page.",
   type: "object",
+  icon: SquareIcon,
   fields: [
     {
       name: "placeholder",

--- a/studioShared/schemas/objects/imageBlock.ts
+++ b/studioShared/schemas/objects/imageBlock.ts
@@ -1,3 +1,4 @@
+import { ImageIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
@@ -8,6 +9,7 @@ const imageBlock = defineField({
   name: "imageBlock",
   title: "Image Block",
   type: "object",
+  icon: ImageIcon,
   fields: [
     {
       title: "Image",

--- a/studioShared/schemas/objects/listBlock.ts
+++ b/studioShared/schemas/objects/listBlock.ts
@@ -1,3 +1,4 @@
+import { TagIcon, TagsIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
@@ -5,6 +6,7 @@ import { firstTranslation } from "studio/utils/i18n";
 const listBlock = defineField({
   name: "listBlock",
   title: "List Block",
+  icon: TagsIcon,
   description:
     "This block could be used to add a list of skills, tools, methods etc. used for this project.",
   type: "object",
@@ -27,6 +29,7 @@ const listBlock = defineField({
           type: "object",
           title: "List Item",
           name: "listItem",
+          icon: TagIcon,
           fields: [
             {
               name: "text",

--- a/studioShared/schemas/objects/quoteBlock.ts
+++ b/studioShared/schemas/objects/quoteBlock.ts
@@ -1,3 +1,4 @@
+import { CommentIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { firstTranslation } from "studio/utils/i18n";
@@ -6,6 +7,7 @@ const quoteBlock = defineField({
   name: "quoteBlock",
   type: "object",
   title: "Quote Block",
+  icon: CommentIcon,
   fields: [
     {
       name: "quote",

--- a/studioShared/schemas/objects/resultsBlock.ts
+++ b/studioShared/schemas/objects/resultsBlock.ts
@@ -1,3 +1,4 @@
+import { BarChartIcon, ChartUpwardIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
@@ -7,6 +8,7 @@ const resultsBlock = defineField({
   name: "resultsBlock",
   type: "object",
   title: "Results Block",
+  icon: ChartUpwardIcon,
   description: "This block can be used to add some results from the project.",
   fields: [
     {
@@ -28,6 +30,7 @@ const resultsBlock = defineField({
           type: "object",
           title: "Result List Item",
           name: "resultlistitem",
+          icon: BarChartIcon,
           fields: [
             {
               name: "result",

--- a/studioShared/schemas/objects/splitSection.ts
+++ b/studioShared/schemas/objects/splitSection.ts
@@ -1,3 +1,4 @@
+import { InlineIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { humanizeCamelCase } from "studio/utils/stringUtils";
@@ -11,6 +12,7 @@ export const splitSectionSections = [...baseCustomerCaseSections, emptySection];
 const splitSection = defineField({
   name: "splitSection",
   title: "Split Section",
+  icon: InlineIcon,
   description: "Section containing two other sections, displayed side-by-side",
   type: "object",
   fields: [

--- a/studioShared/schemas/objects/textBlock.ts
+++ b/studioShared/schemas/objects/textBlock.ts
@@ -1,3 +1,4 @@
+import { BlockContentIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { firstTranslation } from "studio/utils/i18n";
@@ -6,6 +7,7 @@ const textBlock = defineField({
   name: "textBlock",
   title: "Text Block",
   type: "object",
+  icon: BlockContentIcon,
   fields: [
     {
       name: "sectionTitle",


### PR DESCRIPTION
Added icons to the shared studio to improve user experience as it will be easier to identify the different sections. 

<img width="643" alt="Screenshot 2024-11-07 at 09 30 32" src="https://github.com/user-attachments/assets/e79b1f51-bebc-45fb-8869-046b94bc9e1b">
<img width="612" alt="Screenshot 2024-11-07 at 09 30 48" src="https://github.com/user-attachments/assets/59d4460e-2d3b-4f56-a66c-73073e74bc6a">
<img width="633" alt="Screenshot 2024-11-07 at 09 31 11" src="https://github.com/user-attachments/assets/4701be47-45a7-4380-b361-fe5b4e8e8ef8">

<img width="643" alt="Screenshot 2024-11-07 at 09 31 30" src="https://github.com/user-attachments/assets/57c729b6-ab33-452f-9ac2-7c4f4572b69e">

<img width="649" alt="Screenshot 2024-11-07 at 09 33 08" src="https://github.com/user-attachments/assets/4ba8c986-5d78-4ee6-9b5b-c91c42ad6f44">
<img width="213" alt="Screenshot 2024-11-07 at 09 33 25" src="https://github.com/user-attachments/assets/46b423ad-3fbb-4d2d-9508-b02fabc86325">
<img width="673" alt="Screenshot 2024-11-07 at 09 33 38" src="https://github.com/user-attachments/assets/6c400ee6-ad4f-4532-bb90-45e0ed6d4e39">

