### PR TITLE
fix: cache employee and optimise fetching single person

### DIFF
--- a/src/components/sections/employees/EmployeeList.tsx
+++ b/src/components/sections/employees/EmployeeList.tsx
@@ -36,9 +36,8 @@ export default function EmployeeList({
 }: EmployeesProps) {
   const employeesRes = use(employeesPromise);
   const employees = employeesRes.ok ? employeesRes.value : [];
-  const [filteredEmployees, setFilteredEmployees] = useState<
-    ChewbaccaEmployee[]
-  >(shuffleEmployees(employees));
+  const [filteredEmployees, setFilteredEmployees] =
+    useState<ChewbaccaEmployee[]>(employees);
 
   const locations = Array.from(new Set(employees.map((e) => e.officeName)));
   const t = useTranslations("employee_card");
@@ -160,8 +159,4 @@ export default function EmployeeList({
       </div>
     </>
   );
-}
-
-function shuffleEmployees(employees: ChewbaccaEmployee[]) {
-  return employees.sort(() => Math.random() - 0.5);
 }

--- a/src/components/sections/employees/Employees.tsx
+++ b/src/components/sections/employees/Employees.tsx
@@ -26,7 +26,9 @@ export default async function Employees({ language, section }: EmployeesProps) {
   );
   const employeesPageSlug = employeesPageRes.data.slug;
 
-  const countryTld = domainFromHostname(headers().get("host")).split(".")[1];
+  const countryTld = domainFromHostname(headers().get("host"))
+    .split(".")
+    .at(-1);
   const employees = fetchAllChewbaccaEmployees(countryTld);
 
   return (

--- a/src/utils/pageData.ts
+++ b/src/utils/pageData.ts
@@ -35,7 +35,7 @@ import { CUSTOMER_CASE_QUERY } from "studioShared/lib/queries/customerCases";
 import { loadSharedQuery } from "studioShared/lib/store";
 import { customerCaseID } from "studioShared/schemas/documents/customerCase";
 
-import { emailFromAliasAndHostname, fetchChewbaccaEmployee } from "./employees";
+import { fetchChewbaccaEmployee } from "./employees";
 import { isNonNullQueryResponse } from "./queryResponse";
 import { domainFromHostname } from "./url";
 
@@ -282,9 +282,8 @@ async function fetchEmployeePage({
     return null;
   }
   const employeeAlias = path[1];
-  const employee = await fetchChewbaccaEmployee(
-    emailFromAliasAndHostname(employeeAlias, hostname),
-  );
+  const employee = await fetchChewbaccaEmployee(employeeAlias, hostname);
+
   if (!employee.ok) {
     return null;
   }


### PR DESCRIPTION
Caches employees and avoid fetching too much information when fetching single employee


(PS: this hostname ordeal is not ideal the slightest, but figuring that handling se/no in a better way is out of scope of this and also, have no immediate solution)