### PR TITLE
Add more SoMe platforms and change wording in footer

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -69,7 +69,7 @@
     "text": "We have multiple offices in Norway and Sweden. Feel free to drop by for a cup of coffee or just a friendly chat.",
     "mainMenu": "Main menu",
     "other": "Other",
-    "socialMedia": "Follow us",
+    "socialMedia": "Places we share",
     "contact": "General contact"
   }
 }

--- a/messages/no.json
+++ b/messages/no.json
@@ -68,7 +68,7 @@
     "text": "Vi har flere kontorer i Norge og Sverige. Kom gjerne innom for en kopp kaffe eller bare en hyggelig prat.",
     "mainMenu": "Hovedmeny",
     "other": "Annet",
-    "socialMedia": "Følg oss",
+    "socialMedia": "Steder vi deler",
     "contact": "Generell kontakt"
   }
 }

--- a/messages/se.json
+++ b/messages/se.json
@@ -68,7 +68,7 @@
     "text": "Vi har flera kontor i Sverige och Norge. Du är välkommen att komma förbi för en kopp kaffe eller bara en trevlig pratstund.",
     "mainMenu": "Huvudmeny",
     "other": "Övrigt",
-    "socialMedia": "Följ oss",
+    "socialMedia": "Platser vi delar",
     "contact": "Kontakt"
   }
 }

--- a/studio/components/SoMeInputs.tsx
+++ b/studio/components/SoMeInputs.tsx
@@ -14,6 +14,9 @@ export const SoMePlatforms: { [key: string]: string } = {
   pinterest: "Pinterest",
   medium: "Medium",
   tikTok: "Tiktok",
+  github: "GitHub",
+  podcast: "Podcast",
+  bluesky: "Bluesky",
 };
 
 const detectPlatformFromUrl = (url: string): string | null => {
@@ -73,7 +76,7 @@ const SoMeInputs: React.FC<ObjectInputProps<Record<string, unknown>>> = ({
       <Box>
         <Stack space={3}>
           <Label htmlFor={urlInputName} as={"label"}>
-            URL
+            URL, must include https
           </Label>
           <TextInput
             id={urlInputName}
@@ -87,7 +90,9 @@ const SoMeInputs: React.FC<ObjectInputProps<Record<string, unknown>>> = ({
       <Box>
         <Stack space={3}>
           <Label htmlFor={platformInputName} as={"label"}>
-            Platform
+            Platform (if you can not find the right platform for your link,
+            please add the link to the Footer directly through the Navigation
+            Manager)
           </Label>
           <Select
             id={platformInputName}

--- a/studio/schemas/documents/siteSettings/socialMediaProfiles.ts
+++ b/studio/schemas/documents/siteSettings/socialMediaProfiles.ts
@@ -15,7 +15,7 @@ const socialMediaLinks = defineType({
       type: "array",
       of: [{ type: SocialMediaID.link }],
       description:
-        "Add links to your social media profiles. This allows visitors to connect with you on social platforms.",
+        "Add links to your social media profiles. This allows visitors to connect with you on social platforms. If the link does not match any of the predefined platforms listed, please add the link directly to the footer through the Navigation Manager",
     },
   ],
   preview: {


### PR DESCRIPTION
Github, podcast and bluesky were not represented in the social media platforms of the Social Media links component, which meant that they did not show in the footer, so they have been added now. In addition, the wording in the footer regarding social media has been changed.

I also added some warnings and advice to Sanity.


<img width="191" alt="Screenshot 2024-12-12 at 09 52 46" src="https://github.com/user-attachments/assets/2f92610a-dee3-4698-802b-c46ac1e3db79" />

<img width="784" alt="Screenshot 2024-12-12 at 09 53 01" src="https://github.com/user-attachments/assets/c752478b-4ae1-422c-814f-64c3dec51204" />
