### PR TITLE
fix: adds option to enforce no cover for sanity image

### DIFF
--- a/src/components/image/SanityImage.tsx
+++ b/src/components/image/SanityImage.tsx
@@ -39,9 +39,11 @@ const useNextSanityGlobalImage = (
 const SanityAssetImage = ({
   image,
   imageProps,
+  objectFit = "cover",
 }: {
   image: IImage;
   imageProps?: UseNextSanityImageProps;
+  objectFit?: "cover" | "none";
 }) => {
   const objectPosition = image.hotspot
     ? `${image.hotspot.x * 100}% ${image.hotspot.y * 100}%`
@@ -56,12 +58,16 @@ const SanityAssetImage = ({
       width={imageProps.width}
       height={imageProps.height}
       blurDataURL={image.metadata?.lqip}
-      style={{
-        objectFit: "cover",
-        objectPosition,
-        maxWidth: "100%",
-        maxHeight: "100%",
-      }}
+      style={
+        objectFit === "none"
+          ? {}
+          : {
+              objectFit: "cover",
+              objectPosition,
+              maxWidth: "100%",
+              maxHeight: "100%",
+            }
+      }
     />
   );
 };
@@ -76,24 +82,44 @@ export function SanitySharedImage({ image }: { image: IImage }) {
   return <SanityAssetImage image={image} imageProps={imageProps} />;
 }
 
-function SanityGlobalImage({ image }: { image: IImage }) {
+function SanityGlobalImage({
+  image,
+  objectFit = "cover",
+}: {
+  image: IImage;
+  objectFit?: "cover" | "none";
+}) {
   const imageProps = useNextSanityGlobalImage(image);
   return (
-    <SanityAssetImage image={image} imageProps={imageProps ?? undefined} />
+    <SanityAssetImage
+      objectFit={objectFit}
+      image={image}
+      imageProps={imageProps ?? undefined}
+    />
   );
 }
 
-export function SanityImage({ image }: { image: IImage }) {
+export function SanityImage({
+  image,
+  objectFit = "cover",
+}: {
+  image: IImage;
+  objectFit?: "cover" | "none";
+}) {
   if (image?.src) {
     return (
       <Image
         alt={image?.alt || ""}
         src={image.src.src}
-        style={{ objectFit: "cover", height: "100%", width: "100%" }}
+        style={
+          objectFit === "none"
+            ? {}
+            : { objectFit: "cover", height: "100%", width: "100%" }
+        }
         width={300}
         height={300}
       />
     );
   }
-  return <SanityGlobalImage image={image} />;
+  return <SanityGlobalImage image={image} objectFit={objectFit} />;
 }

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -55,7 +55,7 @@ const ImageSplitComponent = ({ section }: ImageSplitProps) => {
       {section.imageExtended && (
         <div className={imageClass}>
           <div>
-            <SanityImage image={section.imageExtended} />
+            <SanityImage image={section.imageExtended} objectFit="none" />
           </div>
         </div>
       )}

--- a/src/components/sections/image-split/image-split.module.css
+++ b/src/components/sections/image-split/image-split.module.css
@@ -55,6 +55,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  justify-content: center;
 }
 
 .textContainer__link {
@@ -77,5 +78,6 @@
 .image img {
   display: block;
   margin: 0 auto;
-  width: 100%;
+  max-width: 100%;
+  height: auto;
 }


### PR DESCRIPTION
This is not the best solution as it requires the block them self to programatically set if it should be cover or not and is not left to the user of the CMS. But thinking for release/launch this is better then nothing. For this to be user controlled we'd have to replace a lot of basic settings for images around everywhere images is used or find a way to do this within sanity. Needs more research.

(Kind of) Fixes #990 

But this allows for block like this at least:
![Screenshot 2024-12-11 at 21 15 57](https://github.com/user-attachments/assets/969a0d88-049e-4ae7-84bb-9e15f05662ad)
![Screenshot 2024-12-11 at 21 15 46](https://github.com/user-attachments/assets/67a0f8a5-e4dc-45cd-871f-4bc09b45c26d)
![Screenshot 2024-12-11 at 21 15 41](https://github.com/user-attachments/assets/9bcce872-2f42-439f-b5e5-f73cbab731a3)
![Screenshot 2024-12-11 at 21 15 34](https://github.com/user-attachments/assets/250c1a33-5e7d-4813-b6f8-61cacb2bcff9)
