### PR TITLE
feat: adds split image component and add it to Employee site

### DIFF
--- a/src/components/linkButton/LinkButton.tsx
+++ b/src/components/linkButton/LinkButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import Link from "next/link";
 
 import { getHref } from "src/utils/link";
 import { ILink } from "studio/lib/interfaces/navigation";
@@ -25,9 +25,9 @@ const LinkButton = ({ isSmall, type = "primary", link }: IButton) => {
   return (
     href &&
     linkTitleValue && (
-      <a className={className} href={href}>
+      <Link className={className} href={href}>
         {linkTitleValue}
-      </a>
+      </Link>
     )
   );
 };

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -42,9 +42,16 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
           />
         )}
 
-        {section.link && (
+        {section.actions.length > 0 && (
           <div className={styles.textContainer__link}>
-            <LinkButton isSmall link={section.link} />
+            {section.actions.map((action, index) => (
+              <LinkButton
+                key={action._key}
+                type={index === 0 ? "primary" : "secondary"}
+                isSmall
+                link={action}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -1,0 +1,42 @@
+import { PortableText, PortableTextReactComponents } from "@portabletext/react";
+
+import { SanityImage } from "src/components/image/SanityImage";
+import CustomLink from "src/components/link/CustomLink";
+import Text from "src/components/text/Text";
+import { ImageSplitSection } from "studio/lib/interfaces/pages";
+
+import styles from "./image-split.module.css";
+
+interface ImageSplitProps {
+  section: ImageSplitSection;
+}
+
+const myPortableTextComponents: Partial<PortableTextReactComponents> = {
+  block: ({ children }) => <Text type="bodySmall">{children}</Text>,
+};
+
+const ImageSplitComponent = ({ section }: ImageSplitProps) => {
+  return (
+    <article className={styles.article}>
+      <Text type="h2">{section.basicTitle}</Text>
+
+      <div>
+        {section.richText && (
+          <PortableText
+            value={section.richText}
+            components={myPortableTextComponents}
+          />
+        )}
+        {section.link && <CustomLink link={section.link} />}
+      </div>
+
+      {section.imageExtended && (
+        <div className={styles.image}>
+          <SanityImage image={section.imageExtended} />
+        </div>
+      )}
+    </article>
+  );
+};
+
+export default ImageSplitComponent;

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -6,6 +6,7 @@ import Text from "src/components/text/Text";
 import { ImageSplitSection } from "studio/lib/interfaces/pages";
 
 import styles from "./image-split.module.css";
+import { ImageAlignment } from "studio/schemas/fields/media";
 
 interface ImageSplitProps {
   section: ImageSplitSection;
@@ -16,8 +17,19 @@ const myPortableTextComponents: Partial<PortableTextReactComponents> = {
 };
 
 const ImageSplitComponent = ({ section }: ImageSplitProps) => {
+  const hasImage = section.imageExtended;
+  const alignment = section.imageExtended?.imageAlignment;
+  const showImageToLeft = hasImage && alignment == ImageAlignment.Left;
+  const showImageToRight = hasImage && alignment == ImageAlignment.Right;
+
   return (
     <article className={styles.imageSplit}>
+      {showImageToLeft && (
+        <div className={styles.image}>
+          <SanityImage image={section.imageExtended} />
+        </div>
+      )}
+
       <div className={styles.textContainer}>
         <Text type="h4" as="h2">
           {section.basicTitle}
@@ -37,7 +49,7 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
         )}
       </div>
 
-      {section.imageExtended && (
+      {showImageToRight && (
         <div className={styles.image}>
           <SanityImage image={section.imageExtended} />
         </div>

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -1,7 +1,7 @@
 import { PortableText, PortableTextReactComponents } from "@portabletext/react";
 
 import { SanityImage } from "src/components/image/SanityImage";
-import CustomLink from "src/components/link/CustomLink";
+import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
 import { ImageSplitSection } from "studio/lib/interfaces/pages";
 
@@ -12,22 +12,29 @@ interface ImageSplitProps {
 }
 
 const myPortableTextComponents: Partial<PortableTextReactComponents> = {
-  block: ({ children }) => <Text type="bodySmall">{children}</Text>,
+  block: ({ children }) => <Text type="bodyNormal">{children}</Text>,
 };
 
 const ImageSplitComponent = ({ section }: ImageSplitProps) => {
   return (
-    <article className={styles.article}>
-      <Text type="h2">{section.basicTitle}</Text>
+    <article className={styles.imageSplit}>
+      <div className={styles.textContainer}>
+        <Text type="h4" as="h2">
+          {section.basicTitle}
+        </Text>
 
-      <div>
         {section.richText && (
           <PortableText
             value={section.richText}
             components={myPortableTextComponents}
           />
         )}
-        {section.link && <CustomLink link={section.link} />}
+
+        {section.link && (
+          <div className={styles.textContainer__link}>
+            <LinkButton isSmall link={section.link} />
+          </div>
+        )}
       </div>
 
       {section.imageExtended && (

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -4,9 +4,9 @@ import { SanityImage } from "src/components/image/SanityImage";
 import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
 import { ImageSplitSection } from "studio/lib/interfaces/pages";
+import { ImageAlignment } from "studio/schemas/fields/media";
 
 import styles from "./image-split.module.css";
-import { ImageAlignment } from "studio/schemas/fields/media";
 
 interface ImageSplitProps {
   section: ImageSplitSection;

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -1,5 +1,3 @@
-import { PortableText, PortableTextReactComponents } from "@portabletext/react";
-
 import { SanityImage } from "src/components/image/SanityImage";
 import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
@@ -11,10 +9,6 @@ import styles from "./image-split.module.css";
 interface ImageSplitProps {
   section: ImageSplitSection;
 }
-
-const myPortableTextComponents: Partial<PortableTextReactComponents> = {
-  block: ({ children }) => <Text type="bodyNormal">{children}</Text>,
-};
 
 const ImageSplitComponent = ({ section }: ImageSplitProps) => {
   const hasImage = section.imageExtended;
@@ -35,11 +29,8 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
           {section.basicTitle}
         </Text>
 
-        {section.richText && (
-          <PortableText
-            value={section.richText}
-            components={myPortableTextComponents}
-          />
+        {section.description && (
+          <Text type="bodyNormal">{section.description}</Text>
         )}
 
         {section.actions.length > 0 && (

--- a/src/components/sections/image-split/ImageSplitPreview.tsx
+++ b/src/components/sections/image-split/ImageSplitPreview.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useQuery } from "@sanity/react-loader";
+import { Suspense } from "react";
+
+import { PreviewProps } from "src/types/preview";
+import { ImageSplitSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { PAGE_QUERY } from "studio/lib/queries/pages";
+
+import ImageSplit from "./ImageSplit";
+
+export default function ImageSplitComponentPreview({
+  sectionIndex,
+  initialData,
+}: PreviewProps) {
+  const { data: newData } = useQuery<PageBuilder | null>(
+    PAGE_QUERY,
+    { id: initialData.data._id, language: initialData.data.language },
+    { initial: initialData },
+  );
+
+  const imageSplitSection = newData
+    ? (newData.sections.find(
+        (section, index) =>
+          section._type === "imageSplitSection" && index === sectionIndex,
+      ) as ImageSplitSection)
+    : (initialData.data.sections.find(
+        (section, index) =>
+          section._type === "imageSplitSection" && index === sectionIndex,
+      ) as ImageSplitSection);
+
+  return (
+    <Suspense>
+      <ImageSplit section={imageSplitSection} />
+    </Suspense>
+  );
+}

--- a/src/components/sections/image-split/image-split.module.css
+++ b/src/components/sections/image-split/image-split.module.css
@@ -1,23 +1,29 @@
-.shared {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+.imageSplit {
+  max-width: var(--max-content-width-small);
+
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+
+  gap: 3rem;
+  row-gap: 5.25rem;
+  padding: 1rem;
+  margin: 3.75rem auto;
+
+  box-sizing: content-box;
   align-items: center;
 }
 
-.callout {
-  composes: shared;
-  width: -webkit-fill-available;
-  max-width: 75rem;
-  gap: 3rem;
+.textContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
 
-  padding: 5rem 2rem;
+.textContainer__link {
+  margin-top: 1.5rem;
+}
 
-  @media (min-width: 640px) {
-    padding: 5rem 3rem;
-  }
-
-  @media (min-width: 1024px) {
-    padding: 7.5rem;
-  }
+.image {
+  display: flex;
+  justify-content: center;
 }

--- a/src/components/sections/image-split/image-split.module.css
+++ b/src/components/sections/image-split/image-split.module.css
@@ -21,6 +21,9 @@
 
 .textContainer__link {
   margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .image {

--- a/src/components/sections/image-split/image-split.module.css
+++ b/src/components/sections/image-split/image-split.module.css
@@ -1,0 +1,23 @@
+.shared {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.callout {
+  composes: shared;
+  width: -webkit-fill-available;
+  max-width: 75rem;
+  gap: 3rem;
+
+  padding: 5rem 2rem;
+
+  @media (min-width: 640px) {
+    padding: 5rem 3rem;
+  }
+
+  @media (min-width: 1024px) {
+    padding: 7.5rem;
+  }
+}

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -1,5 +1,4 @@
 import { QueryResponseInitial } from "@sanity/react-loader";
-import React from "react";
 
 import Article from "src/components/sections/article/Article";
 import ArticlePreview from "src/components/sections/article/ArticlePreview";
@@ -13,6 +12,8 @@ import Grid from "src/components/sections/grid/Grid";
 import GridPreview from "src/components/sections/grid/GridPreview";
 import { Hero } from "src/components/sections/hero/Hero";
 import HeroPreview from "src/components/sections/hero/HeroPreview";
+import ImageSplitComponent from "src/components/sections/image-split/ImageSplit";
+import ImageSplitComponentPreview from "src/components/sections/image-split/ImageSplitPreview";
 import ImageSectionComponent from "src/components/sections/imageSection/ImageSectionComponent";
 import ImageSectionComponentPreview from "src/components/sections/imageSection/ImageSectionComponentPreview";
 import { LogoSalad } from "src/components/sections/logoSalad/LogoSalad";
@@ -26,6 +27,7 @@ import {
   GridSection,
   HeroSection,
   ImageSection,
+  ImageSplitSection,
   LogoSaladSection,
   PageBuilder,
   Section,
@@ -145,6 +147,26 @@ const renderImageSection = (
     <ImageSectionComponent section={section} />
   );
 };
+function ImageSplitSectionWrapper({
+  section,
+  sectionIndex,
+  isDraftMode,
+  initialData,
+}: {
+  section: ImageSplitSection;
+  sectionIndex: number;
+  isDraftMode: boolean;
+  initialData: QueryResponseInitial<PageBuilder>;
+}) {
+  return isDraftMode ? (
+    <ImageSplitComponentPreview
+      initialData={initialData}
+      sectionIndex={sectionIndex}
+    />
+  ) : (
+    <ImageSplitComponent section={section} />
+  );
+}
 
 const renderGridSection = (
   section: GridSection,
@@ -217,6 +239,15 @@ const SectionRenderer = ({
         sectionIndex,
         isDraftMode,
         initialData,
+      );
+    case "imageSplitSection":
+      return (
+        <ImageSplitSectionWrapper
+          section={section}
+          sectionIndex={sectionIndex}
+          isDraftMode={isDraftMode}
+          initialData={initialData}
+        />
       );
     case "grid":
       return renderGridSection(section, sectionIndex, isDraftMode, initialData);

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -73,7 +73,7 @@ export interface ImageSplitSection {
   _key: string;
   basicTitle: string;
   imageExtended: ImageExtendedProps;
-  richText?: PortableTextBlock[];
+  description: string;
   actions: ILink[];
 }
 

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -74,7 +74,7 @@ export interface ImageSplitSection {
   basicTitle: string;
   imageExtended: ImageExtendedProps;
   richText?: PortableTextBlock[];
-  link?: ILink;
+  actions: ILink[];
 }
 
 export interface GridSection {

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -68,6 +68,15 @@ export interface ImageSection {
   image: IImage;
 }
 
+export interface ImageSplitSection {
+  _type: "imageSplitSection";
+  _key: string;
+  basicTitle: string;
+  imageExtended: ImageExtendedProps;
+  richText?: PortableTextBlock[];
+  link?: ILink;
+}
+
 export interface GridSection {
   _type: "grid";
   _key: string;
@@ -108,6 +117,7 @@ export type Section =
   | CallToActionSection
   | TestimonialsSection
   | ImageSection
+  | ImageSplitSection
   | GridSection
   | ContactBoxSection
   | EmployeesSection;

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -29,6 +29,8 @@ const SECTIONS_FRAGMENT = groq`
     },
     _type == "imageSplitSection" => {
       ...,
+      "basicTitle": ${translatedFieldFragment("basicTitle")},
+      "description": ${translatedFieldFragment("description")},
       actions[] {
         ...,
         ${TRANSLATED_LINK_FRAGMENT}

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -29,7 +29,7 @@ const SECTIONS_FRAGMENT = groq`
     },
     _type == "imageSplitSection" => {
       ...,
-      link {
+      actions[] {
         ...,
         ${TRANSLATED_LINK_FRAGMENT}
       }

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -27,6 +27,13 @@ const SECTIONS_FRAGMENT = groq`
         ${TRANSLATED_LINK_FRAGMENT}
       }
     },
+    _type == "imageSplitSection" => {
+      ...,
+      link {
+        ...,
+        ${TRANSLATED_LINK_FRAGMENT}
+      }
+    },
     _type == "ctaSection" => {
       ...,
       callToActions[] {

--- a/studio/schemas/documents/pageBuilder.ts
+++ b/studio/schemas/documents/pageBuilder.ts
@@ -10,6 +10,7 @@ import { employees } from "studio/schemas/objects/sections/employees";
 import grid from "studio/schemas/objects/sections/grid";
 import hero from "studio/schemas/objects/sections/hero";
 import imageSection from "studio/schemas/objects/sections/image";
+import imageSplitSection from "studio/schemas/objects/sections/imagesplit";
 import logoSalad from "studio/schemas/objects/sections/logoSalad";
 import testimonals from "studio/schemas/objects/sections/testimonials";
 import seo from "studio/schemas/objects/seo";
@@ -47,6 +48,7 @@ const pageBuilder = defineType({
         callout,
         callToAction,
         testimonals,
+        imageSplitSection,
         imageSection,
         grid,
         employees,

--- a/studio/schemas/objects/sections/imagesplit.ts
+++ b/studio/schemas/objects/sections/imagesplit.ts
@@ -1,8 +1,9 @@
 import { defineField } from "sanity";
 
 import { imageExtended } from "studio/schemas/fields/media";
-import { richText, title } from "studio/schemas/fields/text";
+import { titleID } from "studio/schemas/fields/text";
 import { link } from "studio/schemas/objects/link";
+import { firstTranslation } from "studio/utils/i18n";
 
 export const imageID = "imageSplitSection";
 
@@ -11,8 +12,22 @@ export const imageSplitSection = defineField({
   title: "Image Split",
   type: "object",
   fields: [
-    title,
-    richText,
+    {
+      name: titleID.basic,
+      type: "internationalizedArrayString",
+      title: "Title",
+      description:
+        "Enter the primary title that will be displayed at the top of the employees section.",
+    },
+
+    {
+      name: "description",
+      type: "internationalizedArrayString",
+      title: "Main content",
+      description:
+        "Enter the main content that will be displayed below the title.",
+    },
+
     imageExtended,
     {
       name: "actions",
@@ -28,8 +43,7 @@ export const imageSplitSection = defineField({
     prepare(selection) {
       const { title } = selection;
       return {
-        title: title,
-        subtitle: "Image",
+        title: firstTranslation(title) ?? undefined,
       };
     },
   },

--- a/studio/schemas/objects/sections/imagesplit.ts
+++ b/studio/schemas/objects/sections/imagesplit.ts
@@ -1,0 +1,28 @@
+import { defineField } from "sanity";
+
+import { imageExtended } from "studio/schemas/fields/media";
+import { richText, title } from "studio/schemas/fields/text";
+import { link } from "studio/schemas/objects/link";
+
+export const imageID = "imageSplitSection";
+
+export const imageSplitSection = defineField({
+  name: imageID,
+  title: "Image Split",
+  type: "object",
+  fields: [title, richText, imageExtended, link],
+  preview: {
+    select: {
+      title: "basicTitle",
+    },
+    prepare(selection) {
+      const { title } = selection;
+      return {
+        title: title,
+        subtitle: "Image",
+      };
+    },
+  },
+});
+
+export default imageSplitSection;

--- a/studio/schemas/objects/sections/imagesplit.ts
+++ b/studio/schemas/objects/sections/imagesplit.ts
@@ -10,7 +10,17 @@ export const imageSplitSection = defineField({
   name: imageID,
   title: "Image Split",
   type: "object",
-  fields: [title, richText, imageExtended, link],
+  fields: [
+    title,
+    richText,
+    imageExtended,
+    {
+      name: "actions",
+      title: "Actions (links)",
+      type: "array",
+      of: [link],
+    },
+  ],
   preview: {
     select: {
       title: "basicTitle",


### PR DESCRIPTION
Adds generic split image module that should work like this:
Can be used on several places, but adds this specific block to employee site.

Fixes https://github.com/varianter/variant.no/issues/897

## Todo later:

- Fix ButtonLink component to match design


Screenshots:

![Screenshot 2024-11-29 at 19 18 27](https://github.com/user-attachments/assets/ae9b36be-d881-4584-a175-4036c1dae223)
![Screenshot 2024-11-29 at 19 18 07](https://github.com/user-attachments/assets/85e9981f-e7a6-41c5-a52f-8f32f034ef1a)
![Screenshot 2024-11-29 at 19 20 04](https://github.com/user-attachments/assets/e81975c5-f41f-4541-9ad2-263bd74cfa1a)

