### PR TITLE
Add missing translations for bonus stuff

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -50,7 +50,7 @@
     },
     "bonus": {
       "location": "Location",
-      "bonuses": "Bonuses",
+      "bonuses": "Previous bonuses",
       "year": "Year",
       "amount": "Amount"
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -36,7 +36,7 @@
     "visit_cv": "Visit mini-CV",
     "read_more": "Read more"
   },
-  "compensation_calculator": {
+  "compensation": {
     "calculator": {
       "formLabel": "Salary calculator",
       "educationInput": "Education",
@@ -47,6 +47,12 @@
     "degreeOptions": {
       "bachelor": "Bachelor",
       "master": "Master"
+    },
+    "bonus": {
+      "location": "Location",
+      "bonuses": "Bonuses",
+      "year": "Year",
+      "amount": "Amount"
     }
   },
   "employee_card": {

--- a/messages/no.json
+++ b/messages/no.json
@@ -32,7 +32,7 @@
     "contact_sale": "Kontakt salg!",
     "contact_us": "Kontakt oss"
   },
-  "compensation_calculator": {
+  "compensation": {
     "calculator": {
       "formLabel": "Lønnskalkulator",
       "educationInput": "Utdanning",
@@ -44,7 +44,12 @@
       "bachelor": "Bachelor",
       "master": "Master"
     },
-    "test": "test"
+    "bonus": {
+      "location": "Lokasjon",
+      "bonuses": "Bonuser",
+      "year": "År",
+      "amount": "Beløp"
+    }
   },
   "custom_link": {
     "visit_cv": "Gå til mini-CV",

--- a/messages/no.json
+++ b/messages/no.json
@@ -46,7 +46,7 @@
     },
     "bonus": {
       "location": "Lokasjon",
-      "bonuses": "Bonuser",
+      "bonuses": "Tidligere bonuser",
       "year": "År",
       "amount": "Beløp"
     }

--- a/messages/se.json
+++ b/messages/se.json
@@ -46,7 +46,7 @@
     },
     "bonus": {
       "location": "Kontor",
-      "bonuses": "Bonusar",
+      "bonuses": "Tidigare bonusar",
       "year": "År",
       "amount": "Belopp"
     }

--- a/messages/se.json
+++ b/messages/se.json
@@ -32,7 +32,7 @@
     "contact_sale": "Kontakta sälj!",
     "contact_us": "Kontakt oss"
   },
-  "compensation_calculator": {
+  "compensation": {
     "calculator": {
       "formLabel": "Lönskalkulator",
       "educationInput": "Utbildning",
@@ -43,6 +43,12 @@
     "degreeOptions": {
       "bachelor": "Bachelor",
       "master": "Master"
+    },
+    "bonus": {
+      "location": "Kontor",
+      "bonuses": "Bonusar",
+      "year": "År",
+      "amount": "Belopp"
     }
   },
   "custom_link": {

--- a/src/components/compensations/CompensationSelector.tsx
+++ b/src/components/compensations/CompensationSelector.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useTranslations } from "next-intl";
 import { useState } from "react";
 
 import {
@@ -24,6 +25,8 @@ export default function CompensationSelector({
   locations,
   locale,
 }: CompensationsProps) {
+  const t = useTranslations("compensation");
+
   const hasBenefits = (id: string) =>
     compensations.benefitsByLocation.some((b) => b.location._ref === id);
 
@@ -51,7 +54,7 @@ export default function CompensationSelector({
     <div className={styles.compensationWrapper}>
       <RadioButtonGroup
         id="location-group"
-        label="Velg lokasjon"
+        label={t("bonus.location")}
         options={locationOptions}
         selectedId={selectedLocation}
         onValueChange={(option) => {

--- a/src/components/compensations/components/yearlyBonuses/YearlyBonuses.tsx
+++ b/src/components/compensations/components/yearlyBonuses/YearlyBonuses.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "next-intl";
+
 import Text from "src/components/text/Text";
 import { formatAsCurrency } from "src/utils/i18n";
 import { BonusPage } from "studio/lib/interfaces/compensations";
@@ -11,17 +13,18 @@ interface YearlyBonusesProps {
 }
 
 const YearlyBonuses = ({ bonuses, locale }: YearlyBonusesProps) => {
+  const t = useTranslations("compensation");
   return (
     <div className={styles.wrapper}>
-      <Text type={"h3"}>Historisk bonus</Text>
+      <Text type={"h3"}>{t("bonus.bonuses")}</Text>
       <table className={styles.table}>
         <thead>
           <tr>
             <th>
-              <Text>År</Text>
+              <Text type="h5">{t("bonus.year")}</Text>
             </th>
             <th className={styles.bonusHeader}>
-              <Text>Beløp</Text>
+              <Text type="h5">{t("bonus.amount")}</Text>
             </th>
           </tr>
         </thead>

--- a/src/components/sections/compensation-calculator/Calculator.tsx
+++ b/src/components/sections/compensation-calculator/Calculator.tsx
@@ -32,7 +32,7 @@ export default function Calculator({
   initialYear,
   background,
 }: CalculatorProps) {
-  const t = useTranslations("compensation_calculator");
+  const t = useTranslations("compensation");
   const locale = use(localeRes);
   const salaries = use(salariesRes);
   const [year, setYear] = useState(


### PR DESCRIPTION
## Summary
- Add missing translations for bonus stuff
- Change wording from "Velg lokasjon" to "Lokasjon", as we we don't use the "Velg"/"Select" prefix in other filters.
- Change wording from "Historisk bonus" to simply "Bonuser"/"Bonuses", as it's obvious from the years in "Year" column that it's for previous years. Aaaand "historisk bonus" makes it sound like it's the greatest bonus in history 😅  I guess we could use "Tidligere bonuser" or "Årlige bonuser" instead? Thoughts?

## Screenshots
### Before
![Screenshot 2024-12-17 at 11 58 37](https://github.com/user-attachments/assets/7228c99b-a848-48a3-ad73-2ed060e66bd1)

### After
![Screenshot 2024-12-17 at 11 58 43](https://github.com/user-attachments/assets/6f5752d2-6560-4ff0-a699-cc86dfeb39fe)
