### PR TITLE
hover and focus styles for job postings

### DIFF
--- a/src/components/jobPosting/jobPosting.module.css
+++ b/src/components/jobPosting/jobPosting.module.css
@@ -10,6 +10,17 @@
   width: 100%;
   background-color: var(--text-primary-light);
   color: var(--text-primary);
+  transition: all 0.3s ease;
+
+  &:hover {
+    background-color: var(--Background-secondary, #eaeaea);
+    border-radius: 0.375rem;
+  }
+
+  &:focus {
+    outline: 2px solid var(--surface-yellow, #ffd02f);
+    transition: none;
+  }
 
   &::after {
     width: 1.5rem;


### PR DESCRIPTION
Added styling to job postings. 

hover
<img width="1082" alt="Screenshot 2025-01-08 at 12 35 20" src="https://github.com/user-attachments/assets/b70cc658-132d-42ff-9a9f-8bdda1c35b09" />

focus
<img width="1096" alt="Screenshot 2025-01-08 at 12 35 33" src="https://github.com/user-attachments/assets/88cc53e6-f574-4db6-8b2a-37924836977a" />
