### PR TITLE
fix: stop header disappearing due to scroll on nav

### DIFF
--- a/src/components/link/CustomLink.tsx
+++ b/src/components/link/CustomLink.tsx
@@ -14,6 +14,7 @@ interface ICustomLink {
   isSelected?: boolean;
   size?: "normal" | "small";
   color?: "dark" | "light";
+  scroll?: boolean;
 }
 
 const CustomLink = ({
@@ -22,6 +23,7 @@ const CustomLink = ({
   isSelected,
   size = "normal",
   color = "dark",
+  scroll,
 }: ICustomLink) => {
   const href = getHref(link);
   const newTab = link.newTab;
@@ -64,6 +66,7 @@ const CustomLink = ({
             target={target}
             rel={rel}
             aria-label={link.ariaLabel}
+            scroll={scroll}
           >
             <span className={styles.dot}></span>
             {link.linkTitle}

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -187,7 +187,12 @@ export const renderPageLinks = (
       const isSelected = pathname === `${linkUrl}`;
       return (
         <li key={link._key}>
-          <CustomLink link={link} type="headerLink" isSelected={isSelected} />
+          <CustomLink
+            link={link}
+            type="headerLink"
+            isSelected={isSelected}
+            scroll={false}
+          />
         </li>
       );
     })}


### PR DESCRIPTION
This will stop the header from disappearing when you navigate using header links.
An alternative solution is to modify the useScrollDirection hook to have setTimeout on page load before it triggers