### PR TITLE
checks in seo

### DIFF
--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -103,13 +103,16 @@ export function seoDataFromCustomerCase(customerCase: CustomerCaseDocument) {
     keywords: [
       customerCase.projectInfo.customer,
       customerCase.projectInfo.sector,
-      customerCase.projectInfo.deliveries.projectManagement.map(
-        (d) => d.projectManagementDelivery,
-      ),
-      customerCase.projectInfo.deliveries.design.map((d) => d.designDelivery),
-      customerCase.projectInfo.deliveries.development.map(
-        (d) => d.developmentDelivery,
-      ),
+      customerCase.projectInfo.deliveries.projectManagement &&
+        customerCase.projectInfo.deliveries.projectManagement.map(
+          (d) => d.projectManagementDelivery,
+        ),
+      customerCase.projectInfo.deliveries.design &&
+        customerCase.projectInfo.deliveries.design.map((d) => d.designDelivery),
+      customerCase.projectInfo.deliveries.development &&
+        customerCase.projectInfo.deliveries.development.map(
+          (d) => d.developmentDelivery,
+        ),
     ].join(","),
   };
 }


### PR DESCRIPTION
Empty fields in customer case project deliveries caused the page to crash. The issue arose because the SEO component attempted to map an empty array. This pull request adds checks in the SEO logic to prevent such errors.