### PR TITLE
💄 Align text CSS classes with design

### DIFF
--- a/src/components/navigation/breadCrumbMenu/BreadCrumbMenu.tsx
+++ b/src/components/navigation/breadCrumbMenu/BreadCrumbMenu.tsx
@@ -48,7 +48,7 @@ export const BreadCrumbMenu = ({
                 className={
                   isLast ? styles.breadCrumbText : styles.breadCrumbLink
                 }
-                type={isLast ? "labelSemibold" : "desktopLink"}
+                type={isLast ? "labelRegular" : "desktopLink"}
               >
                 {title}
               </Text>

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -103,7 +103,7 @@ export const Header = ({
                   />
                 )}
                 <Button size="large" type="secondary" background="light">
-                  <Text type="labelRegular">{t("contact_us")}</Text>
+                  <Text type="labelLarge">{t("contact_us")}</Text>
                 </Button>
               </div>
               <button

--- a/src/components/sections/employees/EmployeeList.tsx
+++ b/src/components/sections/employees/EmployeeList.tsx
@@ -99,7 +99,7 @@ export default function EmployeeList({
     <>
       <div className={styles.employeeFiltersWrapper}>
         <div className={styles.employeeFilterWrapper}>
-          <Text type="labelSemibold" className={styles.employeeFilterLabel}>
+          <Text type="labelRegular" className={styles.employeeFilterLabel}>
             {t("field")}
           </Text>
           <Tag
@@ -125,7 +125,7 @@ export default function EmployeeList({
           })}
         </div>
         <div className={styles.employeeFilterWrapper}>
-          <Text type="labelSemibold" className={styles.employeeFilterLabel}>
+          <Text type="labelRegular" className={styles.employeeFilterLabel}>
             {t("location")}
           </Text>
           <Tag

--- a/src/components/text/Text.stories.tsx
+++ b/src/components/text/Text.stories.tsx
@@ -19,7 +19,6 @@ const meta: Meta<typeof Text> = {
           "h6",
           "labelSmall",
           "labelRegular",
-          "labelBold",
           "quoteItalic",
           "quoteNormal",
           "bodyExtraSmall",

--- a/src/components/text/Text.stories.tsx
+++ b/src/components/text/Text.stories.tsx
@@ -18,9 +18,7 @@ const meta: Meta<typeof Text> = {
           "h5",
           "h6",
           "labelSmall",
-          "labelLight",
           "labelRegular",
-          "labelSemibold",
           "labelBold",
           "quoteItalic",
           "quoteNormal",
@@ -100,24 +98,10 @@ export const LabelSmall: Story = {
   },
 };
 
-export const LabelLight: Story = {
-  args: {
-    type: "labelLight",
-    children: "This is a Label Light text",
-  },
-};
-
 export const LabelRegular: Story = {
   args: {
     type: "labelRegular",
     children: "This is a Label Regular text",
-  },
-};
-
-export const LabelSemibold: Story = {
-  args: {
-    type: "labelSemibold",
-    children: "This is a Label Semibold text",
   },
 };
 

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -10,10 +10,9 @@ export type TextType =
   | "desktopLink"
   | "desktopLinkBig"
   | "labelSmall"
-  | "labelLight"
   | "labelRegular"
-  | "labelSemibold"
   | "labelBold"
+  | "labelLarge"
   | "quoteItalic"
   | "quoteNormal"
   | "bodyExtraSmall"
@@ -34,10 +33,9 @@ const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
   desktopLink: "p",
   desktopLinkBig: "p",
   labelSmall: "span",
-  labelLight: "span",
   labelRegular: "span",
-  labelSemibold: "span",
   labelBold: "span",
+  labelLarge: "span",
   quoteItalic: "p",
   quoteNormal: "p",
   bodyExtraSmall: "p",
@@ -59,10 +57,9 @@ const classMap: { [key in TextType]?: string } = {
   desktopLink: styles.desktopLink,
   desktopLinkBig: styles.desktopLinkBig,
   labelSmall: styles.labelSmall,
-  labelLight: styles.labelLight,
   labelRegular: styles.labelRegular,
-  labelSemibold: styles.labelSemibold,
   labelBold: styles.labelBold,
+  labelLarge: styles.labelLarge,
   quoteItalic: styles.quoteItalic,
   quoteNormal: styles.quoteNormal,
   bodyExtraSmall: styles.bodyExtraSmall,

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -11,7 +11,6 @@ export type TextType =
   | "desktopLinkBig"
   | "labelSmall"
   | "labelRegular"
-  | "labelBold"
   | "labelLarge"
   | "quoteItalic"
   | "quoteNormal"
@@ -34,7 +33,6 @@ const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
   desktopLinkBig: "p",
   labelSmall: "span",
   labelRegular: "span",
-  labelBold: "span",
   labelLarge: "span",
   quoteItalic: "p",
   quoteNormal: "p",
@@ -58,7 +56,6 @@ const classMap: { [key in TextType]?: string } = {
   desktopLinkBig: styles.desktopLinkBig,
   labelSmall: styles.labelSmall,
   labelRegular: styles.labelRegular,
-  labelBold: styles.labelBold,
   labelLarge: styles.labelLarge,
   quoteItalic: styles.quoteItalic,
   quoteNormal: styles.quoteNormal,

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -91,7 +91,7 @@
 
 .bodySmall {
   font-size: 1rem;
-  font-weight: 300;
+  font-weight: 400;
   line-height: 150%;
 }
 
@@ -110,7 +110,7 @@
 .labelSmall {
   font-size: 0.875rem;
   font-weight: 400;
-  line-height: 1.5rem;
+  line-height: 171.429%;
 }
 
 .labelRegular {

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -4,9 +4,7 @@
 }
 
 .labelSmall,
-.labelLight,
 .labelRegular,
-.labelSemibold,
 .labelBold,
 .quoteItalic,
 .quoteNormal,
@@ -22,32 +20,33 @@
 .h1 {
   font-size: 4.5rem;
   font-style: normal;
-  font-weight: 600;
-  line-height: 120%;
+  font-weight: 450;
+  line-height: 111.111%;
 }
 
 .h2 {
-  font-size: 3rem;
-  font-weight: 600;
-  line-height: 120%;
+  font-size: 3.5rem;
+  font-weight: 450;
+  line-height: 114.286%;
 }
 
 .h3 {
-  font-size: 2.125rem;
-  font-weight: 600;
+  font-size: 2rem;
+  font-weight: 450;
+  line-height: 125%;
 }
 
 .h4 {
   font-size: 1.5rem;
   font-style: normal;
-  font-weight: 500;
-  line-height: 120%; /* 1.8rem */
+  font-weight: 450;
+  line-height: 133.3%;
 }
 
 .h5 {
   font-size: 1.25rem;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 450;
   line-height: 120%;
 }
 
@@ -58,7 +57,7 @@
   font-size: 1rem;
   font-style: normal;
   font-weight: 400;
-  line-height: 110%;
+  line-height: 150%;
 }
 
 .desktopLinkBig {
@@ -71,7 +70,7 @@
 
 .bodyXl {
   font-size: 2.5rem;
-  font-weight: 400;
+  font-weight: 300;
   line-height: 120%;
   letter-spacing: 0.025rem;
 }
@@ -79,14 +78,16 @@
 .bodyBig {
   font-size: 1.5rem;
   font-style: normal;
-  font-weight: 400;
-  line-height: 130%;
+  font-weight: 300;
+  line-height: 133.333%;
 }
 
 .bodyNormal {
   font-size: 1.25rem;
   font-style: normal;
   font-weight: 300;
+  line-height: 160%;
+  letter-spacing: 0.0125rem;
 }
 
 .bodySmall {
@@ -96,14 +97,14 @@
 }
 
 .bodyExtraSmall {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 400;
-  line-height: 18px;
-  letter-spacing: 0.14px;
+  line-height: 128.571%;
+  letter-spacing: 0.00875rem;
 
   @media (max-width: 375px) {
-    font-size: 12px;
-    letter-spacing: 0.12px;
+    font-size: 0.75px;
+    letter-spacing: 0.0075rem;
   }
 }
 
@@ -113,31 +114,25 @@
   line-height: 1.5rem;
 }
 
-.labelLight {
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 300;
-  line-height: 120%;
-}
-
 .labelRegular {
   font-size: 1rem;
   font-style: normal;
   font-weight: 400;
-  line-height: 120%;
-}
-
-.labelSemibold {
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 600;
-  line-height: 120%;
+  line-height: 150%;
+  letter-spacing: 0.02rem;
 }
 
 .labelBold {
   font-size: 1rem;
   font-style: normal;
   font-weight: 800;
+  line-height: 120%;
+}
+
+.labelLarge {
+  font-size: 1.25rem;
+  font-style: normal;
+  font-weight: 400;
   line-height: 120%;
 }
 
@@ -149,9 +144,16 @@
   white-space: pre-line;
 }
 
+.quoteItalic {
+  font-size: 1.5rem;
+  font-style: italic;
+  font-weight: 400;
+  line-height: 130%;
+  white-space: pre-line;
+}
+
 /* TODO: add font variables */
 /* .labelBold */
 /* .quoteItalic */
-/* .labelSemibold, */
 /* .labelBold, */
 /* .quoteItalic, */

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -5,7 +5,6 @@
 
 .labelSmall,
 .labelRegular,
-.labelBold,
 .quoteItalic,
 .quoteNormal,
 .bodyExtraSmall,
@@ -122,13 +121,6 @@
   letter-spacing: 0.02rem;
 }
 
-.labelBold {
-  font-size: 1rem;
-  font-style: normal;
-  font-weight: 800;
-  line-height: 120%;
-}
-
 .labelLarge {
   font-size: 1.25rem;
   font-style: normal;
@@ -151,9 +143,3 @@
   line-height: 130%;
   white-space: pre-line;
 }
-
-/* TODO: add font variables */
-/* .labelBold */
-/* .quoteItalic */
-/* .labelBold, */
-/* .quoteItalic, */


### PR DESCRIPTION
## Summary
- 💄 Align text styles with design
- 💄 Add `labelLarge`
- 🔥 Remove unused classes `labelSemibold`, `labelBold` and `labelLight`

### Screenshots
#### Jobb: Before
<img width="1211" alt="Screenshot 2024-12-06 at 11 13 35" src="https://github.com/user-attachments/assets/b482d908-2c2a-4ed0-86fb-09b95352d382">

#### Jobb: After
<img width="1351" alt="Screenshot 2024-12-06 at 11 13 31" src="https://github.com/user-attachments/assets/a3c5644f-ba80-4eee-809d-0965d06b39d7">

#### Folk: Before
<img width="1422" alt="Screenshot 2024-12-06 at 11 13 17" src="https://github.com/user-attachments/assets/45cd01c6-5298-4d3d-bf6f-0fc01635555c">

#### Folk: After
<img width="1434" alt="Screenshot 2024-12-06 at 11 13 13" src="https://github.com/user-attachments/assets/ae711b71-d4f0-4d26-a973-48f1b4321c18">

