### PR TITLE
fix: localtion label for job listings

### DIFF
--- a/src/components/jobPosting/JobPosting.tsx
+++ b/src/components/jobPosting/JobPosting.tsx
@@ -11,9 +11,13 @@ function sortAlphabetically(list: string[]) {
 
 interface JobPostingProps {
   jobPosting: IJobPosting;
+  showLocations?: boolean;
 }
 
-export default function JobPosting({ jobPosting }: JobPostingProps) {
+export default function JobPosting({
+  jobPosting,
+  showLocations = true,
+}: JobPostingProps) {
   const jobPostingLocations = sortAlphabetically(
     jobPosting.locations.map(
       (location: CompanyLocation) => location.companyLocationName,
@@ -30,9 +34,11 @@ export default function JobPosting({ jobPosting }: JobPostingProps) {
         <div className={styles.role}>
           <Text type={"h5"}>{jobPosting.role}</Text>
         </div>
-        <div className={styles.locations}>
-          <Badge>{jobPostingLocations}</Badge>
-        </div>
+        {showLocations && (
+          <div className={styles.locations}>
+            <Badge>{jobPostingLocations}</Badge>
+          </div>
+        )}
       </div>
     </a>
   );

--- a/src/components/jobPosting/jobPosting.module.css
+++ b/src/components/jobPosting/jobPosting.module.css
@@ -33,7 +33,6 @@
 }
 
 .role {
-  width: 250px;
   @media (max-width: 640px) {
     width: 100%;
   }

--- a/src/components/sections/jobs/JobPostingList.tsx
+++ b/src/components/sections/jobs/JobPostingList.tsx
@@ -95,7 +95,11 @@ export default function JobPostingList({
       </div>
       <div className={styles.jobPostings}>
         {filteredJobPostings?.map((jobPosting: IJobPosting) => (
-          <JobPosting jobPosting={jobPosting} key={jobPosting._key} />
+          <JobPosting
+            jobPosting={jobPosting}
+            key={jobPosting._key}
+            showLocations={locationFilter == null}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
Fixes job listings size

Don't show location when selected location (everyone is the same)

<img width="500" alt="Screenshot 2024-12-12 at 14 38 37" src="https://github.com/user-attachments/assets/6d3b2212-0f5b-4fe2-8274-e45c02057149" />
<img width="1035" alt="Screenshot 2024-12-12 at 14 38 24" src="https://github.com/user-attachments/assets/c0740520-2244-48cc-b924-9abf505bd2a0" />
<img width="943" alt="Screenshot 2024-12-12 at 14 38 22" src="https://github.com/user-attachments/assets/543cb274-ce41-4153-a962-2ae87e1d9cb5" />
