### PR TITLE
✨ Add schemas for job postings

### DIFF
--- a/studio/deskStructure.ts
+++ b/studio/deskStructure.ts
@@ -28,6 +28,7 @@ import { brandAssetsID } from "./schemas/documents/siteSettings/brandAssets";
 import { localeID } from "./schemas/documents/siteSettings/locale";
 import { soMeLinksID } from "./schemas/documents/siteSettings/socialMediaProfiles";
 import { customerCasesPageID } from "./schemas/documents/specialPages/customerCasesPage";
+import { jobPostingsID } from "./schemas/documents/admin/jobPostings";
 
 // Admin Section
 const adminSection = (S: StructureBuilder) =>
@@ -58,6 +59,15 @@ const adminSection = (S: StructureBuilder) =>
             .icon(CogIcon)
             .child(
               S.documentTypeList(legalDocumentID).title("Legal Documents"),
+            ),
+          S.listItem()
+            .title("Job Postings")
+            .icon(CaseIcon)
+            .child(
+              S.document()
+                .schemaType(jobPostingsID)
+                .documentId(jobPostingsID)
+                .title("Job Postings"),
             ),
         ]),
     );

--- a/studio/deskStructure.ts
+++ b/studio/deskStructure.ts
@@ -19,6 +19,7 @@ import { StructureBuilder } from "sanity/structure";
 import { companyInfoID } from "./schemas/documents/admin/companyInfo";
 import { companyLocationID } from "./schemas/documents/admin/companyLocation";
 import { defaultSeoID } from "./schemas/documents/admin/defaultSeo";
+import { jobPostingsID } from "./schemas/documents/admin/jobPostings";
 import { legalDocumentID } from "./schemas/documents/admin/legalDocuments";
 import { compensationsId } from "./schemas/documents/compensations";
 import { languageSettingsID } from "./schemas/documents/languageSettings";
@@ -28,7 +29,6 @@ import { brandAssetsID } from "./schemas/documents/siteSettings/brandAssets";
 import { localeID } from "./schemas/documents/siteSettings/locale";
 import { soMeLinksID } from "./schemas/documents/siteSettings/socialMediaProfiles";
 import { customerCasesPageID } from "./schemas/documents/specialPages/customerCasesPage";
-import { jobPostingsID } from "./schemas/documents/admin/jobPostings";
 
 // Admin Section
 const adminSection = (S: StructureBuilder) =>

--- a/studio/schema.ts
+++ b/studio/schema.ts
@@ -20,6 +20,8 @@ import { footerSection } from "./schemas/objects/footerSection";
 import { link } from "./schemas/objects/link";
 import seo from "./schemas/objects/seo";
 import { socialMedia } from "./schemas/objects/socialMedia";
+import jobPosting from "./schemas/objects/jobPosting";
+import jobPostings from "./schemas/documents/admin/jobPostings";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
@@ -43,5 +45,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     richText,
     seo,
     announcement,
+    jobPosting,
+    jobPostings,
   ],
 };

--- a/studio/schema.ts
+++ b/studio/schema.ts
@@ -3,6 +3,7 @@ import { type SchemaTypeDefinition } from "sanity";
 import companyInfo from "./schemas/documents/admin/companyInfo";
 import companyLocation from "./schemas/documents/admin/companyLocation";
 import defaultSeo from "./schemas/documents/admin/defaultSeo";
+import jobPostings from "./schemas/documents/admin/jobPostings";
 import legalDocument from "./schemas/documents/admin/legalDocuments";
 import compensations from "./schemas/documents/compensations";
 import languageSettings from "./schemas/documents/languageSettings";
@@ -17,11 +18,10 @@ import callToActionField from "./schemas/fields/callToActionFields";
 import { richText } from "./schemas/fields/text";
 import benefitsByLocation from "./schemas/objects/compensations/benefitsByLocation";
 import { footerSection } from "./schemas/objects/footerSection";
+import jobPosting from "./schemas/objects/jobPosting";
 import { link } from "./schemas/objects/link";
 import seo from "./schemas/objects/seo";
 import { socialMedia } from "./schemas/objects/socialMedia";
