### PR TITLE
change translations messages and edit imagesize

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -54,9 +54,9 @@
     "location": "Location",
     "all": "All",
     "Project Management": "Project Management",
-    "design": "Design",
-    "development": "Development",
-    "administration": "Administration",
+    "Design": "Design",
+    "Utvikling": "Development",
+    "Administasjon": "Administration",
     "field": "Field",
     "showMore": "Show all"
   },

--- a/messages/no.json
+++ b/messages/no.json
@@ -53,9 +53,9 @@
     "location": "Lokasjon",
     "all": "Alle",
     "Project Management": "Prosjektledelse",
-    "design": "Design",
-    "development": "Utvikling",
-    "administration": "Administrasjon",
+    "Design": "Design",
+    "Utvikling": "Utvikling",
+    "Administasjon": "Administrasjon",
     "field": "Fag",
     "showMore": "Vis alle"
   },

--- a/messages/se.json
+++ b/messages/se.json
@@ -53,9 +53,9 @@
     "location": "Kontor",
     "all": "Alla",
     "Project Management": "Projektledning",
-    "design": "Design",
-    "development": "Utveckling",
-    "administration": "Administration",
+    "Design": "Design",
+    "Utvikling": "Utveckling",
+    "Administasjon": "Administration",
     "field": "Fält",
     "showMore": "Vis alla"
   },

--- a/src/components/sections/employeeHighlight/employeeHighlight.module.css
+++ b/src/components/sections/employeeHighlight/employeeHighlight.module.css
@@ -18,7 +18,7 @@
 .image {
   min-width: 20rem;
   width: 100%;
-  height: auto;
+  height: 24rem;
   object-fit: cover;
 
   & img {

--- a/src/components/sections/employeeHighlight/employeeHighlight.module.css
+++ b/src/components/sections/employeeHighlight/employeeHighlight.module.css
@@ -16,10 +16,9 @@
 }
 
 .image {
+  aspect-ratio: 1 / 1;
   min-width: 20rem;
-  width: 100%;
-  height: 24rem;
-  object-fit: cover;
+  max-height: 30rem;
 
   & img {
     border-radius: 0.375rem;
@@ -28,6 +27,12 @@
   @media (max-width: 834px) {
     max-width: 60%;
   }
+}
+
+.image img {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .textContainer {


### PR DESCRIPTION
Fix of this image sizing issue and revert changes in i18n messages. 

<img width="1175" alt="Screenshot 2024-12-09 at 15 54 32" src="https://github.com/user-attachments/assets/9dcb1c78-af89-4124-aba3-8dadad118dce">
