### PR TITLE
V3 refactor project info

### DIFF
--- a/public/_assets/arrow-right.svg
+++ b/public/_assets/arrow-right.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ArrowRight">
+<path id="Vector" d="M3.125 10H16.875" stroke="#343330" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M11.25 4.375L16.875 10L11.25 15.625" stroke="#343330" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/public/_assets/arrow-up-right.svg
+++ b/public/_assets/arrow-up-right.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ArrowUpRight">
+<path id="Vector" d="M6 18L18 6" stroke="#343330" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M8.25 6H18V15.75" stroke="#343330" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/public/_assets/arrow.svg
+++ b/public/_assets/arrow.svg
@@ -1,8 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="arrow-down 2">
-<g id="Group 39643">
-<path id="Vector" d="M3.20212 12L20 12" stroke="#206A6F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path id="Vector_2" d="M13 5L20 12L13 19" stroke="#206A6F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
-</g>
-</svg>

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -1,0 +1,27 @@
+import Text from "src/components/text/Text";
+
+import styles from "./badge.module.css";
+
+interface IBadge {
+  children: React.ReactNode;
+  badgeColor?: string;
+  textColor?: string;
+}
+
+const Badge = ({
+  children,
+  badgeColor = "#EAEAEA",
+  textColor = "#222424",
+}: IBadge) => {
+  const badgeColors = {
+    backgroundColor: badgeColor,
+    color: textColor,
+  };
+  return (
+    <div className={styles.badgeWrapper} style={badgeColors}>
+      <Text type="bodySmall">{children}</Text>
+    </div>
+  );
+};
+
+export default Badge;

--- a/src/components/badge/badge.module.css
+++ b/src/components/badge/badge.module.css
@@ -1,0 +1,9 @@
+.badgeWrapper {
+  display: inline-flex;
+  height: 1.5rem;
+  padding: 0.375rem 0.75rem;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  border-radius: 624.9375rem;
+}

--- a/src/components/customerCases/customerCase/CustomerCase.tsx
+++ b/src/components/customerCases/customerCase/CustomerCase.tsx
@@ -1,16 +1,12 @@
-import { getTranslations } from "next-intl/server";
-
 import { SanitySharedImage } from "src/components/image/SanityImage";
 import Text from "src/components/text/Text";
 import { fetchEmployeesByEmails } from "src/utils/employees";
-import {
-  CustomerCase as CustomerCaseDocument,
-  CustomerSector,
-} from "studioShared/lib/interfaces/customerCases";
+import { CustomerCase as CustomerCaseDocument } from "studioShared/lib/interfaces/customerCases";
 
 import ContactInformation from "./contactInformation/ContactInformation";
 import styles from "./customerCase.module.css";
 import FeaturedCases from "./featuredCases/FeaturedCases";
+import CustomerCaseProjectInfo from "./projectInfo/CustomerCaseProjectInfo";
 import CustomerCaseConsultants from "./sections/customerCaseConsultants/CustomerCaseConsultants";
 import { CustomerCaseSection } from "./sections/CustomerCaseSection";
 
