### PR TITLE
feat: remove hover and icon from external link

### DIFF
--- a/src/components/link/link.module.css
+++ b/src/components/link/link.module.css
@@ -62,21 +62,6 @@
   @media (min-width: 1024px) {
     font-size: 1.25rem;
   }
-
-  &:hover {
-    gap: 1rem;
-    font-weight: 400;
-  }
-
-  &::after {
-    content: "";
-    width: 24px;
-    height: 24px;
-    display: inline-block;
-    -webkit-mask-size: cover;
-    background-color: var(--text-primary);
-    -webkit-mask: url("/_assets/arrow-up-right.svg") no-repeat 50% 50%;
-  }
 }
 
 .colorLight .internalLink {

--- a/src/components/link/link.module.css
+++ b/src/components/link/link.module.css
@@ -62,6 +62,16 @@
   @media (min-width: 1024px) {
     font-size: 1.25rem;
   }
+
+  &::after {
+    content: "";
+    width: 24px;
+    height: 24px;
+    display: inline-block;
+    -webkit-mask-size: cover;
+    background-color: var(--text-primary);
+    -webkit-mask: url("/_assets/arrow-up-right.svg") no-repeat 50% 50%;
+  }
 }
 
 .colorLight .internalLink {


### PR DESCRIPTION
## Description
Removed hover effect on custom link external link

## Screenshots
<img width="254" alt="image" src="https://github.com/user-attachments/assets/46bf9c73-8055-4788-839d-2c9269af76b2" />


## Question for reviewer
Should all external links have this styling or just the link on CustomerCase?