### PR TITLE
V3 header fixes

### DIFF
--- a/src/components/link/link.module.css
+++ b/src/components/link/link.module.css
@@ -141,6 +141,7 @@
 
 .headerLink {
   white-space: nowrap;
+  width: 100%;
   color: var(--text-primary);
   cursor: pointer;
   text-decoration: none;
@@ -149,7 +150,7 @@
   font-weight: 500;
   display: inline-flex;
   padding: 0.75rem 1rem 0.75rem 0.75rem;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   gap: 0.375rem;
   position: relative;

--- a/src/components/navigation/header/Header.tsx
+++ b/src/components/navigation/header/Header.tsx
@@ -96,7 +96,7 @@ export const Header = ({
           <div className={styles.wrapper}>
             <div className={styles.desktopWrapper}>
               <Link
-                href="/"
+                href={`/${currentLanguage}`}
                 aria-label="Home"
                 className={styles.logo}
                 scroll={false}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -163,7 +163,7 @@ html {
 
 body {
   margin: 0;
-  padding: 0 1rem;
+  padding: 0 1rem !important;
   color: var(--text-primary);
   background-color: var(--background-bg-light-primary);
   font-family: var(--font-britti-sans);


### PR DESCRIPTION
Fixes several issues with the header, especially on mobile/tablet:

- The mobile/tablet header no longer removes the padding in body when opened
- The clickable area on the header links in mobile/tablet is now using 100% of the width making the area larger
- When a user is on the english version of the site, they no longer end up on the norwegian landing page when clicking the logo in the header

## Before
![Screenshot 2025-01-02 at 10 37 23](https://github.com/user-attachments/assets/e46153f5-0b3a-4275-a7e8-16d120d26d47)

## After
![Screenshot 2025-01-02 at 10 37 03](https://github.com/user-attachments/assets/49dacd23-8034-4189-974f-c84b74a832b1)


Closes #1087 