### PR TITLE
fix: remove contact box margin

### DIFF
--- a/src/components/sections/contact-box/contact-box.module.css
+++ b/src/components/sections/contact-box/contact-box.module.css
@@ -1,5 +1,5 @@
 .contactBox {
-  margin: 8rem auto;
+  margin: auto;
   padding: 0 1rem;
   max-width: var(--max-content-width-large);
 }


### PR DESCRIPTION
Remove the default margin for contact box as it shouldn't implicitly have margin. Might want to see if we should add some layout settings to Sanity for this, but for now I think it is just as good to just remove it.