### PR TITLE
fix: dont load entire images to check if they exist

### DIFF
--- a/src/components/image/SanityImage.tsx
+++ b/src/components/image/SanityImage.tsx
@@ -30,10 +30,14 @@ const useNextSanityGlobalImage = (
 
   useEffect(() => {
     if (studioImage) {
-      fetch(studioImage.src).then((r) => r.ok && setGlobalImage(studioImage));
+      fetch(studioImage.src, {
+        method: "HEAD",
+      }).then((r) => r.ok && setGlobalImage(studioImage));
     }
     if (sharedImage) {
-      fetch(sharedImage.src).then((r) => r.ok && setGlobalImage(sharedImage));
+      fetch(sharedImage.src, {
+        method: "HEAD",
+      }).then((r) => r.ok && setGlobalImage(sharedImage));
     }
   }, [studioImage, sharedImage]);
 


### PR DESCRIPTION
To check for where the image is stored, the client actually fetches the image in addition to actually load it as an image. This check I think is only ment to construct an URL with correct metadata, so this is unnecessary. I don't have time to prioritise for a proper fix and avoid this issue properly, but as a temporary measure we can at least avoid loading 5-6 megs of images just to check if they exists.

Again: We shouldn't have it like this, and we should find a proper way to separate shared studio image vs non-shared. But to avoid downloading lots of lots of data that isn't used, we could at least do some temporary workarounds.

Before:
![image](https://github.com/user-attachments/assets/b4e14f4f-e916-4501-b7a2-638f136a0ea0)

After:
![Screenshot 2024-12-18 at 10 47 57](https://github.com/user-attachments/assets/ae332784-58a5-423c-ba8c-b4782f161626)
