### PR TITLE
fix: Respect new tab option on LinkButton

### DIFF
--- a/src/components/link/CustomLink.tsx
+++ b/src/components/link/CustomLink.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import React from "react";
 
-import { getHref } from "src/utils/link";
+import { getLinkAttributes } from "src/utils/link";
 import { ILink } from "studio/lib/interfaces/navigation";
 
 import styles from "./link.module.css";
@@ -30,10 +30,7 @@ const CustomLink = ({
   color = "dark",
   scroll,
 }: ICustomLink) => {
-  const href = getHref(link);
-  const newTab = link.newTab;
-  const target = newTab ? "_blank" : undefined;
-  const rel = newTab ? "noopener noreferrer" : undefined;
+  const attributes = getLinkAttributes(link);
 
   switch (type) {
     case "link":
@@ -47,14 +44,12 @@ const CustomLink = ({
             }
           >
             <Link
+              {...attributes}
               className={
                 link.linkType == "internal"
                   ? styles.internalLink
                   : styles.externalLink
               }
-              href={href}
-              target={target}
-              rel={rel}
               aria-label={link.ariaLabel}
               scroll={scroll}
             >
@@ -67,10 +62,8 @@ const CustomLink = ({
       return (
         link.linkTitle && (
           <Link
+            {...attributes}
             className={`${styles.headerLink} ${isSelected ? styles.selected : ""}`}
-            href={href}
-            target={target}
-            rel={rel}
             aria-label={link.ariaLabel}
             scroll={scroll}
           >
@@ -83,10 +76,8 @@ const CustomLink = ({
       return (
         link.linkTitle && (
           <Link
+            {...attributes}
             className={styles.footerLink}
-            href={href}
-            target={target}
-            rel={rel}
             aria-label={link.ariaLabel}
             scroll={scroll}
           >
@@ -98,10 +89,8 @@ const CustomLink = ({
       return (
         link.linkTitle && (
           <Link
+            {...attributes}
             className={styles.footerLinkGrey}
-            href={href}
-            target={target}
-            rel={rel}
             aria-label={link.ariaLabel}
             scroll={scroll}
           >

--- a/src/components/link/CustomLink.tsx
+++ b/src/components/link/CustomLink.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import React from "react";
 
 import { getLinkAttributes } from "src/utils/link";
-import { ILink } from "studio/lib/interfaces/navigation";
+import { ILink, LinkType } from "studio/lib/interfaces/navigation";
 
 import styles from "./link.module.css";
 
@@ -30,74 +30,55 @@ const CustomLink = ({
   color = "dark",
   scroll,
 }: ICustomLink) => {
+  const className = getLinkClassName(type, link.linkType, isSelected);
   const attributes = getLinkAttributes(link);
 
-  switch (type) {
+  return (
+    link.linkTitle &&
+    (type === "link" ? (
+      <div
+        className={
+          styles.wrapper +
+          (size === "small" ? ` ${styles.sizeSmall}` : "") +
+          (color === "light" ? ` ${styles.colorLight}` : "")
+        }
+      >
+        <Link
+          {...attributes}
+          className={className}
+          aria-label={link.ariaLabel}
+          scroll={scroll}
+        >
+          {link.linkTitle}
+        </Link>
+      </div>
+    ) : (
+      <Link
+        {...attributes}
+        className={className}
+        aria-label={link.ariaLabel}
+        scroll={scroll}
+      >
+        {link.linkTitle}
+      </Link>
+    ))
+  );
+};
+
+const getLinkClassName = (
+  componentType: ComponentLinkType,
+  linkType: LinkType,
+  isSelected: boolean | undefined,
+) => {
+  switch (componentType) {
     case "link":
-      return (
-        link.linkTitle && (
-          <div
-            className={
-              styles.wrapper +
-              (size === "small" ? ` ${styles.sizeSmall}` : "") +
-              (color === "light" ? ` ${styles.colorLight}` : "")
-            }
-          >
-            <Link
-              {...attributes}
-              className={
-                link.linkType == "internal"
-                  ? styles.internalLink
-                  : styles.externalLink
-              }
-              aria-label={link.ariaLabel}
-              scroll={scroll}
-            >
-              <span className={styles.span}>{link.linkTitle}</span>
-            </Link>
-          </div>
-        )
-      );
+      return linkType == "internal" ? styles.internalLink : styles.externalLink;
     case "headerLink":
-      return (
-        link.linkTitle && (
-          <Link
-            {...attributes}
-            className={`${styles.headerLink} ${isSelected ? styles.selected : ""}`}
-            aria-label={link.ariaLabel}
-            scroll={scroll}
-          >
-            <span className={styles.dot}></span>
-            {link.linkTitle}
-          </Link>
-        )
-      );
+      return `${styles.headerLink} ${isSelected ? styles.selected : ""}`;
     case "footerLink":
-      return (
-        link.linkTitle && (
-          <Link
-            {...attributes}
-            className={styles.footerLink}
-            aria-label={link.ariaLabel}
-            scroll={scroll}
-          >
-            {link.linkTitle}
-          </Link>
-        )
-      );
+      return styles.footerLink;
     case "footerLinkGrey":
-      return (
-        link.linkTitle && (
-          <Link
-            {...attributes}
-            className={styles.footerLinkGrey}
-            aria-label={link.ariaLabel}
-            scroll={scroll}
-          >
-            {link.linkTitle}
-          </Link>
-        )
-      );
+      return styles.footerLinkGrey;
   }
 };
 

--- a/src/components/linkButton/LinkButton.tsx
+++ b/src/components/linkButton/LinkButton.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 import { cn } from "src/utils/css";
-import { getHref } from "src/utils/link";
+import { getLinkAttributes } from "src/utils/link";
 import { ILink } from "studio/lib/interfaces/navigation";
 
 import styles from "./linkButton.module.css";
@@ -37,12 +37,12 @@ const LinkButton = ({
     modifierWithIcon,
   );
 
-  const { href, linkTitle } = getLinkData(props);
+  const { href, linkTitle, target, rel } = getLinkData(props);
 
   return (
     href &&
     linkTitle && (
-      <Link className={className} href={href}>
+      <Link className={className} href={href} target={target} rel={rel}>
         {linkTitle}
       </Link>
     )
@@ -53,7 +53,13 @@ function getLinkData(link: LinkType) {
   if (isLinkTypeString(link)) {
     return { href: link.link, linkTitle: link.linkTitle };
   }
-  return { href: getHref(link.link), linkTitle: link.link.linkTitle };
+
+  const attributes = getLinkAttributes(link.link);
+
+  return {
+    linkTitle: link.link.linkTitle,
+    ...attributes,
+  };
 }
 
 function isLinkTypeString(

--- a/src/utils/link.ts
+++ b/src/utils/link.ts
@@ -17,3 +17,17 @@ export const getHref = (link: ILink): string => {
       return `tel:${link.phone}`;
   }
 };
+
+export function getLinkAttributes(link: ILink): LinkAttributes {
+  const newTab = link.newTab;
+  const target = newTab ? "_blank" : undefined;
+  const rel = newTab ? "noopener noreferrer" : undefined;
+  const href = getHref(link);
+  return { href, target, rel };
+}
+
+type LinkAttributes = {
+  href: string;
+  target?: string;
+  rel?: string;
+};


### PR DESCRIPTION
Oppdaget at `ImageSplit`-komponenten som bruker `LinkButton` ikke respekterte "Should this link open in a new tab". Til forskjell fra `Article` f. eks. som bruker `CustomLink` i stedet.

Prøvde å gjøre det likt på tvers slik at begge deler setter `target` og `rel` avhengig av valg her:

![image](https://github.com/user-attachments/assets/8fbb16a0-96ca-4184-a1ea-bfc2046ebec1)

Skrev om `CustomLink` også da det virket som de typer link var mye likt, bare ulike `className`.