### PR TITLE
fix: update linkbutton to match figma design

### DIFF
--- a/src/components/forms/inputField/inputField.module.css
+++ b/src/components/forms/inputField/inputField.module.css
@@ -21,6 +21,10 @@
   border-radius: var(--radius-small);
   border: 1px solid var(--stroke-primary, #ece1d3);
   background: var(--text-primary-light, #fff);
+
+  &:focus {
+    outline: 2px solid var(--surface-yellow);
+  }
 }
 
 .error {

--- a/src/components/forms/radioButtonGroup/radioButtonGroup.module.css
+++ b/src/components/forms/radioButtonGroup/radioButtonGroup.module.css
@@ -17,6 +17,12 @@
   white-space: nowrap;
 }
 
+.fieldset:focus-within {
+  outline: 2px solid var(--surface-yellow);
+  border-radius: var(--radius-small);
+  outline-offset: 0.5rem;
+}
+
 .wrapper {
   display: flex;
   flex-direction: column;

--- a/src/components/linkButton/LinkButton.stories.tsx
+++ b/src/components/linkButton/LinkButton.stories.tsx
@@ -17,10 +17,10 @@ const meta: Meta<typeof LinkButton> = {
     },
   },
   argTypes: {
-    isSmall: {
+    size: {
       control: {
         type: "select",
-        options: ["true", "false"],
+        options: ["XL", "L", "M", "S"],
       },
     },
     type: {
@@ -40,7 +40,7 @@ type Story = StoryObj<typeof LinkButton>;
 
 export const PrimaryLarge: Story = {
   args: {
-    isSmall: false,
+    size: "XL",
     type: "primary",
     link: {
       _key: "key",
@@ -54,7 +54,7 @@ export const PrimaryLarge: Story = {
 
 export const PrimarySmall: Story = {
   args: {
-    isSmall: true,
+    size: "S",
     type: "primary",
     link: {
       _key: "key",
@@ -68,7 +68,7 @@ export const PrimarySmall: Story = {
 
 export const SecondaryLarge: Story = {
   args: {
-    isSmall: false,
+    size: "XL",
     type: "secondary",
     link: {
       _key: "key",
@@ -82,7 +82,7 @@ export const SecondaryLarge: Story = {
 
 export const SecondarySmall: Story = {
   args: {
-    isSmall: true,
+    size: "S",
     type: "secondary",
     link: {
       _key: "key",

--- a/src/components/linkButton/LinkButton.tsx
+++ b/src/components/linkButton/LinkButton.tsx
@@ -8,25 +8,26 @@ import styles from "./linkButton.module.css";
 
 type LinkButtonType = "primary" | "secondary";
 
-interface IButton {
+type LinkType = { link: ILink } | { link: string; linkTitle: string };
+
+type LinkButtonProps = {
   size?: "XL" | "L" | "M" | "S";
   type?: LinkButtonType;
-  link: ILink;
-  withIcon?: boolean;
+  withoutIcon?: boolean;
   background?: "dark" | "light";
-}
+} & LinkType;
 
 const LinkButton = ({
   size = "XL",
   type = "primary",
-  link,
-  withIcon = true,
+  withoutIcon = false,
   background,
-}: IButton) => {
+  ...props
+}: LinkButtonProps) => {
   const modifierSize = styles[`button--${size.toLowerCase()}`];
   const modifierType = styles[`button--${type}`];
   const modifierBackground = styles[`button--${type}--${background}`];
-  const modifierWithIcon = withIcon ? styles["button--withIcon"] : "";
+  const modifierWithIcon = !withoutIcon ? styles["button--withIcon"] : "";
 
   const className = cn(
     styles.button,
@@ -36,16 +37,29 @@ const LinkButton = ({
     modifierWithIcon,
   );
 
-  const href = getHref(link);
-  const linkTitleValue = link.linkTitle;
+  const { href, linkTitle } = getLinkData(props);
+
   return (
     href &&
-    linkTitleValue && (
+    linkTitle && (
       <Link className={className} href={href}>
-        {linkTitleValue}
+        {linkTitle}
       </Link>
     )
   );
 };
+
+function getLinkData(link: LinkType) {
+  if (isLinkTypeString(link)) {
+    return { href: link.link, linkTitle: link.linkTitle };
+  }
+  return { href: getHref(link.link), linkTitle: link.link.linkTitle };
+}
+
+function isLinkTypeString(
+  link: LinkType,
+): link is { link: string; linkTitle: string } {
+  return typeof link === "object" && "link" in link && "linkTitle" in link;
+}
 
 export default LinkButton;

--- a/src/components/linkButton/LinkButton.tsx
+++ b/src/components/linkButton/LinkButton.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { cn } from "src/utils/css";
 import { getHref } from "src/utils/link";
 import { ILink } from "studio/lib/interfaces/navigation";
 
@@ -8,35 +9,33 @@ import styles from "./linkButton.module.css";
 type LinkButtonType = "primary" | "secondary";
 
 interface IButton {
-  isSmall?: boolean;
+  size?: "XL" | "L" | "M" | "S";
   type?: LinkButtonType;
   link: ILink;
+  withIcon?: boolean;
   background?: "dark" | "light";
 }
 
-const typeClassMap = (
-  background: IButton["background"],
-): {
-  [key in LinkButtonType]: string;
-} => ({
-  primary:
-    background === "dark"
-      ? `${styles.primary} ${styles["primary--darkBg"]}`
-      : styles.primary,
-  secondary:
-    background === "dark"
-      ? `${styles.secondary} ${styles["secondary--darkBg"]}`
-      : styles.secondary,
-});
-
 const LinkButton = ({
-  isSmall,
+  size = "XL",
   type = "primary",
   link,
+  withIcon = true,
   background,
 }: IButton) => {
-  const classMap = typeClassMap(background);
-  const className = `${styles.button} ${isSmall ? styles.small : ""} ${classMap[type]}`;
+  const modifierSize = styles[`button--${size.toLowerCase()}`];
+  const modifierType = styles[`button--${type}`];
+  const modifierBackground = styles[`button--${type}--${background}`];
+  const modifierWithIcon = withIcon ? styles["button--withIcon"] : "";
+
+  const className = cn(
+    styles.button,
+    modifierSize,
+    modifierType,
+    modifierBackground,
+    modifierWithIcon,
+  );
+
   const href = getHref(link);
   const linkTitleValue = link.linkTitle;
   return (

--- a/src/components/linkButton/linkButton.module.css
+++ b/src/components/linkButton/linkButton.module.css
@@ -9,13 +9,12 @@
 
   box-sizing: content-box;
 
-  max-width: 360px;
-
   display: inline-flex;
   align-items: center;
   align-self: stretch;
   justify-content: space-between;
   line-height: 1;
+  white-space: nowrap;
 
   gap: 0.6rem;
 
@@ -122,9 +121,6 @@
   }
 }
 .button--secondary--dark {
-  /* --_button-border: 1px solid var(--background-bg-light-secondary);
-  --_button-color: currentColor; */
-
   --_button-border: 1px solid var(--background-bg-light-secondary);
   --_button-color: currentColor;
 

--- a/src/components/linkButton/linkButton.module.css
+++ b/src/components/linkButton/linkButton.module.css
@@ -1,102 +1,140 @@
 .button {
-  @media (max-width: 640px) {
-    width: 100%;
-    box-sizing: border-box;
-  }
+  --_button-radius: var(--radius-small);
+  --_button-hoverRadius: var(--radius-large);
+  --_button-padding: 0.625rem 1.5rem;
+  --_button-font-size: 1.25rem;
+  --_button-border: none;
+  --_button-background: transparent;
+  --_button-color: currentColor;
+
+  box-sizing: content-box;
+
   max-width: 360px;
-  cursor: pointer;
+
   display: inline-flex;
   align-items: center;
   align-self: stretch;
   justify-content: space-between;
+  line-height: 1;
+
   gap: 0.6rem;
-  border-radius: 1.5625rem;
+
   border: none;
   font-family: var(--font-britti-sans);
   text-decoration: none;
-
-  padding: 0.5rem 1.25rem;
-  font-size: 1.25rem;
   font-weight: 400;
 
-  @media (min-width: 640px) {
-    text-wrap: nowrap;
-  }
-  @media (min-width: 1024px) {
-    font-size: 1.5rem;
-    padding: 0.5rem 1.5rem;
-    justify-content: center;
-  }
-
-  &::after {
-    width: 1.5rem;
-    height: 1.5rem;
-    content: "";
-    -webkit-mask: url("/_assets/arrow-right.svg") no-repeat center;
-    -webkit-mask-size: cover;
-    mask: url("/_assets/arrow-right.svg") no-repeat center;
-    mask-size: cover;
-  }
-}
-
-.small {
-  @media (min-width: 1024px) {
-    font-size: 1.25rem;
-    padding: 0.375rem 1.25rem;
-    font-weight: 400;
-
-    &::after {
-      width: 1.25rem;
-      height: 1.25rem;
-    }
-  }
-}
-
-.primary {
-  background: var(--background-bg-dark);
-  color: var(--background-bg-light-primary);
-  border: 1px solid var(--text-secondary);
+  /* Settings */
+  background: var(--_button-background);
+  padding: var(--_button-padding);
+  font-size: var(--_button-font-size);
+  border: var(--_button-border);
+  border-radius: var(--_button-radius);
+  color: var(--_button-color);
+  transition:
+    border-radius 150ms ease-in,
+    background-color 200ms ease-in;
 
   &:hover {
-    background: var(--text-primary);
+    --_button-radius: var(--_button-hoverRadius);
+  }
+  &:focus {
+    --_button-radius: var(--_button-hoverRadius);
+    outline: 2px solid var(--surface-yellow);
+    outline-offset: 1px;
+  }
+}
+.button--xl {
+  --_button-radius: var(--radius-small);
+  --_button-hoverRadius: var(--radius-large);
+  --_button-padding: 0.625rem 1.5rem;
+  --_button-font-size: 1.25rem;
+}
+.button--l {
+  --_button-hoverRadius: var(--radius-medium);
+  --_button-padding: 0.625rem 0.75rem;
+  --_button-font-size: 1.25rem;
+}
+.button--m {
+  --_button-padding: 0.375rem 0.5rem;
+  --_button-hoverRadius: var(--radius-medium);
+  --_button-font-size: 1rem;
+}
+.button--s {
+  --_button-padding: 0.125rem 0.25rem;
+  --_button-hoverRadius: var(--radius-medium);
+  --_button-font-size: 0.875rem;
+}
+
+.button--withIcon::after {
+  width: 1.5rem;
+  height: 1.5rem;
+  content: "";
+  -webkit-mask: url("/_assets/arrow-right.svg") no-repeat center;
+  -webkit-mask-size: cover;
+  mask: url("/_assets/arrow-right.svg") no-repeat center;
+  mask-size: cover;
+
+  background-color: var(--_button-color);
+}
+
+.button--primary {
+  --_button-border: 1px solid var(--text-secondary);
+  --_button-background: var(--background-bg-dark);
+  --_button-color: var(--background-bg-light-primary);
+
+  &:hover {
+    --_button-background: var(--background-bg-dark);
+  }
+  &:focus {
+    --_button-border: 1px solid var(--surface-yellow);
+  }
+  &:active {
+    --_button-background: var(--text-secondary);
+  }
+}
+
+.button--primary--dark {
+  --_button-border: none;
+  --_button-background: var(--background-bg-light-primary);
+  --_button-color: var(--text-primary);
+  --_button-border: 1px solid var(--background-bg-light-primary);
+
+  &:hover {
+    --_button-background: var(--background-bg-light-primary);
+  }
+  &:active {
+    --_button-background: var(--background-bg-light-secondary);
+  }
+}
+
+.button--secondary {
+  --_button-border: 1px solid var(--text-secondary);
+  --_button-color: var(--background-bg-dark);
+  --_button-background: transparent;
+
+  &:hover {
+    --_button-background: rgba(31, 31, 31, 0.05);
   }
 
   &:active {
-    background: var(--text-secondary);
-  }
-
-  &::after {
-    background-color: var(--text-primary-light);
+    --_button-background: rgba(31, 31, 31, 0.16);
   }
 }
+.button--secondary--dark {
+  /* --_button-border: 1px solid var(--background-bg-light-secondary);
+  --_button-color: currentColor; */
 
-.secondary {
-  --_borderColor: var(--text-secondary);
-  --_color: var(--background-bg-dark);
-  --_iconColor: var(--text-secondary);
-
-  color: var(--_color);
-  background: rgba(255, 255, 255, 0);
-  border: 1px solid var(--_borderColor);
+  --_button-border: 1px solid var(--background-bg-light-secondary);
+  --_button-color: currentColor;
 
   &:hover {
-    background: rgba(31, 31, 31, 0.05);
+    --_button-background: var(--background-bg-dark);
   }
-
+  &:focus {
+    --_button-border: 1px solid var(--surface-yellow);
+  }
   &:active {
-    background: rgba(31, 31, 31, 0.16);
-  }
-
-  &::after {
-    background-color: var(--_iconColor);
-  }
-}
-.secondary--darkBg {
-  /* @TODO: this color needs to be changed */
-  --_borderColor: var(--background-bg-light-secondary);
-  --_color: currentColor;
-
-  &::after {
-    background-color: currentColor;
+    --_button-background: var(--text-secondary);
   }
 }

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from "react";
 import { FocusOn } from "react-focus-on";
 
 import { defaultLanguage } from "i18n/supportedLanguages";
-import Button from "src/components/buttons/Button";
 import LanguageSwitcher from "src/components/languageSwitcher/LanguageSwitcher";
 import CustomLink from "src/components/link/CustomLink";
 import LinkButton from "src/components/linkButton/LinkButton";
@@ -102,9 +101,16 @@ export const Header = ({
                     pathTranslations={pathTranslations}
                   />
                 )}
-                <Button size="large" type="secondary" background="light">
-                  <Text type="labelLarge">{t("contact_us")}</Text>
-                </Button>
+
+                {/* THIS SHOULD BE MOVED TO SANITY */}
+                <LinkButton
+                  link="mailto:post@variant.no"
+                  linkTitle={t("contact_us")}
+                  size="L"
+                  type="primary"
+                  background="light"
+                  withoutIcon
+                />
               </div>
               <button
                 aria-haspopup="true"
@@ -131,9 +137,16 @@ export const Header = ({
                       pathTranslations={pathTranslations}
                     />
                   )}
-                  <Button size="large" type="primary" background="dark">
-                    <Text type="labelRegular">{t("contact_us")}</Text>
-                  </Button>
+
+                  {/* THIS SHOULD BE MOVED TO SANITY */}
+                  <LinkButton
+                    link="mailto:post@variant.no"
+                    linkTitle={t("contact_us")}
+                    size="L"
+                    type="primary"
+                    background="light"
+                    withoutIcon
+                  />
                 </div>
               </div>
             )}

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -28,6 +28,7 @@ export interface IHeader {
   announcement: Announcement | null;
   currentLanguage: string;
   pathTranslations: InternationalizedString;
+  contactEmail: string | undefined;
 }
 
 const filterLinks = (data: ILink[], type: string) =>
@@ -38,6 +39,7 @@ export const Header = ({
   announcement,
   currentLanguage,
   pathTranslations,
+  contactEmail,
 }: IHeader) => {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
@@ -102,15 +104,16 @@ export const Header = ({
                   />
                 )}
 
-                {/* THIS SHOULD BE MOVED TO SANITY */}
-                <LinkButton
-                  link="mailto:post@variant.no"
-                  linkTitle={t("contact_us")}
-                  size="L"
-                  type="primary"
-                  background="light"
-                  withoutIcon
-                />
+                {contactEmail && (
+                  <LinkButton
+                    link={`mailto:${contactEmail}`}
+                    linkTitle={t("contact_us")}
+                    size="L"
+                    type="primary"
+                    background="light"
+                    withoutIcon
+                  />
+                )}
               </div>
               <button
                 aria-haspopup="true"
@@ -138,15 +141,16 @@ export const Header = ({
                     />
                   )}
 
-                  {/* THIS SHOULD BE MOVED TO SANITY */}
-                  <LinkButton
-                    link="mailto:post@variant.no"
-                    linkTitle={t("contact_us")}
-                    size="L"
-                    type="primary"
-                    background="light"
-                    withoutIcon
-                  />
+                  {contactEmail && (
+                    <LinkButton
+                      link={`mailto:${contactEmail}`}
+                      linkTitle={t("contact_us")}
+                      size="L"
+                      type="primary"
+                      background="light"
+                      withoutIcon
+                    />
+                  )}
                 </div>
               </div>
             )}

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -184,7 +184,7 @@ export const renderPageCTAs = (ctas: ILink[], isMobile: boolean) => (
       <li key={link._key}>
         <LinkButton
           link={link}
-          isSmall={true}
+          size="S"
           type={ctas.length < 2 || index === 1 ? "primary" : "secondary"}
         />
       </li>

--- a/src/components/navigation/header/HeaderPreview.tsx
+++ b/src/components/navigation/header/HeaderPreview.tsx
@@ -19,12 +19,14 @@ export default function HeaderPreview({
   initialAnnouncement,
   currentLanguage,
   pathTranslations,
+  contactEmail,
 }: {
   initialNav: QueryResponseInitial<Navigation>;
   initialBrandAssets: QueryResponseInitial<BrandAssets>;
   initialAnnouncement: QueryResponseInitial<Announcement | null>;
   currentLanguage: string;
   pathTranslations: InternationalizedString;
+  contactEmail: string | undefined;
 }) {
   const { data: newNav } = useQuery<Navigation | null>(
     NAV_QUERY,
@@ -51,6 +53,7 @@ export default function HeaderPreview({
         announcement={newAnnouncement}
         currentLanguage={currentLanguage}
         pathTranslations={pathTranslations}
+        contactEmail={contactEmail}
       />
     )
   );

--- a/src/components/navigation/header/PageHeader.tsx
+++ b/src/components/navigation/header/PageHeader.tsx
@@ -4,6 +4,7 @@ import { Announcement } from "studio/lib/interfaces/announcement";
 import { BrandAssets } from "studio/lib/interfaces/brandAssets";
 import { InternationalizedString } from "studio/lib/interfaces/global";
 import { Navigation } from "studio/lib/interfaces/navigation";
+import { COMPANY_EMAIL_QUERY } from "studio/lib/queries/admin";
 import {
   ANNOUNCEMENT_QUERY,
   BRAND_ASSETS_QUERY,
@@ -43,6 +44,10 @@ export default async function PageHeader({
     { perspective },
   );
 
+  const initialCompanyEmail = await loadStudioQuery<
+    { companyEmail: string } | undefined
+  >(COMPANY_EMAIL_QUERY, {}, { perspective });
+
   return (
     isNonNullQueryResponse(initialBrandAssets) &&
     isNonNullQueryResponse(initialNav) &&
@@ -53,6 +58,7 @@ export default async function PageHeader({
         initialAnnouncement={initialAnnouncement}
         currentLanguage={language}
         pathTranslations={pathTranslations}
+        contactEmail={initialCompanyEmail.data?.companyEmail}
       />
     ) : (
       <Header
@@ -61,6 +67,7 @@ export default async function PageHeader({
         announcement={initialAnnouncement.data}
         currentLanguage={language}
         pathTranslations={pathTranslations}
+        contactEmail={initialCompanyEmail.data?.companyEmail}
       />
     ))
   );

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -55,13 +55,13 @@ export default async function CompensationCalculator({
             <Calculator
               localeRes={localeRes}
               salariesRes={salariesRes}
-              initialDegree={"master"}
+              initialDegree="master"
               background={radioBackground}
             />
           </Suspense>
 
           {section.calculatorBlock.calculatorLink?.linkTitle && (
-            <div className={styles.calculatorLink}>
+            <div className={styles.calculatorBottomLink}>
               <LinkButton
                 type="secondary"
                 background={
@@ -91,7 +91,7 @@ export default async function CompensationCalculator({
           )}
 
           {section.handbookBlock.handbookLink?.linkTitle && (
-            <div className={styles.handbookLink}>
+            <div className={styles.handbookBottomLink}>
               <LinkButton
                 type="secondary"
                 background={

--- a/src/components/sections/compensation-calculator/compensation-calculator.module.css
+++ b/src/components/sections/compensation-calculator/compensation-calculator.module.css
@@ -56,8 +56,8 @@
   --_calcColor: var(--text-primary-light);
 }
 
-.calculatorLink,
-.handbookLink {
+.calculatorBottomLink,
+.handbookBottomLink {
   margin-top: auto;
   padding-top: 3rem;
 }
@@ -68,6 +68,7 @@
   flex-wrap: wrap;
   list-style: none;
   padding: 0;
+  margin-top: 2rem;
 }
 .handbookLinks li {
   padding: 0;

--- a/src/components/sections/contact-box/contact-box.module.css
+++ b/src/components/sections/contact-box/contact-box.module.css
@@ -1,5 +1,5 @@
 .contactBox {
-  margin: auto;
+  margin: 1rem auto;
   padding: 0 1rem;
   max-width: var(--max-content-width-large);
 }

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -39,7 +39,7 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
               <LinkButton
                 key={action._key}
                 type={index === 0 ? "primary" : "secondary"}
-                isSmall
+                size="S"
                 link={action}
               />
             ))}

--- a/studio/lib/queries/admin.ts
+++ b/studio/lib/queries/admin.ts
@@ -7,6 +7,10 @@ import { translatedFieldFragment } from "./utils/i18n";
 //Parent Company
 export const COMPANY_INFO_QUERY = groq`*[_type == "${companyInfoID}"][0]`;
 
+export const COMPANY_EMAIL_QUERY = groq`*[_type == "${companyInfoID}"][0] {
+  companyEmail
+}`;
+
 //Company Locations
 export const COMPANY_LOCATIONS_QUERY = groq`*[_type == "companyLocation"]`;
 


### PR DESCRIPTION
Fixes https://github.com/varianter/variant.no/issues/936
Matching button design with component in Figma. And supporting normal link strings.



## Todo later

- Should support all types of icons
- Follow up on some inconsistencies with secondary and background (hover, active etc) that doesn't follow design a cross different views in Figma


## Screenshots

![Screenshot 2024-12-06 at 19 26 07](https://github.com/user-attachments/assets/7741ae24-b846-4850-b6fa-863dc6b36118)
![Screenshot 2024-12-06 at 19 26 04](https://github.com/user-attachments/assets/48ff8e4f-ba82-4532-afd0-540f129ae36e)
![Screenshot 2024-12-06 at 19 25 56](https://github.com/user-attachments/assets/c142d271-66c1-4308-bf30-63913c87d71e)
