### PR TITLE
Remove announcement banner for first launch

### DIFF
--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -26,7 +26,7 @@ import styles from "./header.module.css";
 export interface IHeader {
   navigation: Navigation;
   assets: BrandAssets;
-  announcement: Announcement | null;
+  announcement?: Announcement | null;
   currentLanguage: string;
   pathTranslations: InternationalizedString;
 }
@@ -36,7 +36,7 @@ const filterLinks = (data: ILink[], type: string) =>
 
 export const Header = ({
   navigation,
-  announcement,
+  /* announcement, */
   currentLanguage,
   pathTranslations,
 }: IHeader) => {
@@ -73,11 +73,11 @@ export const Header = ({
     };
   }, []);
 
-  const showAnnouncement =
+  /* const showAnnouncement =
     announcement !== null &&
     announcement.text?.length > 0 &&
     (!announcement.hideAfter || new Date(announcement.hideAfter) > new Date());
-
+ */
   const t = useTranslations("contact_information");
 
   return (
@@ -139,7 +139,7 @@ export const Header = ({
             )}
           </div>
         </nav>
-        {showAnnouncement && (
+        {/* {showAnnouncement && (
           <div className={styles.announcementWrapper}>
             <div className={styles.announcementContent}>
               <Text type={"bodySmall"}>{announcement.text}</Text>
@@ -154,7 +154,7 @@ export const Header = ({
               )}
             </div>
           </div>
-        )}
+        )} */}
       </FocusOn>
     </>
   );


### PR DESCRIPTION
Removing the announcement banner as we have decided to not include it in the first launch of the website. Commenting out the code so it can be added later.

# Note:
When we bring it back it needs to match the new design of the header.