### PR TITLE
feat: adds support for multiple headings and proper sizing for image split component

### DIFF
--- a/src/components/image/SanityImage.tsx
+++ b/src/components/image/SanityImage.tsx
@@ -92,6 +92,8 @@ export function SanityImage({ image }: { image: IImage }) {
         alt={image?.alt || ""}
         src={image.src.src}
         style={{ objectFit: "cover", height: "100%", width: "100%" }}
+        width={300}
+        height={300}
       />
     );
   }

--- a/src/components/image/SanityImage.tsx
+++ b/src/components/image/SanityImage.tsx
@@ -92,8 +92,6 @@ export function SanityImage({ image }: { image: IImage }) {
         alt={image?.alt || ""}
         src={image.src.src}
         style={{ objectFit: "cover", height: "100%", width: "100%" }}
-        width={300}
-        height={300}
       />
     );
   }

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -3,6 +3,7 @@ import { ElementType } from "react";
 import { SanityImage } from "src/components/image/SanityImage";
 import LinkButton from "src/components/linkButton/LinkButton";
 import Text, { TextType } from "src/components/text/Text";
+import { cnIf } from "src/utils/css";
 import { ImageSplitSection } from "studio/lib/interfaces/pages";
 import { ImageAlignment } from "studio/schemas/fields/media";
 
@@ -16,16 +17,17 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
   const hasImage = section.imageExtended;
   const alignment = section.imageExtended?.imageAlignment;
   const showImageToLeft = hasImage && alignment == ImageAlignment.Left;