@@ -27,8 +23,6 @@ export default async function CustomerCase({
     customerCase.projectInfo.consultants,
   );
 
-  const t = await getTranslations("customer_case");
-
   return (
     <div className={styles.wrapper}>
       <div className={styles.content}>
@@ -36,144 +30,14 @@ export default async function CustomerCase({
           {customerCase.basicTitle}
         </Text>
         <hr className={styles.divider} />
-        <div className={styles.projectInfo}>
-          <div className={styles.projectInfoInner}>
-            {customerCase.projectInfo.customerSectors && (
-              <div>
-                <Text className={styles.title} type="labelRegular">
-                  {t("customer").toUpperCase()}
-                </Text>
-                <div className={styles.projectInfoItem}>
-                  {customerCase.projectInfo.customerSectors.map(
-                    (sector: CustomerSector) => (
-                      <Text
-                        key={sector.key}
-                        type="bodyNormal"
-                        className={styles.dotSeperator}
-                      >
-                        {sector.customerSector}
-                      </Text>
-                    ),
-                  )}
-                </div>
-              </div>
-            )}
-            {consultantsResult.ok && (
-              <div>
-                <Text className={styles.title} type="labelRegular">
-                  {t("variants").toUpperCase()}
-                </Text>
-                <div className={styles.varianter}>
-                  <Text>【</Text>
-                  {consultantsResult.value.map((c) => (
-                    <Text
-                      key={c.name}
-                      type="bodyNormal"
-                      className={styles.dotSeperatorVarianter}
-                    >
-                      {c.name}
-                    </Text>
-                  ))}
-                  <Text>】</Text>
-                </div>
-              </div>
-            )}
-            {customerCase.projectInfo.collaborators && (
-              <div>
-                <Text className={styles.title} type="labelRegular">
-                  {t("collaborators").toUpperCase()}
-                </Text>
-                <div className={styles.projectInfoItem}>
-                  {customerCase.projectInfo.collaborators.map(
-                    (collaborator) => (
-                      <Text
-                        type="bodyNormal"
-                        key={collaborator}
-                        className={styles.dotSeperator}
-                      >
-                        {collaborator}
-                      </Text>
-                    ),
-                  )}
-                </div>
-              </div>
-            )}
-            {customerCase.projectInfo.url && (
-              <div>
-                <Text className={styles.title} type="labelRegular">
-                  {t("url").toUpperCase()}
-                </Text>
-                <Text type="bodyNormal">{customerCase.projectInfo.url}</Text>
-              </div>
-            )}
+        {consultantsResult.ok && (
+          <div className={styles.projectInfoWrapper}>
+            <CustomerCaseProjectInfo
+              projectInfo={customerCase.projectInfo}
+              consultantsInProject={consultantsResult.value}
+            />
           </div>
-          <div>
-            {customerCase.projectInfo.deliveries && (
-              <div className={styles.deliveries}>
-                {customerCase.projectInfo.deliveries["projectManagement"] && (
-                  <div>
-                    <Text className={styles.title} type="labelRegular">
-                      {t("project_management").toUpperCase()}
-                    </Text>
-                    <div className={styles.projectInfoItem}>
-                      {customerCase.projectInfo.deliveries[
-                        "projectManagement"
-                      ].map((projectManagement) => (
-                        <Text
-                          type="bodyNormal"
-                          key={projectManagement.key}
-                          className={styles.dotSeperator}
-                        >
-                          {projectManagement.projectManagementDelivery}
-                        </Text>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {customerCase.projectInfo.deliveries["design"] && (
-                  <div>
-                    <Text className={styles.title} type="labelRegular">
-                      {t("design").toUpperCase()}
-                    </Text>
-                    <div className={styles.projectInfoItem}>
-                      {customerCase.projectInfo.deliveries["design"].map(
-                        (design) => (
-                          <Text
-                            key={design.key}
-                            type="bodyNormal"
-                            className={styles.dotSeperator}
-                          >
-                            {design.designDelivery}
-                          </Text>
-                        ),
-                      )}
-                    </div>
-                  </div>
-                )}
-                {customerCase.projectInfo.deliveries["development"] && (
-                  <div>
-                    <Text className={styles.title} type="labelRegular">
-                      {t("development").toUpperCase()}
-                    </Text>
-                    <div className={styles.projectInfoItem}>
-                      {customerCase.projectInfo.deliveries["development"].map(
-                        (development) => (
-                          <Text
-                            key={development.key}
-                            type="bodyNormal"
-                            className={styles.dotSeperator}
-                          >
-                            {development.developmentDelivery}
-                          </Text>
-                        ),
-                      )}
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
+        )}
         <div className={styles.mainImageWrapper}>
           <SanitySharedImage image={customerCase.image} />
         </div>

--- a/src/components/customerCases/customerCase/customerCase.module.css
+++ b/src/components/customerCases/customerCase/customerCase.module.css
@@ -50,61 +50,12 @@
   margin: 1rem 0;
 }
 
-.projectInfo {
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
-}
-
-.projectInfoInner {
-  width: 537px;
-  max-width: 537px;
-  gap: 1.5rem;
+.projectInfoWrapper {
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
-}
-
-.dotSeperator::after {
-  content: "·";
-  margin: 0 0.5rem;
-}
-
-.dotSeperator:last-child:after {
-  content: "";
-  margin: 0;
-}
-
-.varianter {
-  max-width: 537px;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-}
-
-.dotSeperatorVarianter::after {
-  content: "·";
-  margin: 0 0.5rem;
-}
-
-.dotSeperatorVarianter:nth-last-child(2)::after {
-  content: "";
-  margin: 0rem;
-}
-
-.projectInfoItem {
-  display: flex;
-  flex-direction: row;
-}
-
-.title {
-  color: var(--text-tertiary);
-}
-
-.deliveries {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  align-self: center;
+  width: 100%;
+  max-width: 960px;
 }
 
 .sectionsWrapper {

--- a/src/components/customerCases/customerCase/projectInfo/CustomerCaseProjectInfo.tsx
+++ b/src/components/customerCases/customerCase/projectInfo/CustomerCaseProjectInfo.tsx
@@ -1,0 +1,163 @@
+import { getTranslations } from "next-intl/server";
+
+import Badge from "src/components/badge/Badge";
+import CustomLink from "src/components/link/CustomLink";
+import Text from "src/components/text/Text";
+import { ChewbaccaEmployee } from "src/types/employees";
+import { LinkType } from "studio/lib/interfaces/navigation";
+import {
+  CustomerCaseProjectInfo as CustomerCaseCaseProjectInfoObject,
+  CustomerSector,
+} from "studioShared/lib/interfaces/customerCases";
+
+import styles from "./customerCaseProjectInfo.module.css";
+
+interface CustomerCaseProjectInfoProps {
+  projectInfo: CustomerCaseCaseProjectInfoObject;
+  consultantsInProject: ChewbaccaEmployee[];
+}
+
+export default async function CustomerCaseProjectInfo({
+  projectInfo,
+  consultantsInProject,
+}: CustomerCaseProjectInfoProps) {
+  const t = await getTranslations("customer_case");
+
+  return (
+    <>
+      <div className={styles.projectInfo}>
+        <div className={styles.projectInfoInner}>
+          {projectInfo.customerSectors && (
+            <div>
+              <Text className={styles.title} type="labelRegular">
+                {t("customer").toUpperCase()}
+              </Text>
+              <div className={styles.badgeWrapper}>
+                {projectInfo.customerSectors.map((sector: CustomerSector) => (
+                  <Badge key={sector._key}>{sector.customerSector}</Badge>
+                ))}
+              </div>
+            </div>
+          )}
+          <div>
+            <Text className={styles.title} type="labelRegular">
+              {t("variants").toUpperCase()}
+            </Text>
+            <div className={styles.varianter}>
+              <Text className={styles.preFancyCharacter}>【 </Text>
+              {consultantsInProject.map((c) => (
+                <Text
+                  key={c.name}
+                  type="bodyNormal"
+                  className={styles.dotSeperatorVarianter}
+                >
+                  {c.name}
+                </Text>
+              ))}
+              <Text className={styles.afterFancyCharacter}> 】</Text>
+            </div>
+          </div>
+          {projectInfo.collaborators && (
+            <div>
+              <Text className={styles.title} type="labelRegular">
+                {t("collaborators").toUpperCase()}
+              </Text>
+              <div className={styles.projectInfoItem}>
+                {projectInfo.collaborators.map((collaborator) => (
+                  <Text
+                    type="bodyNormal"
+                    key={collaborator}
+                    className={styles.dotSeperator}
+                  >
+                    {collaborator}
+                  </Text>
+                ))}
+              </div>
+            </div>
+          )}
+          {projectInfo.url && (
+            <div className={styles.urlWrapper}>
+              <Text className={styles.title} type="labelRegular">
+                {t("url")}
+              </Text>
+              <CustomLink
+                link={{
+                  _key: "go-to-external-link",
+                  _type: "link",
+                  linkType: LinkType.External,
+                  linkTitle: projectInfo.url,
+                  url: projectInfo.url,
+                  ariaLabel: projectInfo.url,
+                }}
+              />
+            </div>
+          )}
+        </div>
+        <div>
+          {projectInfo.deliveries && (
+            <div className={styles.deliveries}>
+              {projectInfo.deliveries["projectManagement"] && (
+                <div>
+                  <Text className={styles.title} type="labelRegular">
+                    {t("project_management").toUpperCase()}
+                  </Text>
+                  <div className={styles.projectInfoItem}>
+                    {projectInfo.deliveries["projectManagement"].map(
+                      (projectManagement) => (
+                        <Text
+                          type="bodyNormal"
+                          key={projectManagement.key}
+                          className={styles.dotSeperator}
+                        >
+                          {projectManagement.projectManagementDelivery}
+                        </Text>
+                      ),
+                    )}
+                  </div>
+                </div>
+              )}
+              {projectInfo.deliveries["design"] && (
+                <div>
+                  <Text className={styles.title} type="labelRegular">
+                    {t("design").toUpperCase()}
+                  </Text>
+                  <div className={styles.projectInfoItem}>
+                    {projectInfo.deliveries["design"].map((design) => (
+                      <Text
+                        key={design.key}
+                        type="bodyNormal"
+                        className={styles.dotSeperator}
+                      >
+                        {design.designDelivery}
+                      </Text>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {projectInfo.deliveries["development"] && (
+                <div>
+                  <Text className={styles.title} type="labelRegular">
+                    {t("development").toUpperCase()}
+                  </Text>
+                  <div className={styles.projectInfoItem}>
+                    {projectInfo.deliveries["development"].map(
+                      (development) => (
+                        <Text
+                          key={development.key}
+                          type="bodyNormal"
+                          className={styles.dotSeperator}
+                        >
+                          {development.developmentDelivery}
+                        </Text>
+                      ),
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/customerCases/customerCase/projectInfo/customerCaseProjectInfo.module.css
+++ b/src/components/customerCases/customerCase/projectInfo/customerCaseProjectInfo.module.css
@@ -1,0 +1,84 @@
+.projectInfo {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  width: 100%;
+
+  @media (max-width: 425px) {
+    flex-direction: column;
+    gap: 3rem;
+  }
+}
+
+.projectInfoInner {
+  gap: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+}
+
+.badgeWrapper {
+  display: flex;
+  align-items: flex-start;
+  align-content: flex-start;
+  gap: 0.375rem;
+  align-self: stretch;
+  flex-wrap: wrap;
+  padding-top: 0.25rem;
+}
+
+.dotSeperator::after {
+  content: "·";
+  margin: 0 0.5rem;
+}
+
+.dotSeperator:last-child:after {
+  content: "";
+  margin: 0;
+}
+
+.varianter {
+  max-width: 537px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.dotSeperatorVarianter::after {
+  content: "·";
+  margin: 0 0.5rem;
+}
+
+.dotSeperatorVarianter:nth-last-child(2)::after {
+  content: "";
+  margin: 0rem;
+}
+
+.projectInfoItem {
+  display: flex;
+  flex-direction: row;
+}
+
+.title {
+  color: var(--text-tertiary);
+}
+
+.deliveries {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.preFancyCharacter {
+  margin-right: 0.38rem;
+}
+
+.afterFancyCharacter {
+  margin-left: 0.38rem;
+}
+
+.urlWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}

--- a/src/components/link/CustomLink.tsx
+++ b/src/components/link/CustomLink.tsx
@@ -43,7 +43,11 @@ const CustomLink = ({
         }
       >
         <Link
-          className={styles.link}
+          className={
+            link.linkType == "internal"
+              ? styles.internalLink
+              : styles.externalLink
+          }
           href={href}
           target={target}
           rel={rel}
@@ -51,7 +55,6 @@ const CustomLink = ({
         >
           <span className={styles.span}>{link.linkTitle}</span>
         </Link>
-        <div className={styles.underline}></div>
       </div>
     ) : (
       <Link

--- a/src/components/link/link.module.css
+++ b/src/components/link/link.module.css
@@ -11,21 +11,7 @@
   gap: 0;
 }
 
-.underline {
-  width: 100%;
-  height: 0.0625rem;
-  background-color: var(--primary-black);
-}
-
-.colorLight .underline {
-  background-color: var(--primary-white);
-}
-
-.sizeSmall .underline {
-  margin-top: -0.125rem;
-}
-
-.link {
+.internalLink {
   color: var(--primary-black);
 
   display: inline-flex;
@@ -36,7 +22,7 @@
   gap: 0.5rem;
   font-family: var(--font-britti-sans);
   font-size: 1.125rem;
-  font-weight: 500;
+  font-weight: 300;
 
   transition: gap 100ms ease-in-out;
 
@@ -46,7 +32,7 @@
 
   &:hover {
     gap: 1rem;
-    font-weight: 600;
+    font-weight: 400;
   }
 
   &::after {
@@ -55,12 +41,47 @@
     height: 24px;
     display: inline-block;
     -webkit-mask-size: cover;
-    background-color: var(--primary-white);
-    -webkit-mask: url("/_assets/arrow.svg") no-repeat 50% 50%;
+    background-color: var(--primary-black);
+    -webkit-mask: url("/_assets/arrow-right.svg") no-repeat 50% 50%;
   }
 }
 
-.colorLight .link {
+.externalLink {
+  color: var(--primary-black);
+
+  display: inline-flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  gap: 0.5rem;
+  font-family: var(--font-britti-sans);
+  font-size: 1.125rem;
+  font-weight: 300;
+
+  transition: gap 100ms ease-in-out;
+
+  @media (min-width: 1024px) {
+    font-size: 1.25rem;
+  }
+
+  &:hover {
+    gap: 1rem;
+    font-weight: 400;
+  }
+
+  &::after {
+    content: "";
+    width: 24px;
+    height: 24px;
+    display: inline-block;
+    -webkit-mask-size: cover;
+    background-color: var(--primary-black);
+    -webkit-mask: url("/_assets/arrow-up-right.svg") no-repeat 50% 50%;
+  }
+}
+
+.colorLight .internalLink {
   color: var(--primary-white);
 
   &::after {
@@ -68,7 +89,32 @@
   }
 }
 
-.sizeSmall .link {
+.colorLight .externalLink {
+  color: var(--primary-white);
+
+  &::after {
+    background-color: var(--primary-white);
+  }
+}
+
+.sizeSmall .internalLink {
+  font-size: 0.95rem;
+  gap: 0.25rem;
+
+  @media (min-width: 1024px) {
+    font-size: 1rem;
+  }
+
+  &:hover {
+    gap: 0.5rem;
+  }
+
+  &::after {
+    transform: scale(0.75);
+  }
+}
+
+.sizeSmall .externalLink {
   font-size: 0.95rem;
   gap: 0.25rem;
 
@@ -87,6 +133,8 @@
 
 .span {
   padding-bottom: 0.125rem;
+  text-decoration: underline;
+  text-underline-position: from-font;
 }
 
 .sizeSmall .span {

--- a/src/components/linkButton/linkButton.module.css
+++ b/src/components/linkButton/linkButton.module.css
@@ -32,9 +32,9 @@
     width: 1.5rem;
     height: 1.5rem;
     content: "";
-    -webkit-mask: url("/_assets/arrow.svg") no-repeat center;
+    -webkit-mask: url("/_assets/arrow-right.svg") no-repeat center;
     -webkit-mask-size: cover;
-    mask: url("/_assets/arrow.svg") no-repeat center;
+    mask: url("/_assets/arrow-right.svg") no-repeat center;
     mask-size: cover;
   }
 }

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -83,14 +83,15 @@
 }
 
 .bodyNormal {
-  font-size: 20px;
+  font-size: 1.25rem;
   font-style: normal;
   font-weight: 300;
 }
 
 .bodySmall {
   font-size: 1rem;
-  font-weight: 400;
+  font-weight: 300;
+  line-height: 150%;
 }
 
 /* TODO: add font variables */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,8 +36,8 @@ html {
   --background-bg-light-secondary: #eaeaea;
 
   /* breakpoints */
-  --breakpoint-mobile: 767px;
-  --breakpoint-tablet: 640px;
+  --breakpoint-mobile: 425px;
+  --breakpoint-tablet: 834px;
   --breakpoint-large: 1024px;
 
   /* max widths */

--- a/studioShared/lib/interfaces/customerCases.ts
+++ b/studioShared/lib/interfaces/customerCases.ts
@@ -17,7 +17,7 @@ export interface CustomerCaseProjectInfo {
 
 export interface CustomerSector {
   customerSector: string;
-  key: string;
+  _key: string;
 }
 
 export interface Deliveries {

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -49,6 +49,7 @@ export const CUSTOMER_CASE_QUERY = groq`
     "projectInfo": projectInfo {
       customer,
       "customerSectors": customerSectors[] {
+        _key,
         "customerSector": ${translatedFieldFragment("customerSectorItem")}
         },
       url,


### PR DESCRIPTION
This PR redesigns and refactors the project info section in customer case:

- Make the badge component to be used in customer sectors for project info, and make it custom by allowing backgroundColor and textColor to be sent in as props, default is grey (preparation for a later PR where the user defines the color of the badges in Sanity)
- Refactor project info into its own component to clean up the CustomerCase component
- Redesign the CustomLink to match the design by adding new arrows to match internal vs. external links, and fixing the underline and font size
- And other minor styling changes to project info so it matches the design, including mobile version

<img width="423" alt="Screenshot 2024-11-26 at 12 33 24" src="https://github.com/user-attachments/assets/e75a516c-0f54-4e7b-a80f-9aa12ce402fd">

<img width="248" alt="Screenshot 2024-11-26 at 12 33 37" src="https://github.com/user-attachments/assets/86c23d8d-3b4e-4417-99c7-4aa5d2de1ac3">
<img width="162" alt="Screenshot 2024-11-26 at 12 33 50" src="https://github.com/user-attachments/assets/48725144-dc56-4cdb-9fbb-a05bb1eb9622">
<img width="1342" alt="Screenshot 2024-11-26 at 12 34 32" src="https://github.com/user-attachments/assets/57786672-3dec-4f44-adcf-f27b292d31f4">
