### PR TITLE
feat: adds sanity structure for compensation calculator section

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -25,6 +25,20 @@
     "visit_cv": "Visit mini-CV",
     "read_more": "Read more"
   },
+  "compensation_calculator": {
+    "calculator": {
+      "formLabel": "Salary calculator",
+      "educationInput": "Education",
+      "yearInput": "The year you started in relevant work",
+      "bonusResult": "+ bonus",
+      "resultLabel": "Your annual salary"
+    },
+    "degreeOptions": {
+      "bachelor": "Bachelor",
+      "master": "Master"
+    }
+  },
+
   "employee_card": {
     "show": "Showing",
     "of": "out of",

--- a/messages/no.json
+++ b/messages/no.json
@@ -21,6 +21,19 @@
     "contact_sale": "Kontakt salg!",
     "contact_us": "Kontakt oss"
   },
+  "compensation_calculator": {
+    "calculator": {
+      "formLabel": "Lønnskalkulator",
+      "educationInput": "Utdanning",
+      "yearInput": "Året du begynte i relevant arbeid",
+      "bonusResult": "+ bonus",
+      "resultLabel": "Din årslønn"
+    },
+    "degreeOptions": {
+      "bachelor": "Bachelor",
+      "master": "Master"
+    }
+  },
   "custom_link": {
     "visit_cv": "Gå til mini-CV",
     "read_more": "Les mer"

--- a/messages/se.json
+++ b/messages/se.json
@@ -21,6 +21,19 @@
     "contact_sale": "Kontakta sälj!",
     "contact_us": "Kontakt oss"
   },
