### PR TITLE
V3 make sanity better

### DIFF
--- a/studio/schemas/objects/sections/article.ts
+++ b/studio/schemas/objects/sections/article.ts
@@ -1,3 +1,4 @@
+import { BlockContentIcon } from "@sanity/icons";
 import { StringInputProps, defineField } from "sanity";
 
 import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
@@ -11,6 +12,7 @@ export const article = defineField({
   name: articleID,
   title: "Article",
   type: "object",
+  icon: BlockContentIcon,
   fields: [
     {
       name: "tag",

--- a/studio/schemas/objects/sections/compensation-calculator.ts
+++ b/studio/schemas/objects/sections/compensation-calculator.ts
@@ -1,3 +1,4 @@
+import { ControlsIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { link } from "studio/schemas/objects/link";
@@ -18,6 +19,7 @@ export const compensationCalculator = defineField({
   name: compensationCalculatorId,
   title: "Compensation Calculator",
   type: "object",
+  icon: ControlsIcon,
   fields: [
     {
       name: "moduleTitle",

--- a/studio/schemas/objects/sections/contact-box.ts
+++ b/studio/schemas/objects/sections/contact-box.ts
@@ -1,3 +1,4 @@
+import { BellIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { StringInputWithCharacterCount } from "studio/components/stringInputWithCharacterCount/StringInputWithCharacterCount";
@@ -22,6 +23,7 @@ export const contactBox = defineField({
   name: contactBoxID,
   title: "Contact Box",
   type: "object",
+  icon: BellIcon,
   fields: [
     {
       name: titleID.basic,

--- a/studio/schemas/objects/sections/employeeHighlight.ts
+++ b/studio/schemas/objects/sections/employeeHighlight.ts
@@ -1,3 +1,4 @@
+import { HighlightIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
@@ -10,6 +11,7 @@ export const employeeHighlightSection = defineField({
   name: employeeHighlightID,
   title: "Employee Highlight",
   type: "object",
+  icon: HighlightIcon,
   fields: [
     {
       name: titleID.basic,

--- a/studio/schemas/objects/sections/employees.ts
+++ b/studio/schemas/objects/sections/employees.ts
@@ -1,3 +1,4 @@
+import { UsersIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { titleID } from "studio/schemas/fields/text";
@@ -8,6 +9,7 @@ export const employees = defineField({
   name: employeesID,
   title: "Employees",
   type: "object",
+  icon: UsersIcon,
   fields: [
     {
       name: titleID.basic,

--- a/studio/schemas/objects/sections/generosity.ts
+++ b/studio/schemas/objects/sections/generosity.ts
@@ -1,3 +1,4 @@
+import { HeartIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { titleID } from "studio/schemas/fields/text";
@@ -9,6 +10,7 @@ export const generositySection = defineField({
   name: generosityID,
   title: "Generosity",
   type: "object",
+  icon: HeartIcon,
   fields: [
     {
       name: titleID.basic,

--- a/studio/schemas/objects/sections/hero.ts
+++ b/studio/schemas/objects/sections/hero.ts
@@ -1,3 +1,4 @@
+import { BoltIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { allTranslations } from "studio/utils/i18n";
@@ -8,6 +9,7 @@ export const hero = defineField({
   name: heroID,
   title: "Hero Section",
   type: "object",
+  icon: BoltIcon,
   fields: [
     {
       name: "title",

--- a/studio/schemas/objects/sections/hero.ts
+++ b/studio/schemas/objects/sections/hero.ts
@@ -13,7 +13,7 @@ export const hero = defineField({
   fields: [
     {
       name: "title",
-      title: "title",
+      title: "Title",
       type: "internationalizedArrayString",
       validation: (rule) =>
         rule.custom<{ value: string; _type: string; _key: string }[]>(
@@ -27,7 +27,7 @@ export const hero = defineField({
 
             if (invalidItems.length > 0) {
               return invalidItems.map((item) => ({
-                message: "title cannot be more than 200 characters long.",
+                message: "Title cannot be more than 200 characters long.",
                 path: [{ _key: item._key }, "value"],
               }));
             }

--- a/studio/schemas/objects/sections/image.ts
+++ b/studio/schemas/objects/sections/image.ts
@@ -1,3 +1,4 @@
+import { ImageIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
@@ -10,6 +11,7 @@ export const imageSection = defineField({
   name: imageID,
   title: "Image",
   type: "object",
+  icon: ImageIcon,
   fields: [
     defineField({
       ...internationalizedImage,

--- a/studio/schemas/objects/sections/imagesplit.ts
+++ b/studio/schemas/objects/sections/imagesplit.ts
@@ -26,7 +26,7 @@ export const imageSplitSection = defineField({
               type: "internationalizedArrayString",
               title: "Title",
               description:
-                "Enter the primary title that will be displayed at the top of the employees section.",
+                "Enter the primary title that will be displayed at the top of the section.",
             },
             {
               name: "description",

--- a/studio/schemas/objects/sections/imagesplit.ts
+++ b/studio/schemas/objects/sections/imagesplit.ts
@@ -1,3 +1,4 @@
+import { InlineIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { imageExtended } from "studio/schemas/fields/media";
@@ -11,6 +12,7 @@ export const imageSplitSection = defineField({
   name: imageID,
   title: "Image Split",
   type: "object",
+  icon: InlineIcon,
   fields: [
     {
       name: "content",

--- a/studio/schemas/objects/sections/jobs.ts
+++ b/studio/schemas/objects/sections/jobs.ts
@@ -1,3 +1,4 @@
+import { UlistIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { titleID } from "studio/schemas/fields/text";
@@ -8,6 +9,7 @@ export const jobs = defineField({
   name: jobsID,
   title: "Jobs",
   type: "object",
+  icon: UlistIcon,
   fields: [
     {
       name: titleID.basic,

--- a/studio/schemas/objects/sections/learning.ts
+++ b/studio/schemas/objects/sections/learning.ts
@@ -23,7 +23,7 @@ export const learningSection = defineField({
       name: "image",
       type: "image",
       title: "Image",
-      description: "An image of the learning",
+      description: "An image representing learning in Variant",
       options: {
         hotspot: true,
       },

--- a/studio/schemas/objects/sections/learning.ts
+++ b/studio/schemas/objects/sections/learning.ts
@@ -1,3 +1,4 @@
+import { BulbOutlineIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { titleID } from "studio/schemas/fields/text";
@@ -8,6 +9,7 @@ export const learningSection = defineField({
   name: learningID,
   title: "Learning",
   type: "object",
+  icon: BulbOutlineIcon,
   fields: [
     {
       name: titleID.basic,

--- a/studio/schemas/objects/sections/logoSalad.ts
+++ b/studio/schemas/objects/sections/logoSalad.ts
@@ -1,3 +1,4 @@
+import { ProjectsIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import image from "studio/schemas/fields/media";
@@ -8,6 +9,7 @@ export const logoSalad = defineField({
   name: logoSaladID,
   title: "Logo Salad",
   type: "object",
+  icon: ProjectsIcon,
   fields: [
     {
       name: "title",

--- a/studio/schemas/objects/sections/logoSalad.ts
+++ b/studio/schemas/objects/sections/logoSalad.ts
@@ -20,7 +20,8 @@ export const logoSalad = defineField({
     {
       name: "logos",
       title: "Logos",
-      description: "Add the logos you want to display.",
+      description:
+        "Add the logos you want to display, remember to use the correct size as defined in Figma.",
       type: "array",
       of: [image],
       validation: (rule) =>

--- a/studio/schemas/objects/sections/openness.ts
+++ b/studio/schemas/objects/sections/openness.ts
@@ -1,3 +1,4 @@
+import { SparkleIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { titleID } from "studio/schemas/fields/text";
@@ -7,6 +8,7 @@ export const opennessSection = defineField({
   name: opennessID,
   title: "Openness",
   type: "object",
+  icon: SparkleIcon,
   fields: [
     {
       name: titleID.basic,

--- a/studio/schemas/objects/sections/openness.ts
+++ b/studio/schemas/objects/sections/openness.ts
@@ -22,7 +22,7 @@ export const opennessSection = defineField({
       name: "image",
       type: "image",
       title: "Image",
-      description: "An image of the openness",
+      description: "Add an image to the section",
       options: {
         hotspot: true,
       },


### PR DESCRIPTION
Adds icons to all the sections in sanity studio to make it easier to see which sections are included, and rewrites some descriptions to the sections to clarify what the section does. 

# Before
<img width="255" alt="Screenshot 2024-12-23 at 10 48 56" src="https://github.com/user-attachments/assets/5e57d7bd-5e8b-4e27-bb14-59f9ccf276bd" />
<img width="730" alt="Screenshot 2024-12-23 at 10 49 12" src="https://github.com/user-attachments/assets/6ff407df-288c-45b8-80b3-60c34dbbc4be" />

# After
<img width="255" alt="Screenshot 2024-12-23 at 10 50 39" src="https://github.com/user-attachments/assets/715a66ed-fe99-47f8-9ccd-f0c93ffb019c" />

<img width="745" alt="Screenshot 2024-12-23 at 10 50 24" src="https://github.com/user-attachments/assets/ee4ff36a-5a70-4505-a357-383aa8d0bb86" />
