### PR TITLE
v3 - customer case styling fixes 

### DIFF
--- a/messages/no.json
+++ b/messages/no.json
@@ -9,7 +9,7 @@
     "industry": "Bransje",
     "delivery": "Leveranse",
     "variants": "Variantene",
-    "in_project": "Varianter i prosjektet",
+    "in_project": "Varianter i arbeid",
     "design": "Design",
     "development": "Utvikling",
     "project_management": "Prosjektledelse",

--- a/src/components/customerCaseEmployeeCard/CustomerCaseEmployeeCard.tsx
+++ b/src/components/customerCaseEmployeeCard/CustomerCaseEmployeeCard.tsx
@@ -1,13 +1,8 @@
 import Image from "next/image";
-import Link from "next/link";
-import { useTranslations } from "next-intl";
 
-import CustomLink from "src/components/link/CustomLink";
 import Text from "src/components/text/Text";
 import formatPhoneNumber from "src/components/utils/formatPhoneNumber";
 import { ChewbaccaEmployee } from "src/types/employees";
-import { aliasFromEmail } from "src/utils/employees";
-import { LinkType } from "studio/lib/interfaces/navigation";
 
 import styles from "./customerCaseEmployeeCard.module.css";
 
@@ -18,13 +13,8 @@ export interface CustomerCaseEmployeeCardProps {
 }
 
 export default function CustomerCaseEmployeeCard({
-  currentLanguage,
   employee,
-  employeePageSlug,
 }: CustomerCaseEmployeeCardProps) {
-  const title = <p className={styles.employeeName}>{employee.name}</p>;
-  const t = useTranslations("custom_link");
-
   return (
     employee.imageThumbUrl &&
     employee.name &&
@@ -39,49 +29,32 @@ export default function CustomerCaseEmployeeCard({
           />
         </div>
         <div className={styles.employeeInfo}>
-          {employeePageSlug !== undefined ? (
-            <Link
-              href={`/${currentLanguage}/${employeePageSlug}/${aliasFromEmail(employee.email)}`}
-            >
-              {title}
-            </Link>
-          ) : (
-            title
-          )}
-          <div className={styles.employeeRole}>
-            {employee.competences.map((competence) => (
-              <Text
-                className={styles.employeeRoleDot}
-                type="labelRegular"
-                key={competence}
-              >
-                {competence}
-              </Text>
-            ))}
+          <div className={styles.employeeName}>
+            <Text type="bodyNormal">{employee.name}</Text>
+            <div className={styles.employeeRole}>
+              {employee.competences.map((competence) => (
+                <Text
+                  className={styles.employeeRoleDot}
+                  type="labelRegular"
+                  key={competence}
+                >
+                  {competence}
+                </Text>
+              ))}
+            </div>
           </div>
-          {employee.email && (
-            <p className={styles.employeeEmail}>{employee.email}</p>
-          )}
-          {employee.telephone && (
-            <p className={styles.employeeTelephone}>
-              {formatPhoneNumber(employee.telephone)}
-            </p>
-          )}
-          {employeePageSlug && (
-            <CustomLink
-              size={"small"}
-              link={{
-                _key: "go-to-mini-cv",
-                _type: "link",
-                linkType: LinkType.Internal,
-                linkTitle: t("visit_cv"),
-                language: currentLanguage,
-                internalLink: {
-                  _ref: `${employeePageSlug}/${aliasFromEmail(employee.email)}`,
-                },
-              }}
-            />
-          )}
+          <div>
+            {employee.email && (
+              <Text type="bodyExtraSmall" className={styles.employeeEmail}>
+                {employee.email}
+              </Text>
+            )}
+            {employee.telephone && (
+              <Text type="bodyExtraSmall" className={styles.employeeTelephone}>
+                {formatPhoneNumber(employee.telephone)}
+              </Text>
+            )}
+          </div>
         </div>
       </div>
     )

--- a/src/components/customerCaseEmployeeCard/customerCaseEmployeeCard.module.css
+++ b/src/components/customerCaseEmployeeCard/customerCaseEmployeeCard.module.css
@@ -2,6 +2,8 @@
   display: flex;
   width: 100%;
   gap: 1rem;
+  min-width: 400px;
+  width: fit-content; 
 }
 
 .employeeImage {
@@ -10,26 +12,28 @@
   align-items: center;
   background-color: var(--primary-black);
   border-radius: 12px;
-  height: 125px;
-  width: 50%;
-  padding: 1rem;
   position: relative;
+  width: 96px;
+  height: 94px;
 }
 
 .employeeInfo {
   display: flex;
   flex-direction: column;
-  width: 100%;
-  gap: 0.5rem;
-  white-space: nowrap;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.employeeName{
+  width: fit-content;
+  display: flex;
+  flex-direction: column;
 }
 
 .employeeRole {
   display: flex;
+  width: fit-content;
   flex-direction: row;
-  overflow: visible;
-  align-self: stretch;
-  width: 100%;
 }
 
 .employeeRoleDot::after {
@@ -42,24 +46,10 @@
   margin: 0;
 }
 
-.employeeName {
-  color: var(--text-primary);
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 120%;
-}
-
-.employeeRole {
-  color: var(--text-primary);
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 120%;
-}
-
+.employeeRole{
+  color: var(--text-tertiary); 
+} 
 .employeeEmail,
 .employeeTelephone {
-  color: var(--text-primary);
-  font-size: 0.75rem;
-  font-weight: 400;
-  line-height: 120%;
+  color: var(--text-tertiary); 
 }

--- a/src/components/customerCaseEmployeeCard/customerCaseEmployeeCard.module.css
+++ b/src/components/customerCaseEmployeeCard/customerCaseEmployeeCard.module.css
@@ -3,7 +3,7 @@
   width: 100%;
   gap: 1rem;
   min-width: 400px;
-  width: fit-content; 
+  width: fit-content;
 }
 
 .employeeImage {
@@ -24,7 +24,7 @@
   height: 100%;
 }
 
-.employeeName{
+.employeeName {
   width: fit-content;
   display: flex;
   flex-direction: column;
@@ -46,10 +46,10 @@
   margin: 0;
 }
 
-.employeeRole{
-  color: var(--text-tertiary); 
-} 
+.employeeRole {
+  color: var(--text-tertiary);
+}
 .employeeEmail,
 .employeeTelephone {
-  color: var(--text-tertiary); 
+  color: var(--text-tertiary);
 }

--- a/src/components/customerCases/customerCase/customerCase.module.css
+++ b/src/components/customerCases/customerCase/customerCase.module.css
@@ -55,7 +55,6 @@
   flex-direction: column;
   align-self: center;
   width: 100%;
-  max-width: 960px;
 }
 
 .sectionsWrapper {

--- a/src/components/customerCases/customerCase/projectInfo/customerCaseProjectInfo.module.css
+++ b/src/components/customerCases/customerCase/projectInfo/customerCaseProjectInfo.module.css
@@ -14,7 +14,6 @@
   gap: 1.5rem;
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
 }
 
 .badgeWrapper {
@@ -38,10 +37,10 @@
 }
 
 .varianter {
-  max-width: 537px;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  max-width: 80%;
 }
 
 .dotSeperatorVarianter::after {
@@ -57,6 +56,7 @@
 .projectInfoItem {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .title {
@@ -67,6 +67,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
 .preFancyCharacter {

--- a/src/components/customerCases/customerCase/projectInfo/customerCaseProjectInfo.module.css
+++ b/src/components/customerCases/customerCase/projectInfo/customerCaseProjectInfo.module.css
@@ -14,6 +14,7 @@
   gap: 1.5rem;
   display: flex;
   flex-direction: column;
+  max-width: 50%;
 }
 
 .badgeWrapper {

--- a/src/components/customerCases/customerCase/sections/customerCaseConsultants/CustomerCaseConsultants.tsx
+++ b/src/components/customerCases/customerCase/sections/customerCaseConsultants/CustomerCaseConsultants.tsx
@@ -29,7 +29,7 @@ export default async function CustomerCaseConsultants({
 
   return (
     <div className={styles.wrapper}>
-      <Text type={"h3"}>{t("in_project")}</Text>
+      <Text type={"h4"}>{t("in_project")}</Text>
       <div className={styles.content}>
         {consultants.map((consultant) => (
           <CustomerCaseEmployeeCard

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,5 +1,5 @@
 :where(.desktopLink, .h1, .h2, .h3, .h4, .h5, .h6, .bodyXl) {
-  margin: 0; 
+  margin: 0;
   font-family: var(--font-britti-sans);
 }
 
@@ -100,7 +100,7 @@
   font-weight: 400;
   line-height: 18px;
   letter-spacing: 0.14px;
-  
+
   @media (max-width: 375px) {
     font-size: 12px;
     letter-spacing: 0.12px;

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,4 +1,5 @@
 :where(.desktopLink, .h1, .h2, .h3, .h4, .h5, .h6, .bodyXl) {
+  margin: 0; 
   font-family: var(--font-britti-sans);
 }
 
@@ -94,8 +95,17 @@
   line-height: 150%;
 }
 
-/* TODO: add font variables */
-/* .bodyExtraSmall */
+.bodyExtraSmall {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+  letter-spacing: 0.14px;
+  
+  @media (max-width: 375px) {
+    font-size: 12px;
+    letter-spacing: 0.12px;
+  }
+}
 
 .labelSmall {
   font-size: 1rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -31,7 +31,7 @@ html {
   /* TODO: upgrade color-scheme with correct colors */
   --secondary-red: #f0503f;
   --text-primary: #222424;
-  --text-tertiary: #5e5e5e;
+  --text-tertiary: #5E5E5E;
 
   --background-bg-light-secondary: #eaeaea;
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -31,7 +31,7 @@ html {
   /* TODO: upgrade color-scheme with correct colors */
   --secondary-red: #f0503f;
   --text-primary: #222424;
-  --text-tertiary: #5E5E5E;
+  --text-tertiary: #5e5e5e;
 
   --background-bg-light-secondary: #eaeaea;
 


### PR DESCRIPTION
Updated the styling of the project info container to improve scalability. Adjusted the employee card design to align with the Figma sketches. Temporarily removed the link on the employee card, as the employee page/mini CV is not a current priority.

<img width="1132" alt="Screenshot 2024-11-26 at 20 35 27" src="https://github.com/user-attachments/assets/22235bb7-78b9-4f60-9313-5becaecbac28">

<img width="1254" alt="Screenshot 2024-11-26 at 20 35 21" src="https://github.com/user-attachments/assets/37a3c606-b947-4ec9-bfa6-7229ad74b841">

<img width="1332" alt="Screenshot 2024-11-26 at 20 34 28" src="https://github.com/user-attachments/assets/7868c6dd-5115-4959-a9a8-841beeb64020">
