### PR TITLE
Fix margins and image on mobile and tablet

### DIFF
--- a/src/components/sections/employeeHighlight/employeeHighlight.module.css
+++ b/src/components/sections/employeeHighlight/employeeHighlight.module.css
@@ -9,8 +9,6 @@
 
   @media (max-width: 834px) {
     flex-direction: column;
-    margin-left: 2rem;
-    margin-right: 2rem;
   }
 }
 
@@ -25,6 +23,7 @@
 
   @media (max-width: 834px) {
     max-width: 60%;
+    margin: auto;
   }
 }
 


### PR DESCRIPTION
Removed margins for tabletand added margin auto on image to center it on mobile devices. 

<img width="448" alt="Screenshot 2024-12-13 at 12 55 55" src="https://github.com/user-attachments/assets/8754cb15-eaeb-40f4-968f-70256b417440" />
