### PR TITLE
💄 Remove unwanted padding from logo salad

### DIFF
--- a/src/components/sections/logoSalad/logoSalad.module.css
+++ b/src/components/sections/logoSalad/logoSalad.module.css
@@ -8,10 +8,6 @@
   composes: shared;
   padding: 5rem 2rem;
   background-color: var(--background-bg-light-primary);
-
-  @media (min-width: 1024px) {
-    padding: 7.5rem 15rem;
-  }
 }
 
 .logoWrapper {


### PR DESCRIPTION
### Before
<img width="1215" alt="Screenshot 2024-12-12 at 10 08 29" src="https://github.com/user-attachments/assets/324241a3-f729-462a-9eb2-f99e0576b20b" />

### After
<img width="1214" alt="Screenshot 2024-12-12 at 10 08 36" src="https://github.com/user-attachments/assets/5f1e0a30-ebb7-405f-85ed-cd9827f06322" />
