### PR TITLE
Fix no padding on mobile devices on compensation page

### DIFF
--- a/src/components/compensations/compensations.module.css
+++ b/src/components/compensations/compensations.module.css
@@ -11,6 +11,10 @@
   gap: 3rem;
   width: 100%;
   max-width: var(--max-content-width-large);
+
+  @media (max-width: 834px) {
+    padding: 10rem 0;
+  }
 }
 
 .text {


### PR DESCRIPTION
Previously:
<img width="447" alt="Screenshot 2024-12-13 at 14 20 29" src="https://github.com/user-attachments/assets/caab32c3-d475-4e74-a163-067b200a6d43" />


Now:
<img width="468" alt="Screenshot 2024-12-13 at 14 20 48" src="https://github.com/user-attachments/assets/ca2c44bc-af1a-4ccc-a3fa-1ae445dc0c57" />