+  "compensation_calculator": {
+    "calculator": {
+      "formLabel": "Lönskalkulator",
+      "educationInput": "Utbildning",
+      "yearInput": "Året du började i relevant arbete",
+      "bonusResult": "+ bonus",
+      "resultLabel": "Din årslön"
+    },
+    "degreeOptions": {
+      "bachelor": "Bachelor",
+      "master": "Master"
+    }
+  },
   "custom_link": {
     "visit_cv": "Besök mini-CV",
     "read_more": "Läs mer"

--- a/src/components/compensations/utils/salary.ts
+++ b/src/components/compensations/utils/salary.ts
@@ -11,7 +11,7 @@ export function calculateSalary(
   salaries: Salaries,
 ): number | undefined {
   const degreeValue = degree === "bachelor" ? 1 : 0;
-  const adjustedYear = examinationYear + degreeValue;
+  const adjustedYear = examinationYear - degreeValue;
   return salaries[adjustedYear];
 }
 

--- a/src/components/forms/inputField/inputField.module.css
+++ b/src/components/forms/inputField/inputField.module.css
@@ -8,7 +8,7 @@
 }
 
 .label {
-  color: var(--background-bg-dark);
+  color: currentColor;
 }
 
 .input {
@@ -16,10 +16,10 @@
   padding: 0.5rem 0.75rem;
   align-items: center;
   gap: 0.5rem;
-  align-self: stretch;
+  font-size: 1rem;
 
-  border-radius: 0.5rem;
-  border: 1px solid var(--background-bg-light-secondary, #ece1d3);
+  border-radius: var(--radius-small);
+  border: 1px solid var(--stroke-primary, #ece1d3);
   background: var(--text-primary-light, #fff);
 }
 

--- a/src/components/forms/radioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/forms/radioButtonGroup/RadioButtonGroup.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import styles from "src/components/forms/radioButtonGroup/radioButtonGroup.module.css";
 import { tagComponentStyle } from "src/components/tag";
 import Text from "src/components/text/Text";
+import { cnIf } from "src/utils/css";
 
 export interface IOption {
   id: string;
@@ -88,13 +89,14 @@ const RadioButton = ({
   onChange,
   background = "light",
 }: RadioButtonProps) => {
-  const className = tagComponentStyle(checked, background);
+  const className = cnIf({
+    [tagComponentStyle(checked, background)]: true,
+    [styles.inputLabelDisabled]: disabled ?? false,
+    [styles.inputLabel]: true,
+  });
 
   return (
-    <label
-      htmlFor={id}
-      className={`${className} ${disabled ? styles.disabledLabel : ""} ${styles.inputLabel}`}
-    >
+    <label htmlFor={id} className={className}>
       <input
         className={styles.input}
         type="radio"

--- a/src/components/forms/radioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/forms/radioButtonGroup/RadioButtonGroup.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 
 import styles from "src/components/forms/radioButtonGroup/radioButtonGroup.module.css";
-import textStyles from "src/components/text/text.module.css";
+import { tagComponentStyle } from "src/components/tag";
+import Text from "src/components/text/Text";
 
 export interface IOption {
   id: string;
@@ -17,6 +18,8 @@ interface RadioButtonProps {
   checked?: boolean;
   disabled?: boolean;
   defaultChecked?: boolean;
+  background?: "light" | "dark" | "violet";
+
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -26,6 +29,7 @@ interface RadioButtonGroupProps {
   options: IOption[];
   selectedId: string;
   onValueChange: (option: IOption) => void;
+  background?: "light" | "dark" | "violet";
 }
 
 export const RadioButtonGroup = ({
@@ -34,6 +38,7 @@ export const RadioButtonGroup = ({
   options,
   selectedId,
   onValueChange,
+  background = "light",
 }: RadioButtonGroupProps) => {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedOption = options.find(
@@ -46,21 +51,28 @@ export const RadioButtonGroup = ({
 
   return (
     <fieldset className={styles.fieldset} id={id}>
-      <legend className={textStyles.h3}>{label}</legend>
-      <div className={styles.wrapper}>
-        {options.map(({ id, label, disabled }) => (
-          <RadioButton
-            key={id}
-            id={id}
-            label={label}
-            name="radio"
-            disabled={disabled}
-            value={id}
-            checked={id === selectedId}
-            onChange={onChange}
-          />
-        ))}
-      </div>
+      <legend className={styles.srOnly}>
+        <Text type="labelRegular" as="span">
+          {label}
+        </Text>
+      </legend>
+      <Text type="labelRegular" aria-hidden>
+        {label}
+      </Text>
+
+      {options.map(({ id, label, disabled }) => (
+        <RadioButton
+          key={id}
+          id={id}
+          label={label}
+          name="radio"
+          disabled={disabled}
+          value={id}
+          checked={id === selectedId}
+          background={background}
+          onChange={onChange}
+        />
+      ))}
     </fieldset>
   );
 };
@@ -70,15 +82,18 @@ const RadioButton = ({
   name,
   value,
   label,
-  checked,
+  checked = false,
   disabled,
   defaultChecked,
   onChange,
+  background = "light",
 }: RadioButtonProps) => {
+  const className = tagComponentStyle(checked, background);
+
   return (
     <label
       htmlFor={id}
-      className={`${styles.container} ${textStyles.caption} ${disabled ? styles.disabledLabel : styles.label}`}
+      className={`${className} ${disabled ? styles.disabledLabel : ""} ${styles.inputLabel}`}
     >
       <input
         className={styles.input}

--- a/src/components/forms/radioButtonGroup/radioButtonGroup.module.css
+++ b/src/components/forms/radioButtonGroup/radioButtonGroup.module.css
@@ -1,6 +1,20 @@
 .fieldset {
   border: 0 none;
   padding: 0;
+
+  display: flex;
+  flex-direction: row;
+  gap: 0.75rem;
+  row-gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.srOnly {
+  /* hide from everything but screen readers */
+  position: absolute;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .wrapper {
@@ -15,49 +29,23 @@
   align-items: center;
 }
 
-.label {
-  font-size: 1rem;
-  color: var(--dark-purple);
-}
-
 .disabledLabel {
   color: gray;
   cursor: not-allowed;
 }
 
+.inputLabel {
+  madgin: 0;
+  padding: 0;
+}
 .input {
   appearance: none;
-  width: 24px;
-  height: 24px;
-  border: 2px solid black;
-  border-radius: 50%;
-  transition: all 0.1s ease-in-out;
-  box-sizing: border-box;
-  background-color: white;
-  position: relative;
-}
-
-.input:checked::after {
-  content: "";
+  width: 0px;
+  height: 0px;
+  border: none;
   position: absolute;
-  top: 4px;
-  left: 4px;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background-color: var(--background-bg-dark);
-}
-
-.input:hover {
-  background-color: var(--background-bg-light-primary);
-  outline: 2px solid var(--background-button-outline-dark);
-}
-
-.input:focus {
-  outline: 2px solid var(--background-button-outline-dark);
-}
-
-.input[disabled] {
-  cursor: not-allowed;
-  border-color: grey;
+  /* hide from everything but screen readers */
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
 }

--- a/src/components/linkButton/LinkButton.tsx
+++ b/src/components/linkButton/LinkButton.tsx
@@ -11,15 +11,32 @@ interface IButton {
   isSmall?: boolean;
   type?: LinkButtonType;
   link: ILink;
+  background?: "dark" | "light";
 }
 
-const typeClassMap: { [key in LinkButtonType]: string } = {
-  primary: styles.primary,
-  secondary: styles.secondary,
-};
+const typeClassMap = (
+  background: IButton["background"],
+): {
+  [key in LinkButtonType]: string;
+} => ({
+  primary:
+    background === "dark"
+      ? `${styles.primary} ${styles["primary--darkBg"]}`
+      : styles.primary,
+  secondary:
+    background === "dark"
+      ? `${styles.secondary} ${styles["secondary--darkBg"]}`
+      : styles.secondary,
+});
 
-const LinkButton = ({ isSmall, type = "primary", link }: IButton) => {
-  const className = `${styles.button} ${isSmall ? styles.small : ""} ${typeClassMap[type]}`;
+const LinkButton = ({
+  isSmall,
+  type = "primary",
+  link,
+  background,
+}: IButton) => {
+  const classMap = typeClassMap(background);
+  const className = `${styles.button} ${isSmall ? styles.small : ""} ${classMap[type]}`;
   const href = getHref(link);
   const linkTitleValue = link.linkTitle;
   return (

--- a/src/components/linkButton/linkButton.module.css
+++ b/src/components/linkButton/linkButton.module.css
@@ -72,9 +72,13 @@
 
 .secondary {
   /* Todo: this color needs to be changes */
-  color: var(--background-bg-dark);
+  --_borderColor: var(--text-secondary);
+  --_color: var(--background-bg-dark);
+  --_iconColor: var(--text-secondary);
+
+  color: var(--_color);
   background: rgba(255, 255, 255, 0);
-  border: 1px solid var(--text-secondary);
+  border: 1px solid var(--_borderColor);
 
   &:hover {
     background: rgba(31, 31, 31, 0.05);
@@ -85,6 +89,15 @@
   }
 
   &::after {
-    background-color: var(--text-secondary);
+    background-color: var(--_iconColor);
+  }
+}
+.secondary--darkBg {
+  /* @TODO: this color needs to be changed */
+  --_borderColor: var(--background-bg-light-secondary);
+  --_color: currentColor;
+
+  &::after {
+    background-color: currentColor;
   }
 }

--- a/src/components/linkButton/linkButton.module.css
+++ b/src/components/linkButton/linkButton.module.css
@@ -71,7 +71,6 @@
 }
 
 .secondary {
-  /* Todo: this color needs to be changes */
   --_borderColor: var(--text-secondary);
   --_color: var(--background-bg-dark);
   --_iconColor: var(--text-secondary);

--- a/src/components/sections/compensation-calculator/Calculator.tsx
+++ b/src/components/sections/compensation-calculator/Calculator.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { use, useState } from "react";
 
 import { calculateSalary } from "src/components/compensations/utils/salary";
@@ -15,14 +16,13 @@ import { Result } from "studio/utils/result";
 
 import styles from "./compensation-calculator.module.css";
 import { Degree, SalaryData } from "./types";
-import { useTranslations } from "next-intl";
 
 type CalculatorProps = {
   localeRes: Promise<LocaleDocument>;
   salariesRes: Promise<Result<SalaryData, unknown>>;
   background: "light" | "dark" | "violet";
   initialDegree: Degree;
-  initialYear: number;
+  initialYear?: number;
 };
 
 export default function Calculator({
@@ -35,7 +35,9 @@ export default function Calculator({
   const t = useTranslations("compensation_calculator");
   const locale = use(localeRes);
   const salaries = use(salariesRes);
-  const [year, setYear] = useState(initialYear);
+  const [year, setYear] = useState(
+    initialYear ?? getMaybeMaxYear(salaries) ?? new Date().getFullYear(),
+  );
   const [degree, setDegree] = useState<Degree>(initialDegree);
 
   if (!locale || !salaries.ok) {
@@ -100,4 +102,9 @@ function getMinMaxYear(salaries: SalaryData) {
   const min = Math.min(...years);
   const max = Math.max(...years);
   return { min, max };
+}
+function getMaybeMaxYear(salaries: Result<SalaryData, unknown>) {
+  if (!salaries.ok) return undefined;
+  const years = Object.keys(salaries.value).map((s) => parseInt(s));
+  return Math.max(...years);
 }

--- a/src/components/sections/compensation-calculator/Calculator.tsx
+++ b/src/components/sections/compensation-calculator/Calculator.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { use, useEffect, useOptimistic, useState } from "react";
+import Text from "src/components/text/Text";
+import { formatAsCurrency } from "src/utils/i18n";
+import { LocaleDocument } from "studio/lib/interfaces/locale";
+import { getSalaryByYear } from "./actions";
+import {
+  IOption,
+  RadioButtonGroup,
+} from "src/components/forms/radioButtonGroup/RadioButtonGroup";
+import InputField from "src/components/forms/inputField/InputField";
+import Button from "src/components/buttons/Button";
+
+export type Degree = "bachelor" | "master";
+
+type CalculatorProps = {
+  initialSalary: number;
+  localeRes: Promise<LocaleDocument>;
+};
+
+type SalarySettings = {
+  year: number;
+  degree: Degree;
+};
+
+export default function Calculator({
+  localeRes,
+  initialSalary,
+}: CalculatorProps) {
+  const locale = use(localeRes);
+  const [year, setYear] = useState(2024);
+  const [degree, setDegree] = useState<Degree>("bachelor");
+  const [salary, setSalary] = useState(initialSalary);
+
+  if (!locale) {
+    console.error(
+      "[CompensationCalculator]: Sanity data not found. Not rendering CompensationCalculator.",
+    );
+    return null;
+  }
+
+  useEffect(() => {
+    async function fetchSalary() {
+      const salaryByYear = await getSalaryByYear(year);
+      console.log(salaryByYear);
+
+      setSalary(salaryByYear.ok ? salaryByYear.value : initialSalary);
+    }
+
+    fetchSalary();
+  }, [year, degree]);
+
+  return (
+    <div>
+      <SalaryCalculator
+        examinationYearValue={year}
+        minExaminationYear={1985}
+        maxExaminationYear={2024}
+        selectedDegree={degree}
+        onDegreeChanged={setDegree}
+        onExaminationYearChanged={setYear}
+        action={async () => {
+          const salaryByYear = await getSalaryByYear(2024);
+
+          console.log(salaryByYear);
+        }}
+      />
+
+      {salary !== null ? (
+        <div aria-live="polite">
+          <Text>Din årslønn</Text>
+          <Text>
+            {salary}
+            {/* {formatAsCurrency(salary, locale.locale, locale.currency)} */}
+          </Text>
+          <Text>+ bonus</Text>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const degreeOptions: IOption[] = [
+  { id: "bachelor", label: "Bachelor" },
+  { id: "master", label: "Master" },
+];
+
+interface SalaryCalculatorProps {
+  examinationYearValue: number;
+  minExaminationYear: number;
+  maxExaminationYear: number;
+  selectedDegree: Degree;
+  onDegreeChanged: (degree: Degree) => void;
+  onExaminationYearChanged: (examinationYear: number) => void;
+  action: (data: FormData) => void;
+}
+
+function SalaryCalculator({
+  examinationYearValue: yearValue,
+  minExaminationYear,
+  maxExaminationYear,
+  selectedDegree,
+  onDegreeChanged,
+  onExaminationYearChanged,
+  action,
+}: SalaryCalculatorProps) {
+  return (
+    <form
+      //TODO: replace aria-label with static translation from Sanity
+      aria-label="salary calculator"
+      action={action}
+    >
+      <RadioButtonGroup
+        id="degree-group"
+        label="Velg utdanning"
+        options={degreeOptions}
+        selectedId={selectedDegree}
+        onValueChange={(selectedOption) =>
+          onDegreeChanged(selectedOption.id as Degree)
+        }
+      />
+      <div>
+        <InputField
+          label="Year"
+          name="examinationYear"
+          type="number"
+          min={minExaminationYear}
+          max={maxExaminationYear}
+          value={yearValue}
+          onChange={(_name, value) => onExaminationYearChanged(parseInt(value))}
+          required
+        />
+      </div>
+      <Button type="secondary" size="small">
+        Regn ut
+      </Button>
+    </form>
+  );
+}

--- a/src/components/sections/compensation-calculator/Calculator.tsx
+++ b/src/components/sections/compensation-calculator/Calculator.tsx
@@ -2,7 +2,6 @@
 
 import { use, useState } from "react";
 
-import Button from "src/components/buttons/Button";
 import { calculateSalary } from "src/components/compensations/utils/salary";
 import InputField from "src/components/forms/inputField/InputField";
 import {
@@ -120,9 +119,6 @@ function SalaryCalculator({
           required
         />
       </div>
-      <Button type="secondary" size="small">
-        Regn ut
-      </Button>
     </form>
   );
 }

--- a/src/components/sections/compensation-calculator/Calculator.tsx
+++ b/src/components/sections/compensation-calculator/Calculator.tsx
@@ -13,21 +13,28 @@ import { formatAsCurrency } from "src/utils/i18n";
 import { LocaleDocument } from "studio/lib/interfaces/locale";
 import { Result } from "studio/utils/result";
 
+import styles from "./compensation-calculator.module.css";
 import { Degree, SalaryData } from "./types";
 
 type CalculatorProps = {
   localeRes: Promise<LocaleDocument>;
   salariesRes: Promise<Result<SalaryData, unknown>>;
-
+  background: "light" | "dark" | "violet";
   initialDegree: Degree;
   initialYear: number;
 };
+
+const degreeOptions: IOption[] = [
+  { id: "bachelor", label: "Bachelor" },
+  { id: "master", label: "Master" },
+];
 
 export default function Calculator({
   localeRes,
   salariesRes,
   initialDegree,
   initialYear,
+  background,
 }: CalculatorProps) {
   const locale = use(localeRes);
   const salaries = use(salariesRes);
@@ -44,81 +51,40 @@ export default function Calculator({
   const salary = calculateSalary(year, degree, salaries.value) ?? 0;
 
   return (
-    <div>
-      <SalaryCalculator
-        examinationYearValue={year}
-        minExaminationYear={1985}
-        maxExaminationYear={2024}
-        selectedDegree={degree}
-        onDegreeChanged={setDegree}
-        onExaminationYearChanged={setYear}
-        action={async () => {}}
-      />
-
-      {salary !== null ? (
-        <div aria-live="polite">
-          <Text>Din årslønn</Text>
-          <Text>
-            {formatAsCurrency(salary, locale.locale, locale.currency)}
-          </Text>
-          <Text>+ bonus</Text>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-const degreeOptions: IOption[] = [
-  { id: "bachelor", label: "Bachelor" },
-  { id: "master", label: "Master" },
-];
-
-interface SalaryCalculatorProps {
-  examinationYearValue: number;
-  minExaminationYear: number;
-  maxExaminationYear: number;
-  selectedDegree: Degree;
-  onDegreeChanged: (degree: Degree) => void;
-  onExaminationYearChanged: (examinationYear: number) => void;
-  action: (data: FormData) => void;
-}
-
-function SalaryCalculator({
-  examinationYearValue: yearValue,
-  minExaminationYear,
-  maxExaminationYear,
-  selectedDegree,
-  onDegreeChanged,
-  onExaminationYearChanged,
-  action,
-}: SalaryCalculatorProps) {
-  return (
-    <form
-      //TODO: replace aria-label with static translation from Sanity
-      aria-label="salary calculator"
-      action={action}
-    >
+    <form className={styles.formCalculator} aria-label="salary calculator">
       <RadioButtonGroup
         id="degree-group"
-        label="Velg utdanning"
+        label="Utdanning"
         options={degreeOptions}
-        selectedId={selectedDegree}
+        background={background}
+        selectedId={degree}
         onValueChange={(selectedOption) =>
-          onDegreeChanged(selectedOption.id as Degree)
+          setDegree(selectedOption.id as Degree)
         }
       />
-      <div>
+
+      <div className={styles.inputWrapper}>
         <InputField
-          label="Year"
+          label="Året du begynte i relevant arbeid"
           name="examinationYear"
           type="number"
-          min={minExaminationYear}
-          max={maxExaminationYear}
-          value={yearValue}
-          onChange={(_name, value) => onExaminationYearChanged(parseInt(value))}
+          min={1085}
+          max={2024}
+          value={year}
+          onChange={(_name, value) => setYear(parseInt(value))}
           required
         />
       </div>
+
+      {salary !== null ? (
+        <div aria-live="polite" className={styles.salaryTextContainer}>
+          <Text type="labelRegular">Din årslønn</Text>
+          <Text className={styles.salaryText}>
+            {formatAsCurrency(salary, locale.locale, locale.currency)}
+          </Text>
+          <Text type="labelRegular">+ bonus</Text>
+        </div>
+      ) : null}
     </form>
   );
 }

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -1,7 +1,9 @@
+import Link from "next/link";
 import { Suspense } from "react";
 
 import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
+import { getHref } from "src/utils/link";
 import { LocaleDocument } from "studio/lib/interfaces/locale";
 import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
 import { LOCALE_QUERY } from "studio/lib/queries/locale";
@@ -59,6 +61,15 @@ export default async function CompensationCalculator({
           {section.calculatorBlock.calculatorLink && (
             <LinkButton link={section.calculatorBlock.calculatorLink} />
           )}
+
+          {section.calculatorBlock.calculatorLink && (
+            <div className={styles.calculatorLink}>
+              <LinkButton
+                type="secondary"
+                link={section.calculatorBlock.calculatorLink}
+              />
+            </div>
+          )}
         </div>
         <div className={handbookBgClassname}>
           <Text type="h3">{section.handbookBlock.handbookTitle}</Text>
@@ -69,13 +80,24 @@ export default async function CompensationCalculator({
           {handbookLinksRes.ok && (
             <div className={styles.handbookLinks}>
               {handbookLinksRes.value.map((link) => (
-                <LinkButton key={link.url} link={link} />
+                <Link
+                  key={link._key}
+                  className={styles.handbookLink}
+                  href={getHref(link)}
+                >
+                  {link.linkTitle}
+                </Link>
               ))}
             </div>
           )}
 
           {section.handbookBlock.handbookLink && (
-            <LinkButton link={section.handbookBlock.handbookLink} />
+            <div className={styles.handbookLink}>
+              <LinkButton
+                type="secondary"
+                link={section.handbookBlock.handbookLink}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -1,8 +1,8 @@
 import Text from "src/components/text/Text";
+import { SalariesByLocation } from "studio/lib/interfaces/compensations";
 import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
 import { COMPENSATIONS_SALARIES } from "studio/lib/queries/specialPages";
 import { loadStudioQuery } from "studio/lib/store";
-import { SalariesByLocation } from "studio/lib/interfaces/compensations";
 
 import styles from "./compensation-calculator.module.css";
 

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -1,16 +1,14 @@
+import { Suspense } from "react";
+
 import Text from "src/components/text/Text";
+import { LocaleDocument } from "studio/lib/interfaces/locale";
 import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
-import { COMPENSATIONS_SALARIES } from "studio/lib/queries/specialPages";
+import { LOCALE_QUERY } from "studio/lib/queries/locale";
 import { loadStudioQuery } from "studio/lib/store";
 
-import { Suspense } from "react";
-import { LocaleDocument } from "studio/lib/interfaces/locale";
-import { LOCALE_QUERY } from "studio/lib/queries/locale";
+import { getSalaryByYear } from "./api";
 import Calculator from "./Calculator";
-import { CompensationData } from "./types";
-
 import styles from "./compensation-calculator.module.css";
-import { getSalaryByYear } from "./actions";
 
 export interface CompensationCalculatorProps {
   language: string;
@@ -18,21 +16,12 @@ export interface CompensationCalculatorProps {
 }
 
 export default async function CompensationCalculator({
-  language,
   section,
 }: CompensationCalculatorProps) {
-  const compensationsSalariesRes = loadStudioQuery<CompensationData>(
-    COMPENSATIONS_SALARIES,
-    {
-      language,
-    },
-  ).then((d) => d.data);
-
+  const salariesRes = getSalaryByYear(2024);
   const localeRes = loadStudioQuery<LocaleDocument>(LOCALE_QUERY).then(
     (d) => d.data,
   );
-
-  const data = await getSalaryByYear(2024);
 
   // TODO: add cn util or andIf
   const calculatorBgClassname =
@@ -43,13 +32,6 @@ export default async function CompensationCalculator({
     section.background === "violet"
       ? `${styles.handbook} ${styles["handbook--violet"]}`
       : styles.handbook;
-
-  if (!data.ok) {
-    console.error(
-      "[CompensationCalculator]: Failed to get salary data for year 2024",
-    );
-    return null;
-  }
 
   return (
     <div>
@@ -63,9 +45,9 @@ export default async function CompensationCalculator({
           <Suspense fallback={<div>Loading...</div>}>
             <Calculator
               localeRes={localeRes}
-              salary={data.value}
-              year={2024}
-              degree={"bachelor"}
+              salariesRes={salariesRes}
+              initialYear={2024}
+              initialDegree={"bachelor"}
             />
           </Suspense>
         </div>

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 
+import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
 import { LocaleDocument } from "studio/lib/interfaces/locale";
 import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
@@ -17,11 +18,14 @@ export interface CompensationCalculatorProps {
 
 export default async function CompensationCalculator({
   section,
+  language,
 }: CompensationCalculatorProps) {
-  const salariesRes = getSalaryByYear(2024);
+  const salariesRes = getSalaryByYear(2024, language);
   const localeRes = loadStudioQuery<LocaleDocument>(LOCALE_QUERY).then(
     (d) => d.data,
   );
+
+  console.log("DATA", section);
 
   // TODO: add cn util or andIf
   const calculatorBgClassname =
@@ -39,21 +43,33 @@ export default async function CompensationCalculator({
 
       <div className={styles.grid}>
         <div className={calculatorBgClassname}>
-          <Text type="h3">{section.calculatorTitle}</Text>
-          <Text type="bodyBig">{section.calculatorDescription}</Text>
+          <Text type="h3">{section.calculatorBlock.calculatorTitle}</Text>
+          <Text type="bodyBig">
+            {section.calculatorBlock.calculatorDescription}
+          </Text>
 
           <Suspense fallback={<div>Loading...</div>}>
             <Calculator
               localeRes={localeRes}
               salariesRes={salariesRes}
               initialYear={2024}
-              initialDegree={"bachelor"}
+              initialDegree={"master"}
             />
           </Suspense>
+
+          {section.calculatorBlock.calculatorLink && (
+            <LinkButton link={section.calculatorBlock.calculatorLink} />
+          )}
         </div>
         <div className={handbookBgClassname}>
-          <Text type="h3">{section.handbookTitle}</Text>
-          <Text type="bodyBig">{section.handbookDescription}</Text>
+          <Text type="h3">{section.handbookBlock.handbookTitle}</Text>
+          <Text type="bodyBig">
+            {section.handbookBlock.handbookDescription}
+          </Text>
+
+          {section.handbookBlock.handbookLink && (
+            <LinkButton link={section.handbookBlock.handbookLink} />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -21,6 +21,7 @@ export default async function CompensationCalculator({
     },
   );
   const compensationCalculator = employeesPageRes.data.slug;
+  console.log(compensationCalculator);
 
   return (
     <div className={styles.wrapper}>

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -1,0 +1,32 @@
+import Text from "src/components/text/Text";
+import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
+import { COMPENSATIONS_BENEFITS } from "studio/lib/queries/specialPages";
+import { loadStudioQuery } from "studio/lib/store";
+
+import styles from "./compensation-calculator.module.css";
+
+export interface CompensationCalculatorProps {
+  language: string;
+  section: CompensationCalculatorSection;
+}
+
+export default async function CompensationCalculator({
+  language,
+  section,
+}: CompensationCalculatorProps) {
+  const employeesPageRes = await loadStudioQuery<{ slug: string }>(
+    COMPENSATIONS_BENEFITS,
+    {
+      language,
+    },
+  );
+  const compensationCalculator = employeesPageRes.data.slug;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.employees}>
+        <Text type="h1">{section.moduleTitle}</Text>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -38,14 +38,18 @@ export default async function CompensationCalculator({
       ? `${styles.handbook} ${styles["handbook--violet"]}`
       : styles.handbook;
 
+  const radioBackground = section.background === "violet" ? "light" : "dark";
+
+  // @TODO add proper translations
+
   return (
-    <div>
+    <div className={styles.container}>
       <Text type="h2">{section.moduleTitle}</Text>
 
       <div className={styles.grid}>
         <div className={calculatorBgClassname}>
           <Text type="h3">{section.calculatorBlock.calculatorTitle}</Text>
-          <Text type="bodyBig">
+          <Text type="bodyBig" className={styles.lightFont}>
             {section.calculatorBlock.calculatorDescription}
           </Text>
 
@@ -55,17 +59,17 @@ export default async function CompensationCalculator({
               salariesRes={salariesRes}
               initialYear={2024}
               initialDegree={"master"}
+              background={radioBackground}
             />
           </Suspense>
 
-          {section.calculatorBlock.calculatorLink && (
-            <LinkButton link={section.calculatorBlock.calculatorLink} />
-          )}
-
-          {section.calculatorBlock.calculatorLink && (
+          {section.calculatorBlock.calculatorLink?.linkTitle && (
             <div className={styles.calculatorLink}>
               <LinkButton
                 type="secondary"
+                background={
+                  section.background === "violet" ? undefined : "dark"
+                }
                 link={section.calculatorBlock.calculatorLink}
               />
             </div>
@@ -73,28 +77,29 @@ export default async function CompensationCalculator({
         </div>
         <div className={handbookBgClassname}>
           <Text type="h3">{section.handbookBlock.handbookTitle}</Text>
-          <Text type="bodyBig">
+          <Text type="bodyBig" className={styles.lightFont}>
             {section.handbookBlock.handbookDescription}
           </Text>
 
           {handbookLinksRes.ok && (
-            <div className={styles.handbookLinks}>
+            <ul className={styles.handbookLinks}>
               {handbookLinksRes.value.map((link) => (
-                <Link
-                  key={link._key}
-                  className={styles.handbookLink}
-                  href={getHref(link)}
-                >
-                  {link.linkTitle}
-                </Link>
+                <li key={link._key}>
+                  <Link className={styles.handbookLink} href={getHref(link)}>
+                    {link.linkTitle}
+                  </Link>
+                </li>
               ))}
-            </div>
+            </ul>
           )}
 
-          {section.handbookBlock.handbookLink && (
+          {section.handbookBlock.handbookLink?.linkTitle && (
             <div className={styles.handbookLink}>
               <LinkButton
                 type="secondary"
+                background={
+                  section.background === "violet" ? "dark" : undefined
+                }
                 link={section.handbookBlock.handbookLink}
               />
             </div>

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -1,7 +1,8 @@
 import Text from "src/components/text/Text";
 import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
-import { COMPENSATIONS_BENEFITS } from "studio/lib/queries/specialPages";
+import { COMPENSATIONS_SALARIES } from "studio/lib/queries/specialPages";
 import { loadStudioQuery } from "studio/lib/store";
+import { SalariesByLocation } from "studio/lib/interfaces/compensations";
 
 import styles from "./compensation-calculator.module.css";
 
@@ -14,19 +15,37 @@ export default async function CompensationCalculator({
   language,
   section,
 }: CompensationCalculatorProps) {
-  const employeesPageRes = await loadStudioQuery<{ slug: string }>(
-    COMPENSATIONS_BENEFITS,
-    {
-      language,
-    },
-  );
-  const compensationCalculator = employeesPageRes.data.slug;
-  console.log(compensationCalculator);
+  const employeesPageRes = await loadStudioQuery<{
+    slug: string;
+    salariesByLocation: SalariesByLocation[];
+  }>(COMPENSATIONS_SALARIES, {
+    language,
+  });
+  console.log(employeesPageRes.data);
+
+  // TODO: add cn util or andIf
+  const calculatorBgClassname =
+    section.background === "violet"
+      ? `${styles.calculator} ${styles["calculator--violet"]}`
+      : styles.calculator;
+  const handbookBgClassname =
+    section.background === "violet"
+      ? `${styles.handbook} ${styles["handbook--violet"]}`
+      : styles.handbook;
 
   return (
-    <div className={styles.wrapper}>
-      <div className={styles.employees}>
-        <Text type="h1">{section.moduleTitle}</Text>
+    <div>
+      <Text type="h2">{section.moduleTitle}</Text>
+
+      <div className={styles.grid}>
+        <div className={calculatorBgClassname}>
+          <Text type="h3">{section.calculatorTitle}</Text>
+          <Text type="bodyBig">{section.calculatorDescription}</Text>
+        </div>
+        <div className={handbookBgClassname}>
+          <Text type="h3">{section.handbookTitle}</Text>
+          <Text type="bodyBig">{section.handbookDescription}</Text>
+        </div>
       </div>
     </div>
   );

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -5,12 +5,13 @@ import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
 import { cnIf } from "src/utils/css";
 import { getHref } from "src/utils/link";
-import { LocaleDocument } from "studio/lib/interfaces/locale";
 import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
-import { LOCALE_QUERY } from "studio/lib/queries/locale";
-import { loadStudioQuery } from "studio/lib/store";
 
-import { getHandbookLinksFromCompensationPage, getSalaryByYear } from "./api";
+import {
+  getHandbookLinksFromCompensationPage,
+  getLatestSalaries,
+  getLocale,
+} from "./api";
 import Calculator from "./Calculator";
 import styles from "./compensation-calculator.module.css";
 
@@ -23,10 +24,9 @@ export default async function CompensationCalculator({
   section,
   language,
 }: CompensationCalculatorProps) {
-  const salariesRes = getSalaryByYear(2024, language);
-  const localeRes = loadStudioQuery<LocaleDocument>(LOCALE_QUERY).then(
-    (d) => d.data,
-  );
+  const salariesRes = getLatestSalaries();
+  const localeRes = getLocale();
+
   const handbookLinksRes = await getHandbookLinksFromCompensationPage(language);
 
   const calculatorBgClassname = cnIf({

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -7,7 +7,7 @@ import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
 import { LOCALE_QUERY } from "studio/lib/queries/locale";
 import { loadStudioQuery } from "studio/lib/store";
 
-import { getSalaryByYear } from "./api";
+import { getHandbookLinksFromCompensationPage, getSalaryByYear } from "./api";
 import Calculator from "./Calculator";
 import styles from "./compensation-calculator.module.css";
 
@@ -24,6 +24,7 @@ export default async function CompensationCalculator({
   const localeRes = loadStudioQuery<LocaleDocument>(LOCALE_QUERY).then(
     (d) => d.data,
   );
+  const handbookLinksRes = await getHandbookLinksFromCompensationPage(language);
 
   // TODO: add cn util or andIf
   const calculatorBgClassname =
@@ -64,6 +65,14 @@ export default async function CompensationCalculator({
           <Text type="bodyBig">
             {section.handbookBlock.handbookDescription}
           </Text>
+
+          {handbookLinksRes.ok && (
+            <div className={styles.handbookLinks}>
+              {handbookLinksRes.value.map((link) => (
+                <LinkButton key={link.url} link={link} />
+              ))}
+            </div>
+          )}
 
           {section.handbookBlock.handbookLink && (
             <LinkButton link={section.handbookBlock.handbookLink} />

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 
 import LinkButton from "src/components/linkButton/LinkButton";
 import Text from "src/components/text/Text";
+import { cnIf } from "src/utils/css";
 import { getHref } from "src/utils/link";
 import { LocaleDocument } from "studio/lib/interfaces/locale";
 import { CompensationCalculatorSection } from "studio/lib/interfaces/pages";
@@ -12,7 +13,6 @@ import { loadStudioQuery } from "studio/lib/store";
 import { getHandbookLinksFromCompensationPage, getSalaryByYear } from "./api";
 import Calculator from "./Calculator";
 import styles from "./compensation-calculator.module.css";
-import { cnIf } from "src/utils/css";
 
 export interface CompensationCalculatorProps {
   language: string;
@@ -55,7 +55,6 @@ export default async function CompensationCalculator({
             <Calculator
               localeRes={localeRes}
               salariesRes={salariesRes}
-              initialYear={2024}
               initialDegree={"master"}
               background={radioBackground}
             />

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -25,8 +25,6 @@ export default async function CompensationCalculator({
     (d) => d.data,
   );
 
-  console.log("DATA", section);
-
   // TODO: add cn util or andIf
   const calculatorBgClassname =
     section.background === "violet"

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -12,6 +12,7 @@ import { loadStudioQuery } from "studio/lib/store";
 import { getHandbookLinksFromCompensationPage, getSalaryByYear } from "./api";
 import Calculator from "./Calculator";
 import styles from "./compensation-calculator.module.css";
+import { cnIf } from "src/utils/css";
 
 export interface CompensationCalculatorProps {
   language: string;
@@ -28,19 +29,16 @@ export default async function CompensationCalculator({
   );
   const handbookLinksRes = await getHandbookLinksFromCompensationPage(language);
 
-  // TODO: add cn util or andIf
-  const calculatorBgClassname =
-    section.background === "violet"
-      ? `${styles.calculator} ${styles["calculator--violet"]}`
-      : styles.calculator;
-  const handbookBgClassname =
-    section.background === "violet"
-      ? `${styles.handbook} ${styles["handbook--violet"]}`
-      : styles.handbook;
+  const calculatorBgClassname = cnIf({
+    [styles.calculator]: true,
+    [styles["calculator--violet"]]: section.background === "violet",
+  });
+  const handbookBgClassname = cnIf({
+    [styles.handbook]: true,
+    [styles["handbook--violet"]]: section.background === "violet",
+  });
 
   const radioBackground = section.background === "violet" ? "light" : "dark";
-
-  // @TODO add proper translations
 
   return (
     <div className={styles.container}>

--- a/src/components/sections/compensation-calculator/actions.ts
+++ b/src/components/sections/compensation-calculator/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { isSalariesType } from "studio/components/salariesInput/utils/parseSalaries";
+import { COMPENSATIONS_SALARY_BY_YEAR } from "studio/lib/queries/specialPages";
+import { loadStudioQuery } from "studio/lib/store";
+import { Result, ResultError, ResultOk } from "studio/utils/result";
+
+export async function getSalaryByYear(
+  year: number,
+): Promise<Result<number, unknown>> {
+  const res = await loadStudioQuery<{
+    salariesByLocation: { yearlySalaries: { salaries: string } };
+  }>(COMPENSATIONS_SALARY_BY_YEAR, {
+    year,
+  });
+
+  try {
+    const parsedSalaries = JSON.parse(
+      res.data.salariesByLocation.yearlySalaries.salaries,
+    );
+    if (!isSalariesType(parsedSalaries) || !parsedSalaries[year]) {
+      return ResultError("Parsed salaries data was not valid");
+    }
+
+    return ResultOk(parsedSalaries[year] as number);
+  } catch (e) {
+    return ResultError("Parsed salaries data was not valid");
+  }
+}

--- a/src/components/sections/compensation-calculator/api.ts
+++ b/src/components/sections/compensation-calculator/api.ts
@@ -1,9 +1,30 @@
 import { isSalariesType } from "studio/components/salariesInput/utils/parseSalaries";
-import { COMPENSATIONS_SALARY_BY_YEAR } from "studio/lib/queries/specialPages";
+import { ILink } from "studio/lib/interfaces/navigation";
+import {
+  COMPENSATIONS_HANDBOOK_LINKS,
+  COMPENSATIONS_SALARY_BY_YEAR,
+} from "studio/lib/queries/specialPages";
 import { loadStudioQuery } from "studio/lib/store";
 import { Result, ResultError, ResultOk } from "studio/utils/result";
 
 import { SalaryData } from "./types";
+
+export async function getHandbookLinksFromCompensationPage(
+  language: string,
+): Promise<Result<ILink[], unknown>> {
+  const res = await loadStudioQuery<{ handbookLinks: ILink[] }>(
+    COMPENSATIONS_HANDBOOK_LINKS,
+    { language },
+    {
+      cache: "force-cache",
+      next: {
+        revalidate: 60 * 60,
+      },
+    },
+  );
+
+  return ResultOk(res.data.handbookLinks);
+}
 
 export async function getSalaryByYear(
   year: number,

--- a/src/components/sections/compensation-calculator/api.ts
+++ b/src/components/sections/compensation-calculator/api.ts
@@ -1,29 +1,39 @@
-"use server";
-
 import { isSalariesType } from "studio/components/salariesInput/utils/parseSalaries";
 import { COMPENSATIONS_SALARY_BY_YEAR } from "studio/lib/queries/specialPages";
 import { loadStudioQuery } from "studio/lib/store";
 import { Result, ResultError, ResultOk } from "studio/utils/result";
 
+import { SalaryData } from "./types";
+
 export async function getSalaryByYear(
   year: number,
-): Promise<Result<number, unknown>> {
+): Promise<Result<SalaryData, unknown>> {
   const res = await loadStudioQuery<{
     salariesByLocation: { yearlySalaries: { salaries: string } };
-  }>(COMPENSATIONS_SALARY_BY_YEAR, {
-    year,
-  });
+  }>(
+    COMPENSATIONS_SALARY_BY_YEAR,
+    {
+      year,
+    },
+    {
+      cache: "force-cache",
+      next: {
+        revalidate: 60 * 60 * 24 * 120,
+      },
+    },
+  );
 
   try {
     const parsedSalaries = JSON.parse(
       res.data.salariesByLocation.yearlySalaries.salaries,
     );
+
     if (!isSalariesType(parsedSalaries) || !parsedSalaries[year]) {
       return ResultError("Parsed salaries data was not valid");
     }
 
-    return ResultOk(parsedSalaries[year] as number);
-  } catch (e) {
+    return ResultOk(parsedSalaries);
+  } catch {
     return ResultError("Parsed salaries data was not valid");
   }
 }

--- a/src/components/sections/compensation-calculator/api.ts
+++ b/src/components/sections/compensation-calculator/api.ts
@@ -1,5 +1,7 @@
 import { isSalariesType } from "studio/components/salariesInput/utils/parseSalaries";
+import { LocaleDocument } from "studio/lib/interfaces/locale";
 import { ILink } from "studio/lib/interfaces/navigation";
+import { LOCALE_QUERY } from "studio/lib/queries/locale";
 import {
   COMPENSATIONS_HANDBOOK_LINKS,
   COMPENSATIONS_SALARY_BY_YEAR,
@@ -26,19 +28,19 @@ export async function getHandbookLinksFromCompensationPage(
   return ResultOk(res.data.handbookLinks);
 }
 
-export async function getSalaryByYear(
-  year: number,
-  language: string,
-): Promise<Result<SalaryData, unknown>> {
+export async function getLocale() {
+  const res = await loadStudioQuery<LocaleDocument>(LOCALE_QUERY);
+  return res.data;
+}
+
+export async function getLatestSalaries(): Promise<
+  Result<SalaryData, unknown>
+> {
   const res = await loadStudioQuery<{
-    slug: string;
     salariesByLocation: { yearlySalaries: { salaries: string } };
   }>(
     COMPENSATIONS_SALARY_BY_YEAR,
-    {
-      year,
-      language,
-    },
+    {},
     {
       cache: "force-cache",
       next: {
@@ -52,7 +54,7 @@ export async function getSalaryByYear(
       res.data.salariesByLocation.yearlySalaries.salaries,
     );
 
-    if (!isSalariesType(parsedSalaries) || !parsedSalaries[year]) {
+    if (!isSalariesType(parsedSalaries)) {
       return ResultError("Parsed salaries data was not valid");
     }
 

--- a/src/components/sections/compensation-calculator/api.ts
+++ b/src/components/sections/compensation-calculator/api.ts
@@ -7,13 +7,16 @@ import { SalaryData } from "./types";
 
 export async function getSalaryByYear(
   year: number,
+  language: string,
 ): Promise<Result<SalaryData, unknown>> {
   const res = await loadStudioQuery<{
+    slug: string;
     salariesByLocation: { yearlySalaries: { salaries: string } };
   }>(
     COMPENSATIONS_SALARY_BY_YEAR,
     {
       year,
+      language,
     },
     {
       cache: "force-cache",

--- a/src/components/sections/compensation-calculator/compensation-calculator.module.css
+++ b/src/components/sections/compensation-calculator/compensation-calculator.module.css
@@ -13,6 +13,10 @@
 
   background-color: var(--_calcBg);
   color: var(--_calcColor);
+
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 .calculator {
   --_calcBg: var(--background-bg-dark);
@@ -25,4 +29,27 @@
 .handbook--violet {
   --_calcBg: var(--surface-violet);
   --_calcColor: var(--text-primary-light);
+}
+
+.calculatorLink,
+.handbookLink {
+  margin-top: auto;
+}
+
+.handbookLinks {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.handbookLink {
+  font-size: 2rem;
+  color: currentColor;
+}
+.handbookLink:hover {
+  text-decoration: underline;
+}
+.handbookLink:not(:last-child)::after {
+  content: "·";
+  margin-left: 0.5rem;
 }

--- a/src/components/sections/compensation-calculator/compensation-calculator.module.css
+++ b/src/components/sections/compensation-calculator/compensation-calculator.module.css
@@ -1,7 +1,18 @@
+.container {
+  max-width: var(--max-content-width-large);
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 1rem;
+}
+@media (min-width: 480px) {
+  .grid {
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  }
 }
 
 .calculator,
@@ -16,8 +27,22 @@
 
   display: flex;
   flex-direction: column;
-  gap: 1rem;
 }
+
+.lightFont {
+  font-weight: 300;
+}
+
+@media (max-width: 440px) {
+  .container {
+    padding: 0 0.5em;
+  }
+  .calculator,
+  .handbook {
+    padding: 1rem;
+  }
+}
+
 .calculator {
   --_calcBg: var(--background-bg-dark);
   --_calcColor: var(--text-primary-light);
@@ -34,12 +59,19 @@
 .calculatorLink,
 .handbookLink {
   margin-top: auto;
+  padding-top: 3rem;
 }
 
 .handbookLinks {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+}
+.handbookLinks li {
+  padding: 0;
+  margin: 0;
 }
 
 .handbookLink {
@@ -49,7 +81,29 @@
 .handbookLink:hover {
   text-decoration: underline;
 }
-.handbookLink:not(:last-child)::after {
+.handbookLinks li:not(:last-child)::after {
   content: "·";
   margin-left: 0.5rem;
+  font-size: 2rem;
+}
+
+.salaryTextContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 2rem;
+}
+.salaryText {
+  font-size: 2.5rem;
+  font-size: clamp(1rem, 10vw, 2.5rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: bold;
+  line-height: 1;
+}
+
+.formCalculator {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 2rem;
 }

--- a/src/components/sections/compensation-calculator/compensation-calculator.module.css
+++ b/src/components/sections/compensation-calculator/compensation-calculator.module.css
@@ -1,0 +1,80 @@
+/* Employees.tsx */
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 5rem 1rem;
+  flex-wrap: wrap;
+
+  max-width: var(--max-content-width-large);
+  margin: 0 auto;
+
+  background: var(--background-bg-light-secondary);
+  padding: 3rem;
+  border-radius: var(--radius-large, 24px);
+
+  @media (max-width: 375px) {
+    padding: 1.5rem;
+  }
+}
+
+.header {
+  color: var(--background-bg-light-primary);
+  font-size: 48px;
+  font-weight: 600;
+  align-self: flex-start;
+}
+
+.employees {
+  display: flex;
+  flex-direction: column;
+  max-width: 1400px;
+  width: 100%;
+  text-wrap: wrap;
+  gap: 0.5rem;
+}
+
+/* EmployeeList.tsx */
+
+.employeeFiltersWrapper {
+  padding: 1.5rem 0;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.employeeFilterWrapper {
+  flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.employeeFilterLabel {
+  flex-shrink: 0;
+  @media (min-width: 375px) {
+    min-width: 4.5rem;
+    width: 4.5rem;
+  }
+}
+
+.peopleCountWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.employeeCount {
+  font-size: 16px;
+}
+
+.employeeCountValue {
+  font-weight: 500;
+}
+
+.peopleContainer {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.5rem;
+}

--- a/src/components/sections/compensation-calculator/compensation-calculator.module.css
+++ b/src/components/sections/compensation-calculator/compensation-calculator.module.css
@@ -1,80 +1,28 @@
-/* Employees.tsx */
-.wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: 5rem 1rem;
-  flex-wrap: wrap;
-
-  max-width: var(--max-content-width-large);
-  margin: 0 auto;
-
-  background: var(--background-bg-light-secondary);
-  padding: 3rem;
-  border-radius: var(--radius-large, 24px);
-
-  @media (max-width: 375px) {
-    padding: 1.5rem;
-  }
-}
-
-.header {
-  color: var(--background-bg-light-primary);
-  font-size: 48px;
-  font-weight: 600;
-  align-self: flex-start;
-}
-
-.employees {
-  display: flex;
-  flex-direction: column;
-  max-width: 1400px;
-  width: 100%;
-  text-wrap: wrap;
-  gap: 0.5rem;
-}
-
-/* EmployeeList.tsx */
-
-.employeeFiltersWrapper {
-  padding: 1.5rem 0;
-  align-self: flex-start;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.employeeFilterWrapper {
-  flex-wrap: wrap;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.employeeFilterLabel {
-  flex-shrink: 0;
-  @media (min-width: 375px) {
-    min-width: 4.5rem;
-    width: 4.5rem;
-  }
-}
-
-.peopleCountWrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.employeeCount {
-  font-size: 16px;
-}
-
-.employeeCountValue {
-  font-weight: 500;
-}
-
-.peopleContainer {
+.grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.calculator,
+.handbook {
+  --_calcBg: var(--background-bg-light-secondary);
+  --_calcColor: var(--text-primary-dark);
+  padding: 3rem;
+  border-radius: var(--radius-small);
+
+  background-color: var(--_calcBg);
+  color: var(--_calcColor);
+}
+.calculator {
+  --_calcBg: var(--background-bg-dark);
+  --_calcColor: var(--text-primary-light);
+}
+.calculator--violet {
+  --_calcBg: var(--surface-violet-light);
+  --_calcColor: var(--text-primary-dark);
+}
+.handbook--violet {
+  --_calcBg: var(--surface-violet);
+  --_calcColor: var(--text-primary-light);
 }

--- a/src/components/sections/compensation-calculator/types.ts
+++ b/src/components/sections/compensation-calculator/types.ts
@@ -4,3 +4,6 @@ export type CompensationData = {
   slug: string;
   salariesByLocation: SalariesByLocation[];
 };
+export type Degree = "bachelor" | "master";
+
+export type SalaryData = Record<string, number>;

--- a/src/components/sections/compensation-calculator/types.ts
+++ b/src/components/sections/compensation-calculator/types.ts
@@ -1,0 +1,6 @@
+import { SalariesByLocation } from "studio/lib/interfaces/compensations";
+
+export type CompensationData = {
+  slug: string;
+  salariesByLocation: SalariesByLocation[];
+};

--- a/src/components/tag/index.tsx
+++ b/src/components/tag/index.tsx
@@ -33,15 +33,21 @@ type TagProps = {
   text: string;
 } & TagInner;
 
+export function tagComponentStyle(active: boolean, background: string) {
+  const activeClass = active ? styles["tag--active"] : "";
+  const bgClass = getBackgroundClass(background);
+  const className = `${styles.tag} ${activeClass} ${bgClass}`;
+  return className;
+}
+
 export const Tag = ({
   text,
   background = "light",
   active = false,
   ...props
 }: TagProps) => {
-  const activeClass = active ? styles["tag--active"] : "";
-  const bgClass = getBackgroundClass(background);
-  const className = `${styles.tag} ${activeClass} ${bgClass}`;
+  const className = tagComponentStyle(active, background);
+
   if (props.type === "button") {
     return (
       <button className={className} onClick={props.onClick}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,6 +124,8 @@ html {
   --surface-red-light: var(--Red-100);
   --surface-yellow-light: var(--Yellow-50);
   --surface-white: var(--Light-50);
+  --surface-violet-light: var(--Violet-50);
+  --surface-violet: var(--Violet-700);
 
   /* breakpoints */
   --breakpoint-mobile: 425px;

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -2,8 +2,9 @@ export function cn(...classes: (string | undefined)[]) {
   return classes.filter(Boolean).join(" ");
 }
 export function cnIf(classes: Record<string, boolean>) {
-  return Object.entries(classes)
-    .filter(([, value]) => value)
-    .map(([key]) => key)
-    .join(" ");
+  return cn(
+    ...Object.entries(classes)
+      .filter(([, value]) => value)
+      .map(([key]) => key),
+  );
 }

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -1,0 +1,9 @@
+export function cn(...classes: (string | undefined)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+export function cnIf(classes: Record<string, boolean>) {
+  return Object.entries(classes)
+    .filter(([, value]) => value)
+    .map(([key]) => key)
+    .join(" ");
+}

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -6,6 +6,7 @@ import Callout from "src/components/sections/callout/Callout";
 import CalloutPreview from "src/components/sections/callout/CalloutPreview";
 import CallToAction from "src/components/sections/callToAction/CallToAction";
 import CallToActionPreview from "src/components/sections/callToAction/CallToActionPreview";
+import CompensationCalculator from "src/components/sections/compensation-calculator/CompensationCalculator";
 import ContactBox from "src/components/sections/contact-box/ContactBox";
 import EmployeeHighlight from "src/components/sections/employeeHighlight/EmployeeHighlight";
 import Employees from "src/components/sections/employees/Employees";
@@ -251,6 +252,8 @@ const SectionRenderer = ({
           initialData={initialData}
         />
       );
+    case "compensationCalculator":
+      return <CompensationCalculator section={section} language={language} />;
     case "grid":
       return renderGridSection(section, sectionIndex, isDraftMode, initialData);
     case "contactBox":

--- a/studio/lib/interfaces/compensations.ts
+++ b/studio/lib/interfaces/compensations.ts
@@ -2,6 +2,8 @@ import { PortableTextBlock, Reference } from "sanity";
 
 import { SeoData } from "src/utils/seo";
 
+import { ILink } from "./navigation";
+
 export interface Benefit {
   _type: string;
   _key: string;
@@ -86,5 +88,6 @@ export interface CompensationsPage {
   bonusesByLocation: BonusesByLocationPage[];
   salariesByLocation: SalariesByLocation[];
   showSalaryCalculator: boolean;
+  handbookLinks: ILink[];
   seo: SeoData;
 }

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -116,6 +116,16 @@ export interface JobsSection {
   subtitle: string;
 }
 
+export interface CompensationCalculatorSection {
+  _type: "compensationCalculator";
+  _key: string;
+  moduleTitle: string;
+  calculatorTitle: string;
+  calculatorDescription: PortableTextBlock[];
+  handbookTitle: string;
+  handbookDescription: PortableTextBlock[];
+}
+
 export interface EmployeeHighlightSection {
   _type: "employeeHighlight";
   _key: string;
@@ -137,8 +147,8 @@ export type Section =
   | GridSection
   | ContactBoxSection
   | EmployeesSection
-  | JobsSection
-  | EmployeeHighlightSection;
+  | CompensationCalculatorSection
+  | JobsSection;
 
 export interface PageBuilder {
   _createdAt: string;

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -122,10 +122,18 @@ export interface CompensationCalculatorSection {
   _key: string;
   moduleTitle: string;
   background: CompensationCalculatorBackground;
-  calculatorTitle: string;
-  calculatorDescription: string;
-  handbookTitle: string;
-  handbookDescription: string;
+
+  calculatorBlock: {
+    calculatorTitle: string;
+    calculatorDescription: string;
+    calculatorLink: ILink;
+  };
+
+  handbookBlock: {
+    handbookTitle: string;
+    handbookDescription: string;
+    handbookLink: ILink;
+  };
 }
 
 export interface EmployeeHighlightSection {

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -1,11 +1,11 @@
 import { PortableTextBlock } from "sanity";
 
 import { SeoData } from "src/utils/seo";
+import { CompensationCalculatorBackground } from "studio/schemas/objects/sections/compensation-calculator";
 
 import { Slug } from "./global";
 import { IImage, ImageExtendedProps } from "./media";
 import { ILink } from "./navigation";
-import { CompensationCalculatorBackground } from "studio/schemas/objects/sections/compensation-calculator";
 
 export interface HeroSection {
   _type: "hero";

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -5,6 +5,7 @@ import { SeoData } from "src/utils/seo";
 import { Slug } from "./global";
 import { IImage, ImageExtendedProps } from "./media";
 import { ILink } from "./navigation";
+import { CompensationCalculatorBackground } from "studio/schemas/objects/sections/compensation-calculator";
 
 export interface HeroSection {
   _type: "hero";
@@ -120,10 +121,11 @@ export interface CompensationCalculatorSection {
   _type: "compensationCalculator";
   _key: string;
   moduleTitle: string;
+  background: CompensationCalculatorBackground;
   calculatorTitle: string;
-  calculatorDescription: PortableTextBlock[];
+  calculatorDescription: string;
   handbookTitle: string;
-  handbookDescription: PortableTextBlock[];
+  handbookDescription: string;
 }
 
 export interface EmployeeHighlightSection {

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -157,6 +157,7 @@ export type Section =
   | GridSection
   | ContactBoxSection
   | EmployeesSection
+  | EmployeeHighlightSection
   | CompensationCalculatorSection
   | JobsSection;
 

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -43,6 +43,13 @@ const SECTIONS_FRAGMENT = groq`
         ${TRANSLATED_LINK_FRAGMENT}
       }
     },
+    _type == "compensationCalculator" => {
+      "moduleTitle": ${translatedFieldFragment("moduleTitle")},
+      "calculatorTitle": ${translatedFieldFragment("calculatorTitle")},
+      "calculatorDesc": ${translatedFieldFragment("calculatorDesc")},
+      "handbookTitle": ${translatedFieldFragment("handbookTitle")},
+      "handbookDesc": ${translatedFieldFragment("handbookDesc")}
+    },
     _type == "employees" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")}
     },

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -44,11 +44,19 @@ const SECTIONS_FRAGMENT = groq`
       }
     },
     _type == "compensationCalculator" => {
+      ...,
       "moduleTitle": ${translatedFieldFragment("moduleTitle")},
-      "calculatorTitle": ${translatedFieldFragment("calculatorTitle")},
-      "calculatorDescription": ${translatedFieldFragment("calculatorDescription")},
-      "handbookTitle": ${translatedFieldFragment("handbookTitle")},
-      "handbookDescription": ${translatedFieldFragment("handbookDescription")}
+
+      "calculatorBlock": calculatorBlock {
+        ...,
+        "calculatorTitle": ${translatedFieldFragment("calculatorTitle")},
+        "calculatorDescription": ${translatedFieldFragment("calculatorDescription")},
+      },
+      "handbookBlock": handbookBlock {
+        ...,
+        "handbookTitle": ${translatedFieldFragment("handbookTitle")},
+        "handbookDescription": ${translatedFieldFragment("handbookDescription")}
+      }
     },
     _type == "employees" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")}

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -46,9 +46,9 @@ const SECTIONS_FRAGMENT = groq`
     _type == "compensationCalculator" => {
       "moduleTitle": ${translatedFieldFragment("moduleTitle")},
       "calculatorTitle": ${translatedFieldFragment("calculatorTitle")},
-      "calculatorDesc": ${translatedFieldFragment("calculatorDesc")},
+      "calculatorDescription": ${translatedFieldFragment("calculatorDescription")},
       "handbookTitle": ${translatedFieldFragment("handbookTitle")},
-      "handbookDesc": ${translatedFieldFragment("handbookDesc")}
+      "handbookDescription": ${translatedFieldFragment("handbookDescription")}
     },
     _type == "employees" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")}

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -51,11 +51,19 @@ const SECTIONS_FRAGMENT = groq`
         ...,
         "calculatorTitle": ${translatedFieldFragment("calculatorTitle")},
         "calculatorDescription": ${translatedFieldFragment("calculatorDescription")},
+        "calculatorLink": calculatorLink {
+          ...,
+          ${TRANSLATED_LINK_FRAGMENT}
+        }
       },
       "handbookBlock": handbookBlock {
         ...,
         "handbookTitle": ${translatedFieldFragment("handbookTitle")},
-        "handbookDescription": ${translatedFieldFragment("handbookDescription")}
+        "handbookDescription": ${translatedFieldFragment("handbookDescription")},
+        "handbookLink": handbookLink {
+          ...,
+          ${TRANSLATED_LINK_FRAGMENT}
+        }
       }
     },
     _type == "employees" => {

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -26,17 +26,11 @@ export const COMPENSATIONS_PAGE_BY_SLUG_QUERY = groq`
     },
   }
 `;
-export const COMPENSATIONS_BENEFITS = groq`
+export const COMPENSATIONS_SALARIES = groq`
   *[_type == "compensations"][0] {
-    ...,
-    ${LANGUAGE_FIELD_FRAGMENT},
-    "benefitsByLocation": benefitsByLocation[] {
-      ...,
-      "benefits": benefits[] {
-        ...,
-        "basicTitle": ${translatedFieldFragment("basicTitle")},
-        "richText": ${translatedFieldFragment("richText")}
-      }
+    "slug": ${translatedFieldFragment("slug")},
+    "salariesByLocation": salariesByLocation[] {
+      ...
     },
   }
 `;

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -1,6 +1,6 @@
 import { groq } from "next-sanity";
 
-import { LANGUAGE_FIELD_FRAGMENT } from "./i18n";
+import { LANGUAGE_FIELD_FRAGMENT, TRANSLATED_LINK_FRAGMENT } from "./i18n";
 import { translatedFieldFragment } from "./utils/i18n";
 
 //Compensations
@@ -44,9 +44,18 @@ export const COMPENSATIONS_SALARY_BY_YEAR = groq`
       "yearlySalaries": yearlySalaries[0] {
         ...
       }
-    },
+    }
   }
 `;
+export const COMPENSATIONS_HANDBOOK_LINKS = groq`
+  *[_type == "compensations"][0] {
+    "handbookLinks": handbookLinks[] {
+      ...,
+      ${TRANSLATED_LINK_FRAGMENT}
+    }
+  }
+`;
+
 export const COMPENSATIONS_PAGE_SITEMAP_QUERY = groq`
   *[_type == "compensations"][0] {
     _updatedAt,

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -26,6 +26,20 @@ export const COMPENSATIONS_PAGE_BY_SLUG_QUERY = groq`
     },
   }
 `;
+export const COMPENSATIONS_BENEFITS = groq`
+  *[_type == "compensations"][0] {
+    ...,
+    ${LANGUAGE_FIELD_FRAGMENT},
+    "benefitsByLocation": benefitsByLocation[] {
+      ...,
+      "benefits": benefits[] {
+        ...,
+        "basicTitle": ${translatedFieldFragment("basicTitle")},
+        "richText": ${translatedFieldFragment("richText")}
+      }
+    },
+  }
+`;
 export const COMPENSATIONS_PAGE_SITEMAP_QUERY = groq`
   *[_type == "compensations"][0] {
     _updatedAt,

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -26,20 +26,12 @@ export const COMPENSATIONS_PAGE_BY_SLUG_QUERY = groq`
     },
   }
 `;
-export const COMPENSATIONS_SALARIES = groq`
-  *[_type == "compensations"][0] {
-    "slug": ${translatedFieldFragment("slug")},
-    "salariesByLocation": salariesByLocation[] {
-      ...
-    },
-  }
-`;
 
 // Just select the first location and the first year..
-// @TODO: make this a bit more robust.
+// @TODO: Check if we need to make this more robust,
+// but yearlySalaries is sorted by year so [0] should be the latest
 export const COMPENSATIONS_SALARY_BY_YEAR = groq`
   *[_type == "compensations"][0] {
-    "slug": ${translatedFieldFragment("slug")},
     "salariesByLocation": salariesByLocation[0] {
       "yearlySalaries": yearlySalaries[0] {
         ...

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -34,6 +34,15 @@ export const COMPENSATIONS_SALARIES = groq`
     },
   }
 `;
+export const COMPENSATIONS_SALARY_BY_YEAR = groq`
+  *[_type == "compensations"][0] {
+    "salariesByLocation": salariesByLocation[0] {
+      "yearlySalaries": yearlySalaries[0] {
+        ...
+      }
+    },
+  }
+`;
 export const COMPENSATIONS_PAGE_SITEMAP_QUERY = groq`
   *[_type == "compensations"][0] {
     _updatedAt,

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -34,8 +34,12 @@ export const COMPENSATIONS_SALARIES = groq`
     },
   }
 `;
+
+// Just select the first location and the first year..
+// @TODO: make this a bit more robust.
 export const COMPENSATIONS_SALARY_BY_YEAR = groq`
   *[_type == "compensations"][0] {
+    "slug": ${translatedFieldFragment("slug")},
     "salariesByLocation": salariesByLocation[0] {
       "yearlySalaries": yearlySalaries[0] {
         ...

--- a/studio/schemas/documents/compensations.ts
+++ b/studio/schemas/documents/compensations.ts
@@ -45,7 +45,7 @@ const compensations = defineType({
       name: "handbookLinks",
       title: "Handbook Section Links",
       description:
-        "Ordered links to sections in handbook to show important information when it comes to benefints. Used by compensation calculator module.",
+        "Ordered links to sections in handbook to show important information when it comes to benefits. Used by compensation calculator module.",
       type: "array",
       of: [link],
     }),

--- a/studio/schemas/documents/compensations.ts
+++ b/studio/schemas/documents/compensations.ts
@@ -6,6 +6,7 @@ import { benefitsByLocation } from "studio/schemas/objects/compensations/benefit
 import { bonusesByLocation } from "studio/schemas/objects/compensations/bonusesByLocation";
 import { pensionPercent } from "studio/schemas/objects/compensations/pension";
 import { salariesByLocation } from "studio/schemas/objects/compensations/salariesByLocation";
+import { link } from "studio/schemas/objects/link";
 import { titleSlug } from "studio/schemas/schemaTypes/slug";
 import { firstTranslation } from "studio/utils/i18n";
 
@@ -39,6 +40,16 @@ const compensations = defineType({
     bonusesByLocation,
     benefitsByLocation,
     salariesByLocation,
+
+    defineField({
+      name: "handbookLinks",
+      title: "Handbook Section Links",
+      description:
+        "Ordered links to sections in handbook to show important information when it comes to benefints. Used by compensation calculator module.",
+      type: "array",
+      of: [link],
+    }),
+
     {
       name: "seo",
       type: "internationalizedArraySeo",

--- a/studio/schemas/documents/pageBuilder.ts
+++ b/studio/schemas/documents/pageBuilder.ts
@@ -5,6 +5,7 @@ import { titleID } from "studio/schemas/fields/text";
 import article from "studio/schemas/objects/sections/article";
 import callout from "studio/schemas/objects/sections/callout";
 import callToAction from "studio/schemas/objects/sections/callToAction";
+import { compensationCalculator } from "studio/schemas/objects/sections/compensation-calculator";
 import contactBox from "studio/schemas/objects/sections/contact-box";
 import { employeeHighlightSection } from "studio/schemas/objects/sections/employeeHighlight";
 import { employees } from "studio/schemas/objects/sections/employees";
@@ -57,6 +58,7 @@ const pageBuilder = defineType({
         contactBox,
         jobs,
         employeeHighlightSection,
+        compensationCalculator,
       ],
     }),
   ],

--- a/studio/schemas/objects/sections/compensation-calculator.ts
+++ b/studio/schemas/objects/sections/compensation-calculator.ts
@@ -2,6 +2,16 @@ import { defineField } from "sanity";
 
 export const compensationCalculatorId = "compensationCalculator";
 
+export enum CompensationCalculatorBackground {
+  Dark = "dark",
+  Violet = "violet",
+}
+
+const backgroundOptions = [
+  { title: "Dark", value: CompensationCalculatorBackground.Dark },
+  { title: "Violet", value: CompensationCalculatorBackground.Violet },
+];
+
 export const compensationCalculator = defineField({
   name: compensationCalculatorId,
   title: "Compensation Calculator",
@@ -18,6 +28,19 @@ export const compensationCalculator = defineField({
       ],
     },
     {
+      name: "background",
+      title: "Background",
+      type: "string",
+      description:
+        "Select the whether the calculator should be purple or have dark background.",
+      options: {
+        list: backgroundOptions,
+        layout: "radio",
+      },
+      initialValue: CompensationCalculatorBackground.Dark,
+    },
+
+    {
       name: "calculatorTitle",
       type: "internationalizedArrayString",
       title: "Calculator Title",
@@ -28,7 +51,7 @@ export const compensationCalculator = defineField({
       ],
     },
     {
-      name: "calculatorDesc",
+      name: "calculatorDescription",
       title: "Calculator Description",
       type: "internationalizedArrayString",
       description: "Description that will be displayed inside the calculator.",
@@ -56,7 +79,7 @@ export const compensationCalculator = defineField({
       ],
     },
     {
-      name: "handbookDesc",
+      name: "handbookDescription",
       title: "Handbook Description",
       type: "internationalizedArrayString",
       description:

--- a/studio/schemas/objects/sections/compensation-calculator.ts
+++ b/studio/schemas/objects/sections/compensation-calculator.ts
@@ -1,5 +1,7 @@
 import { defineField } from "sanity";
 
+import { link } from "studio/schemas/objects/link";
+
 export const compensationCalculatorId = "compensationCalculator";
 
 export enum CompensationCalculatorBackground {
@@ -27,6 +29,7 @@ export const compensationCalculator = defineField({
         { _key: "no", value: "Ansattopplevelsen" },
       ],
     },
+
     {
       name: "background",
       title: "Background",
@@ -41,60 +44,88 @@ export const compensationCalculator = defineField({
     },
 
     {
-      name: "calculatorTitle",
-      type: "internationalizedArrayString",
-      title: "Calculator Title",
-      description: "Title that will be displayed inside the calculator.",
-      initialValue: [
-        { _key: "en", value: "Salary Calculator" },
-        { _key: "no", value: "Lønnskalkulator" },
-      ],
-    },
-    {
-      name: "calculatorDescription",
-      title: "Calculator Description",
-      type: "internationalizedArrayString",
-      description: "Description that will be displayed inside the calculator.",
-      initialValue: [
-        {
-          _key: "en",
-          value:
-            "We believe that salary should be simple, open and predictable. Therefore, we designed a transparent salary model that equalizes all employees.",
-        },
-        {
-          _key: "no",
-          value:
-            "Vi mener lønn bør være enkelt, åpent og forutsigbart. Derfor designet vi en transparent lønnsmodell som likestiller alle ansatte.",
-        },
-      ],
-    },
-    {
-      name: "handbookTitle",
-      type: "internationalizedArrayString",
-      title: "Handbook Title",
-      description: "Title that will be displayed inside the handbook section.",
-      initialValue: [
-        { _key: "en", value: "Handbook" },
-        { _key: "no", value: "Håndbok" },
-      ],
-    },
-    {
-      name: "handbookDescription",
-      title: "Handbook Description",
-      type: "internationalizedArrayString",
-      description:
-        "Description that will be displayed inside the handbook section.",
+      name: "calculatorBlock",
+      type: "object",
 
-      initialValue: [
+      fields: [
         {
-          _key: "en",
-          value:
-            "Words and actions should go hand in hand. All about us, rules and more you can find in the handbook. If we change, we change the handbook.",
+          name: "calculatorTitle",
+          type: "internationalizedArrayString",
+          title: "Calculator Title",
+          description: "Title that will be displayed inside the calculator.",
+          initialValue: [
+            { _key: "en", value: "Salary Calculator" },
+            { _key: "no", value: "Lønnskalkulator" },
+          ],
+        },
+
+        {
+          name: "calculatorDescription",
+          title: "Calculator Description",
+          type: "internationalizedArrayString",
+          description:
+            "Description that will be displayed inside the calculator.",
+          initialValue: [
+            {
+              _key: "en",
+              value:
+                "We believe that salary should be simple, open and predictable. Therefore, we designed a transparent salary model that equalizes all employees.",
+            },
+            {
+              _key: "no",
+              value:
+                "Vi mener lønn bør være enkelt, åpent og forutsigbart. Derfor designet vi en transparent lønnsmodell som likestiller alle ansatte.",
+            },
+          ],
+        },
+
+        {
+          ...link,
+          name: "calculatorLink",
+        },
+      ],
+    },
+
+    {
+      name: "handbookBlock",
+      type: "object",
+
+      fields: [
+        {
+          name: "handbookTitle",
+          type: "internationalizedArrayString",
+          title: "Handbook Title",
+          description:
+            "Title that will be displayed inside the handbook section.",
+          initialValue: [
+            { _key: "en", value: "Handbook" },
+            { _key: "no", value: "Håndbok" },
+          ],
         },
         {
-          _key: "no",
-          value:
-            "Ord og handling bør gå hånd i hånd. Alt om oss, regler og finner du i håndboken. Endrer vi på oss, endrer vi håndboken.",
+          name: "handbookDescription",
+          title: "Handbook Description",
+          type: "internationalizedArrayString",
+          description:
+            "Description that will be displayed inside the handbook section.",
+
+          initialValue: [
+            {
+              _key: "en",
+              value:
+                "Words and actions should go hand in hand. All about us, rules and more you can find in the handbook. If we change, we change the handbook.",
+            },
+            {
+              _key: "no",
+              value:
+                "Ord og handling bør gå hånd i hånd. Alt om oss, regler og finner du i håndboken. Endrer vi på oss, endrer vi håndboken.",
+            },
+          ],
+        },
+
+        {
+          ...link,
+          name: "handbookLink",
         },
       ],
     },

--- a/studio/schemas/objects/sections/compensation-calculator.ts
+++ b/studio/schemas/objects/sections/compensation-calculator.ts
@@ -1,0 +1,86 @@
+import { defineField } from "sanity";
+
+export const compensationCalculatorId = "compensationCalculator";
+
+export const compensationCalculator = defineField({
+  name: compensationCalculatorId,
+  title: "Compensation Calculator",
+  type: "object",
+  fields: [
+    {
+      name: "moduleTitle",
+      type: "internationalizedArrayString",
+      title: "Module Title",
+      description: "Title that will be displayed at the top of the section.",
+      initialValue: [
+        { _key: "en", value: "Employee Experience" },
+        { _key: "no", value: "Ansattopplevelsen" },
+      ],
+    },
+    {
+      name: "calculatorTitle",
+      type: "internationalizedArrayString",
+      title: "Calculator Title",
+      description: "Title that will be displayed inside the calculator.",
+      initialValue: [
+        { _key: "en", value: "Salary Calculator" },
+        { _key: "no", value: "Lønnskalkulator" },
+      ],
+    },
+    {
+      name: "calculatorDesc",
+      title: "Calculator Description",
+      type: "internationalizedArrayString",
+      description: "Description that will be displayed inside the calculator.",
+      initialValue: [
+        {
+          _key: "en",
+          value:
+            "We believe that salary should be simple, open and predictable. Therefore, we designed a transparent salary model that equalizes all employees.",
+        },
+        {
+          _key: "no",
+          value:
+            "Vi mener lønn bør være enkelt, åpent og forutsigbart. Derfor designet vi en transparent lønnsmodell som likestiller alle ansatte.",
+        },
+      ],
+    },
+    {
+      name: "handbookTitle",
+      type: "internationalizedArrayString",
+      title: "Handbook Title",
+      description: "Title that will be displayed inside the handbook section.",
+      initialValue: [
+        { _key: "en", value: "Handbook" },
+        { _key: "no", value: "Håndbok" },
+      ],
+    },
+    {
+      name: "handbookDesc",
+      title: "Handbook Description",
+      type: "internationalizedArrayString",
+      description:
+        "Description that will be displayed inside the handbook section.",
+
+      initialValue: [
+        {
+          _key: "en",
+          value:
+            "Words and actions should go hand in hand. All about us, rules and more you can find in the handbook. If we change, we change the handbook.",
+        },
+        {
+          _key: "no",
+          value:
+            "Ord og handling bør gå hånd i hånd. Alt om oss, regler og finner du i håndboken. Endrer vi på oss, endrer vi håndboken.",
+        },
+      ],
+    },
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: "Compensation Calculator",
+      };
+    },
+  },
+});

--- a/studio/schemas/objects/sections/compensation-calculator.ts
+++ b/studio/schemas/objects/sections/compensation-calculator.ts
@@ -82,6 +82,8 @@ export const compensationCalculator = defineField({
         {
           ...link,
           name: "calculatorLink",
+          description:
+            "Bottom link that will be displayed inside the handbook section.",
         },
       ],
     },
@@ -126,6 +128,8 @@ export const compensationCalculator = defineField({
         {
           ...link,
           name: "handbookLink",
+          description:
+            "Bottom link that will be displayed inside the handbook section.",
         },
       ],
     },

--- a/studio/schemas/objects/sections/compensation-calculator.ts
+++ b/studio/schemas/objects/sections/compensation-calculator.ts
@@ -35,7 +35,7 @@ export const compensationCalculator = defineField({
       title: "Background",
       type: "string",
       description:
-        "Select the whether the calculator should be purple or have dark background.",
+        "Select whether the calculator should have a purple or dark background.",
       options: {
         list: backgroundOptions,
         layout: "radio",


### PR DESCRIPTION
Fixes https://github.com/varianter/variant.no/issues/896

Adds component for showing calculator based on numbers saved in compensation special page. Also extends the compensation special page to have handbook links to be used in the handbook block. This is stored centralised in the compensation page to easier reuse the component a cross different pages without having to add several things manually.


## Todo

- [x] Add translations
- [x] Set default year
- [x] Self-review and see if there are changes I need to do


## Things to follow-up later

- Heading sizes is off (generally)
- Button is wrong (component needs to be updated)
- Haven't added the chevrons but utilising default browser behaviour for number. This can be added in separate PR

<details><summary>Screen shots</summary>
<p>

<img width="1108" alt="Screenshot 2024-12-05 at 16 26 05" src="https://github.com/user-attachments/assets/96dd76bf-e38b-458e-955b-9f064e7cad6d">

<img width="1226" alt="Screenshot 2024-12-05 at 16 23 43" src="https://github.com/user-attachments/assets/129b0ffe-bfd3-40e1-b2ff-45c02eb2e35c">
<img width="288" alt="Screenshot 2024-12-05 at 16 24 53" src="https://github.com/user-attachments/assets/59fac1bb-37f3-4782-9ee0-3482fdda45e8">

</p>
</details> 

