### PR TITLE
feat: change logo salad styling to be more compact

### DIFF
--- a/src/components/sections/logoSalad/logoSalad.module.css
+++ b/src/components/sections/logoSalad/logoSalad.module.css
@@ -1,5 +1,7 @@
 .wrapper {
   padding: 5rem 0;
+  max-width: var(--max-content-width-large);
+  margin: 0 auto;
   background-color: var(--background-bg-light-primary);
 }
 

--- a/src/components/sections/logoSalad/logoSalad.module.css
+++ b/src/components/sections/logoSalad/logoSalad.module.css
@@ -1,11 +1,4 @@
-.shared {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
 .wrapper {
-  composes: shared;
   padding: 5rem 0;
   background-color: var(--background-bg-light-primary);
 }
@@ -17,23 +10,34 @@
 .logoWrapper {
   padding: 0;
   margin: 0;
-  list-style: none;
-  align-content: flex-start;
-  max-width: var(--max-content-width-large);
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.5rem 3rem;
+  justify-content: center;
 
-  & > li {
-    max-width: 15rem;
-    max-height: 5rem;
-    overflow: hidden;
-    object-fit: contain;
-    display: inline-block;
-    margin-right: 3rem;
+  &>li {
+    list-style: none;
+
+    & img {
+      height: 4.5rem;
+      width: auto;
+
+      @media (max-width: 834px) {
+        height: 3.625rem;
+      }
+
+      @media (max-width: 425px) {
+        height: 3rem;
+      }
+    }
+  }
+
+  @media (max-width: 834px) {
+    gap: 1rem 2.25rem;
   }
 
   @media (max-width: 425px) {
-    text-wrap: balance;
-    & > li {
-      margin-right: 1rem;
-    }
+    gap: 0.5rem 1.5rem;
   }
 }

--- a/src/components/sections/logoSalad/logoSalad.module.css
+++ b/src/components/sections/logoSalad/logoSalad.module.css
@@ -18,7 +18,7 @@
   gap: 1.5rem 3rem;
   justify-content: center;
 
-  &>li {
+  & > li {
     list-style: none;
 
     & img {


### PR DESCRIPTION
## Description
- Flexbox on logo salad for gap spacing on different screen width
- Set the height of the image on different screen sizes
- Center logos as in the design sketches.

## Screenshots

### Mobile
#### Before
<img width="633" alt="image" src="https://github.com/user-attachments/assets/24bbe840-814b-4779-b0f6-f7c53b413576" />

#### After
<img width="635" alt="image" src="https://github.com/user-attachments/assets/c2c5cf82-5eae-49ec-90e1-3308af8a47d8" />

### Tablet
#### Before
<img width="974" alt="image" src="https://github.com/user-attachments/assets/2266b453-9437-4560-9fd2-927bd0c1d2ef" />

#### After
<img width="977" alt="image" src="https://github.com/user-attachments/assets/7389f9d2-abab-45ba-9b7f-add10fc88b66" />

### Desktop
#### Before
<img width="970" alt="image" src="https://github.com/user-attachments/assets/d4e8bfb8-90be-4443-9b54-3b118cfe75c8" />

#### After
<img width="985" alt="image" src="https://github.com/user-attachments/assets/9a60894d-0be2-49c4-b756-8443b6af0094" />