-import jobPosting from "./schemas/objects/jobPosting";
-import jobPostings from "./schemas/documents/admin/jobPostings";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [

--- a/studio/schemas/documents/admin/jobPostings.ts
+++ b/studio/schemas/documents/admin/jobPostings.ts
@@ -1,0 +1,21 @@
+import { defineType } from "sanity";
+
+import { jobPostingID } from "studio/schemas/objects/jobPosting";
+
+export const jobPostingsID = "jobPostings";
+
+const jobPostings = defineType({
+  name: jobPostingsID,
+  type: "document",
+  title: "Job Postings",
+  fields: [
+    {
+      name: "jobPostings",
+      title: "Job Postings",
+      type: "array",
+      of: [{ type: jobPostingID }],
+    },
+  ],
+});
+
+export default jobPostings;

--- a/studio/schemas/documents/admin/jobPostings.ts
+++ b/studio/schemas/documents/admin/jobPostings.ts
@@ -10,7 +10,7 @@ const jobPostings = defineType({
   title: "Job Postings",
   fields: [
     {
-      name: "jobPostings",
+      name: "jobPostingsArray",
       title: "Job Postings",
       type: "array",
       of: [{ type: jobPostingID }],

--- a/studio/schemas/objects/jobPosting.ts
+++ b/studio/schemas/objects/jobPosting.ts
@@ -15,6 +15,7 @@ const jobPosting = defineType({
       name: "role",
       type: "internationalizedArrayString",
       description: "The name of the role",
+      validation: (rule) => rule.required().error("Role name is required"),
     },
     {
       title: "Location",
@@ -27,7 +28,15 @@ const jobPosting = defineType({
       title: "Recruitee ad URL",
       name: "recruiteeAdUrl",
       type: "url",
-      description: "URL to Recruitee ad",
+      description:
+        "URL to Recruitee ad. Please  enter the full URL, including 'https://', e.g., 'https://www.example.com'.",
+      validation: (rule) => [
+        rule.required(),
+        rule.uri({
+          scheme: ["http", "https"],
+          allowRelative: false,
+        }),
+      ],
     },
   ],
   preview: {

--- a/studio/schemas/objects/jobPosting.ts
+++ b/studio/schemas/objects/jobPosting.ts
@@ -1,6 +1,7 @@
 import { defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
+import { companyLocationID } from "studio/schemas/documents/admin/companyLocation";
 import { firstTranslation } from "studio/utils/i18n";
 
 export const jobPostingID = "jobPosting";
@@ -18,18 +19,24 @@ const jobPosting = defineType({
       validation: (rule) => rule.required().error("Role name is required"),
     },
     {
-      title: "Location",
-      name: "location",
-      type: "reference",
-      to: [{ type: "companyLocation" }],
+      title: "Locations",
+      name: "locations",
+      type: "array",
       description: "Where is the role located?",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: companyLocationID }],
+        },
+      ],
+      validation: (rule) => rule.required(),
     },
     {
       title: "Recruitee ad URL",
       name: "recruiteeAdUrl",
       type: "url",
       description:
-        "URL to Recruitee ad. Please  enter the full URL, including 'https://', e.g., 'https://www.example.com'.",
+        "URL to Recruitee ad. Please enter the full URL, including 'https://', e.g., 'https://www.example.com'.",
       validation: (rule) => [
         rule.required(),
         rule.uri({
@@ -42,10 +49,8 @@ const jobPosting = defineType({
   preview: {
     select: {
       title: "role",
-      location: "location.companyLocationName",
     },
-    prepare(selection) {
-      const { title, location } = selection;
+    prepare({ title }) {
       if (!isInternationalizedString(title)) {
         throw new TypeError(
           `Expected 'title' to be InternationalizedString, was ${typeof title}`,
@@ -53,7 +58,6 @@ const jobPosting = defineType({
       }
       return {
         title: firstTranslation(title) ?? undefined,
-        subtitle: location,
       };
     },
   },

--- a/studio/schemas/objects/jobPosting.ts
+++ b/studio/schemas/objects/jobPosting.ts
@@ -1,0 +1,52 @@
+import { defineType } from "sanity";
+import { isInternationalizedString } from "studio/lib/interfaces/global";
+import { firstTranslation } from "studio/utils/i18n";
+
+export const jobPostingID = "jobPosting";
+
+const jobPosting = defineType({
+  name: jobPostingID,
+  title: "Job Posting",
+  type: "object",
+  fields: [
+    {
+      title: "Role",
+      name: "role",
+      type: "internationalizedArrayString",
+      description: "The name of the role",
+    },
+    {
+      title: "Location",
+      name: "location",
+      type: "reference",
+      to: [{ type: "companyLocation" }],
+      description: "Where is the role located?",
+    },
+    {
+      title: "Recruitee ad URL",
+      name: "recruiteeAdUrl",
+      type: "url",
+      description: "URL to Recruitee ad",
+    },
+  ],
+  preview: {
+    select: {
+      title: "role",
+      location: "location.companyLocationName",
+    },
+    prepare(selection) {
+      const { title, location } = selection;
+      if (!isInternationalizedString(title)) {
+        throw new TypeError(
+          `Expected 'title' to be InternationalizedString, was ${typeof title}`,
+        );
+      }
+      return {
+        title: firstTranslation(title) ?? undefined,
+        subtitle: location,
+      };
+    },
+  },
+});
+
+export default jobPosting;

--- a/studio/schemas/objects/jobPosting.ts
+++ b/studio/schemas/objects/jobPosting.ts
@@ -1,4 +1,5 @@
 import { defineType } from "sanity";
+
 import { isInternationalizedString } from "studio/lib/interfaces/global";
 import { firstTranslation } from "studio/utils/i18n";
 


### PR DESCRIPTION
## Summary 
- Display job postings under `Admin`
- Add schemas `jobPosting` and `jobPostings`
  - A job posting consists of `role`, `locations` and `recruiteeAdUrl`. The naming can be discussed (as always!)

## For reviewer
- I have `jobPosting.ts` in `studio/schemas/objects` and `jobPostings.ts` in `studio/schemas/documents/admin`. Correct?

## Screenshots
<img width="1722" alt="Screenshot 2024-11-26 at 08 48 55" src="https://github.com/user-attachments/assets/1dccc00d-09fd-40c7-9683-954d20af5e54">
<img width="684" alt="Screenshot 2024-11-26 at 16 59 10" src="https://github.com/user-attachments/assets/aba81915-c4ae-4e40-bd96-7d5825820b9a">
<img width="713" alt="Screenshot 2024-11-26 at 08 49 28" src="https://github.com/user-attachments/assets/163d5b54-0156-4e53-9438-37ce07cfd0c3">
