### PR TITLE
🐛 Set max year to 2023 in salary calculator

### DIFF
--- a/src/components/compensations/utils/salary.ts
+++ b/src/components/compensations/utils/salary.ts
@@ -11,7 +11,7 @@ export function calculateSalary(
   salaries: Salaries,
 ): number | undefined {
   const degreeValue = degree === "bachelor" ? 1 : 0;
-  const adjustedYear = examinationYear - degreeValue;
+  const adjustedYear = examinationYear + degreeValue;
   return salaries[adjustedYear];
 }
 

--- a/src/components/compensations/utils/salary.ts
+++ b/src/components/compensations/utils/salary.ts
@@ -10,8 +10,8 @@ export function calculateSalary(
   degree: string,
   salaries: Salaries,
 ): number | undefined {
-  const degreeValue = degree === "bachelor" ? 1 : 0;
-  const adjustedYear = examinationYear + degreeValue;
+  const adjustedYear =
+    degree == "master" ? examinationYear - 1 : examinationYear;
   return salaries[adjustedYear];
 }
 

--- a/src/components/sections/compensation-calculator/Calculator.tsx
+++ b/src/components/sections/compensation-calculator/Calculator.tsx
@@ -48,7 +48,7 @@ export default function Calculator({
   }
 
   const { min, max } = getMinMaxYear(salaries.value);
-  const salary = calculateSalary(year, degree, salaries.value) ?? 0;
+  const salary = calculateSalary(year + 1, degree, salaries.value) ?? 0;
 
   const degreeOptions: IOption[] = [
     { id: "bachelor", label: t("degreeOptions.bachelor") },
@@ -100,11 +100,13 @@ export default function Calculator({
 function getMinMaxYear(salaries: SalaryData) {
   const years = Object.keys(salaries).map((s) => parseInt(s));
   const min = Math.min(...years);
-  const max = Math.max(...years);
+  // We subtract 1 because we don't have data for the current year
+  const max = Math.max(...years) - 1;
   return { min, max };
 }
 function getMaybeMaxYear(salaries: Result<SalaryData, unknown>) {
   if (!salaries.ok) return undefined;
   const years = Object.keys(salaries.value).map((s) => parseInt(s));
-  return Math.max(...years);
+  // We subtract 1 because we don't have data for the current year
+  return Math.max(...years) - 1;
 }


### PR DESCRIPTION
## Summary
We don't have salaries for 2024 graduates, pending the 2025 salary adjustments, so we need to set max year to 2023 (like we do in [the current salary calculator](https://www.variant.no/kalkulator)). Subtracting 1 from the maximum year (2024) to display 2023 in the input field, and then adding 1 before calling `calculateSalary`, gives me _the ick_, but it works ...

### Screenshots
#### Before
<img width="692" alt="Screenshot 2024-12-10 at 10 58 48" src="https://github.com/user-attachments/assets/3917077e-a3a0-4926-b407-c5f923ff19e0">
<img width="689" alt="Screenshot 2024-12-10 at 10 58 43" src="https://github.com/user-attachments/assets/87798815-f0da-471e-b54a-a235d1e06b5d">

#### After
<img width="689" alt="Screenshot 2024-12-10 at 10 58 20" src="https://github.com/user-attachments/assets/adb2569d-ddaa-4cdc-943b-3f65c0b3e1e1">
<img width="693" alt="Screenshot 2024-12-10 at 10 58 24" src="https://github.com/user-attachments/assets/9d38b6ce-a770-471e-89cb-77355ad9bbb7">

