### PR TITLE
💄 Changed from :focus to :focus-visible 

### DIFF
--- a/src/components/forms/checkbox/checkbox.module.css
+++ b/src/components/forms/checkbox/checkbox.module.css
@@ -55,7 +55,7 @@
 }
 
 /* Focus Styles */
-.input:focus + .checkbox {
+.input:focus-visible + .checkbox {
   outline: 2px solid var(--stroke-primary);
   outline-offset: 2px;
 }

--- a/src/components/linkButton/linkButton.module.css
+++ b/src/components/linkButton/linkButton.module.css
@@ -37,7 +37,7 @@
   &:hover {
     --_button-radius: var(--_button-hoverRadius);
   }
-  &:focus {
+  &:focus-visible {
     --_button-radius: var(--_button-hoverRadius);
     outline: 2px solid var(--surface-yellow);
     outline-offset: 1px;
@@ -85,7 +85,7 @@
   &:hover {
     --_button-background: var(--background-bg-dark);
   }
-  &:focus {
+  &:focus-visible {
     --_button-border: 1px solid var(--surface-yellow);
   }
   &:active {
@@ -127,7 +127,7 @@
   &:hover {
     --_button-background: var(--background-bg-dark);
   }
-  &:focus {
+  &:focus-visible {
     --_button-border: 1px solid var(--surface-yellow);
   }
   &:active {

--- a/src/components/sections/testimonials/testimonials.module.css
+++ b/src/components/sections/testimonials/testimonials.module.css
@@ -114,7 +114,7 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 2px solid var(--stroke-primary);
     border-radius: 0.9375rem;
   }
@@ -179,7 +179,7 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 2px solid #3995ef;
     border-radius: 0.9375rem;
   }

--- a/src/components/tag/tag.module.css
+++ b/src/components/tag/tag.module.css
@@ -22,7 +22,7 @@
 .tag:active {
   --_tag-borderColor: var(--background-bg-light-secondary);
 }
-.tag:focus {
+.tag:focus-visible {
   outline: 2px solid var(--surface-yellow, #ffd02f);
 }
 


### PR DESCRIPTION
To avoid showing outlines when clicking buttons or checkboxes, only when tabbing/keyboarding