-  const showImageToRight = hasImage && alignment == ImageAlignment.Right;
+  const is2vs3 = true;
+
+  const imageSplitClass = cnIf({
+    [styles.imageSplit]: true,
+    [styles["imageSplit--imageLeft"]]: showImageToLeft,
+    [styles["imageSplit--imageRight"]]: !showImageToLeft,
+    [styles["imageSplit--2vs3"]]: is2vs3,
+  });
 
   return (
-    <article className={styles.imageSplit}>
-      {showImageToLeft && (
-        <div className={styles.image}>
-          <SanityImage image={section.imageExtended} />
-        </div>
-      )}
-
+    <article className={imageSplitClass}>
       <div className={styles.textContainer}>
         {section.content.map((content, index) => (
           <Content key={content._key} content={content} isFirst={index === 0} />
@@ -45,7 +47,7 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
         )}
       </div>
 
-      {showImageToRight && (
+      {section.imageExtended && (
         <div className={styles.image}>
           <div>
             <SanityImage image={section.imageExtended} />

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -1,6 +1,8 @@
+import { ElementType } from "react";
+
 import { SanityImage } from "src/components/image/SanityImage";
 import LinkButton from "src/components/linkButton/LinkButton";
-import Text from "src/components/text/Text";
+import Text, { TextType } from "src/components/text/Text";
 import { ImageSplitSection } from "studio/lib/interfaces/pages";
 import { ImageAlignment } from "studio/schemas/fields/media";
 
@@ -25,15 +27,11 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
       )}
 
       <div className={styles.textContainer}>
-        <Text type="h4" as="h2">
-          {section.basicTitle}
-        </Text>
+        {section.content.map((content, index) => (
+          <Content key={content._key} content={content} isFirst={index === 0} />
+        ))}
 
-        {section.description && (
-          <Text type="bodyNormal">{section.description}</Text>
-        )}
-
-        {section.actions.length > 0 && (
+        {section.actions?.length > 0 && (
           <div className={styles.textContainer__link}>
             {section.actions.map((action, index) => (
               <LinkButton
@@ -49,11 +47,35 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
 
       {showImageToRight && (
         <div className={styles.image}>
-          <SanityImage image={section.imageExtended} />
+          <div>
+            <SanityImage image={section.imageExtended} />
+          </div>
         </div>
       )}
     </article>
   );
 };
+
+function Content({
+  content,
+  isFirst,
+}: {
+  content: ImageSplitProps["section"]["content"][0];
+  isFirst: boolean;
+}) {
+  const [type, asType] = isFirst ? ["h2", "h2"] : ["h4", "h3"];
+
+  return (
+    <>
+      <Text type={type as TextType} as={asType as ElementType}>
+        {content.basicTitle}
+      </Text>
+
+      {content.description && (
+        <Text type="bodyNormal">{content.description}</Text>
+      )}
+    </>
+  );
+}
 
 export default ImageSplitComponent;

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -17,13 +17,18 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
   const hasImage = section.imageExtended;
   const alignment = section.imageExtended?.imageAlignment;
   const showImageToLeft = hasImage && alignment == ImageAlignment.Left;
-  const is2vs3 = true;
 
   const imageSplitClass = cnIf({
     [styles.imageSplit]: true,
     [styles["imageSplit--imageLeft"]]: showImageToLeft,
     [styles["imageSplit--imageRight"]]: !showImageToLeft,
-    [styles["imageSplit--2vs3"]]: is2vs3,
+    [styles["imageSplit--2vs3"]]: section.is2vs3,
+    [styles["imageSplit--medium"]]: section.size === "medium",
+  });
+
+  const imageClass = cnIf({
+    [styles.image]: true,
+    [styles["image--fullHeight"]]: section.imageFullHeight,
   });
 
   return (
@@ -39,7 +44,7 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
               <LinkButton
                 key={action._key}
                 type={index === 0 ? "primary" : "secondary"}
-                size="S"
+                size="L"
                 link={action}
               />
             ))}
@@ -48,7 +53,7 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
       </div>
 
       {section.imageExtended && (
-        <div className={styles.image}>
+        <div className={imageClass}>
           <div>
             <SanityImage image={section.imageExtended} />
           </div>

--- a/src/components/sections/image-split/image-split.module.css
+++ b/src/components/sections/image-split/image-split.module.css
@@ -1,8 +1,8 @@
 .imageSplit {
   max-width: var(--max-content-width-small);
 
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  display: flex;
+  flex-direction: row;
 
   gap: 3rem;
   row-gap: 5.25rem;
@@ -14,6 +14,7 @@
 }
 
 .textContainer {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -29,4 +30,5 @@
 .image {
   display: flex;
   justify-content: center;
+  align-self: normal;
 }

--- a/src/components/sections/image-split/image-split.module.css
+++ b/src/components/sections/image-split/image-split.module.css
@@ -12,6 +12,9 @@
   box-sizing: content-box;
   align-items: stretch;
 }
+.imageSplit--medium {
+  max-width: var(--max-content-width-medium);
+}
 .imageSplit--imageLeft {
   grid-template-areas: "image text";
 }
@@ -31,7 +34,7 @@
   .imageSplit--imageLeft.imageSplit--2vs3,
   .imageSplit--imageRight,
   .imageSplit--imageRight.imageSplit--2vs3 {
-    grid-template-rows: auto auto;
+    grid-template-rows: auto minmax(20rem, auto);
     grid-template-columns: 1fr;
   }
   .imageSplit--imageLeft {
@@ -65,10 +68,11 @@
   grid-area: image;
   display: flex;
   justify-content: center;
-
-  & > div {
-    width: 100%;
-  }
+}
+.image--fullHeight > div {
+  width: 100%;
+  height: 100%;
+  display: flex;
 }
 .image img {
   display: block;

--- a/src/components/sections/image-split/image-split.module.css
+++ b/src/components/sections/image-split/image-split.module.css
@@ -1,19 +1,53 @@
 .imageSplit {
   max-width: var(--max-content-width-small);
 
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-areas: "image text";
+  grid-template-columns: 1fr 1fr;
 
-  gap: 3rem;
-  row-gap: 5.25rem;
+  gap: 2rem;
   padding: 1rem;
   margin: 3.75rem auto;
 
   box-sizing: content-box;
-  align-items: center;
+  align-items: stretch;
+}
+.imageSplit--imageLeft {
+  grid-template-areas: "image text";
+}
+.imageSplit--imageLeft.imageSplit--2vs3 {
+  grid-template-columns: 2fr 3fr;
+}
+.imageSplit--imageRight {
+  grid-template-areas: "text image";
+}
+.imageSplit--imageRight.imageSplit--2vs3 {
+  grid-template-columns: 3fr 2fr;
+}
+
+@media (max-width: 768px) {
+  .imageSplit,
+  .imageSplit--imageLeft,
+  .imageSplit--imageLeft.imageSplit--2vs3,
+  .imageSplit--imageRight,
+  .imageSplit--imageRight.imageSplit--2vs3 {
+    grid-template-rows: auto auto;
+    grid-template-columns: 1fr;
+  }
+  .imageSplit--imageLeft {
+    grid-template-areas:
+      "image"
+      "text";
+  }
+  .imageSplit--imageRight {
+    grid-template-areas:
+      "text"
+      "image";
+  }
 }
 
 .textContainer {
+  grid-area: text;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -28,7 +62,16 @@
 }
 
 .image {
+  grid-area: image;
   display: flex;
   justify-content: center;
-  align-self: normal;
+
+  & > div {
+    width: 100%;
+  }
+}
+.image img {
+  display: block;
+  margin: 0 auto;
+  width: 100%;
 }

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -72,6 +72,9 @@ export interface ImageSection {
 export interface ImageSplitSection {
   _type: "imageSplitSection";
   _key: string;
+  size: "small" | "medium";
+  is2vs3: boolean;
+  imageFullHeight: boolean;
   content: {
     _key: string;
     basicTitle: string;

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -72,9 +72,12 @@ export interface ImageSection {
 export interface ImageSplitSection {
   _type: "imageSplitSection";
   _key: string;
-  basicTitle: string;
+  content: {
+    _key: string;
+    basicTitle: string;
+    description: string;
+  }[];
   imageExtended: ImageExtendedProps;
-  description: string;
   actions: ILink[];
 }
 

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -29,8 +29,11 @@ const SECTIONS_FRAGMENT = groq`
     },
     _type == "imageSplitSection" => {
       ...,
-      "basicTitle": ${translatedFieldFragment("basicTitle")},
-      "description": ${translatedFieldFragment("description")},
+      "content": content[]{
+        ...,
+        "basicTitle": ${translatedFieldFragment("basicTitle")},
+        "description": ${translatedFieldFragment("description")},
+      },
       actions[] {
         ...,
         ${TRANSLATED_LINK_FRAGMENT}

--- a/studio/schemas/objects/sections/imagesplit.ts
+++ b/studio/schemas/objects/sections/imagesplit.ts
@@ -49,6 +49,31 @@ export const imageSplitSection = defineField({
       ],
     },
 
+    {
+      name: "size",
+      title: "Size",
+      type: "string",
+      options: { list: ["small", "medium"] },
+      initialValue: "small",
+    },
+
+    {
+      name: "is2vs3",
+      title: "Ratio 2:3",
+      description:
+        "If true, the image will be displayed in a 2:3 ratio. Otherwise, it will be displayed in a 1:1 ratio.",
+      type: "boolean",
+      initialValue: false,
+    },
+
+    {
+      name: "imageFullHeight",
+      title: "Image Full Height",
+      description: "If true, the image will be displayed in full height.",
+      type: "boolean",
+      initialValue: true,
+    },
+
     imageExtended,
     {
       name: "actions",

--- a/studio/schemas/objects/sections/imagesplit.ts
+++ b/studio/schemas/objects/sections/imagesplit.ts
@@ -13,19 +13,40 @@ export const imageSplitSection = defineField({
   type: "object",
   fields: [
     {
-      name: titleID.basic,
-      type: "internationalizedArrayString",
-      title: "Title",
-      description:
-        "Enter the primary title that will be displayed at the top of the employees section.",
-    },
-
-    {
-      name: "description",
-      type: "internationalizedArrayString",
-      title: "Main content",
-      description:
-        "Enter the main content that will be displayed below the title.",
+      name: "content",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          fields: [
+            {
+              name: titleID.basic,
+              type: "internationalizedArrayString",
+              title: "Title",
+              description:
+                "Enter the primary title that will be displayed at the top of the employees section.",
+            },
+            {
+              name: "description",
+              type: "internationalizedArrayString",
+              title: "Main content",
+              description:
+                "Enter the main content that will be displayed below the title.",
+            },
+          ],
+          preview: {
+            select: {
+              title: titleID.basic,
+            },
+            prepare(selection) {
+              const { title } = selection;
+              return {
+                title: firstTranslation(title) ?? undefined,
+              };
+            },
+          },
+        },
+      ],
     },
 
     imageExtended,
@@ -38,12 +59,12 @@ export const imageSplitSection = defineField({
   ],
   preview: {
     select: {
-      title: "basicTitle",
+      content: "content",
     },
     prepare(selection) {
-      const { title } = selection;
+      const { content } = selection;
       return {
-        title: firstTranslation(title) ?? undefined,
+        title: firstTranslation(content[0]?.basicTitle) ?? undefined,
       };
     },
   },


### PR DESCRIPTION
To make image split component more reusable. 

This is not an ideal solution, but is kind of a one size fits almost all. The sanity image component with cover sizing makes this difficult, but I think this is at a bare minimum of what is acceptable before launch. Some images might be cut in some sizes

## Screenshots

<img width="604" alt="Screenshot 2024-12-08 at 21 01 47" src="https://github.com/user-attachments/assets/21d652b1-c1b6-487b-9460-d83b5a807ba1">
<img width="345" alt="Screenshot 2024-12-08 at 21 01 39" src="https://github.com/user-attachments/assets/3a606481-a299-440d-bfbb-de8cc1814923">
<img width="1032" alt="Screenshot 2024-12-08 at 21 00 10" src="https://github.com/user-attachments/assets/be377463-3e1c-423b-a535-cc900817eba6">
