### PR TITLE
Article sections

### DIFF
--- a/src/components/sections/article/Article.tsx
+++ b/src/components/sections/article/Article.tsx
@@ -2,12 +2,12 @@ import { SanityImage } from "src/components/image/SanityImage";
 import CustomLink from "src/components/link/CustomLink";
 import { RichText } from "src/components/richText/RichText";
 import Text from "src/components/text/Text";
-import { ArticleSection } from "studio/lib/interfaces/pages";
+import { IArticle } from "studio/lib/interfaces/pages";
 
 import styles from "./article.module.css";
 
 interface ArticleProps {
-  article: ArticleSection;
+  article: IArticle;
 }
 
 export default function Article({ article }: ArticleProps) {

--- a/src/components/sections/article/ArticlePreview.tsx
+++ b/src/components/sections/article/ArticlePreview.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@sanity/react-loader";
 import { Suspense } from "react";
 
 import { PreviewProps } from "src/types/preview";
-import { ArticleSection, PageBuilder } from "studio/lib/interfaces/pages";
+import { IArticle, PageBuilder } from "studio/lib/interfaces/pages";
 import { PAGE_QUERY } from "studio/lib/queries/pages";
 
 import Article from "./Article";
@@ -21,7 +21,7 @@ export default function ArticlePreview({
 
   const articleSection = data.sections.find(
     (section, index) => section._type === "article" && index === sectionIndex,
-  ) as ArticleSection;
+  ) as IArticle;
 
   return (
     <Suspense>

--- a/src/components/sections/articleSection/ArticleSection.tsx
+++ b/src/components/sections/articleSection/ArticleSection.tsx
@@ -44,7 +44,10 @@ const renderArticleParagraph = ({
 }: IParagraphArticleSection) => (
   <div className={styles.container}>
     <div className={styles.paragraphWrapper}>
-      <Text type="h4" as="h2"> {title} </Text>
+      <Text type="h4" as="h2">
+        {" "}
+        {title}{" "}
+      </Text>
       <Text type="bodySmall">{textContent}</Text>
     </div>
   </div>

--- a/src/components/sections/articleSection/ArticleSection.tsx
+++ b/src/components/sections/articleSection/ArticleSection.tsx
@@ -1,0 +1,60 @@
+import Text from "src/components/text/Text";
+import {
+  IArticleSection,
+  IParagraphArticleSection,
+  IQuoteArticleSection,
+  ITitleArticleSection,
+} from "studio/lib/interfaces/pages";
+
+import styles from "./articleSection.module.css";
+
+interface articleSectionProps {
+  section: IArticleSection;
+}
+
+export default function ArticleSection({ section }: articleSectionProps) {
+  switch (section.articleSectionType) {
+    case "title":
+      return section.articleTitle
+        ? renderArticleTitle(section.articleTitle)
+        : null;
+    case "paragraph":
+      return section.articleParagraph
+        ? renderArticleParagraph(section.articleParagraph)
+        : null;
+    case "quote":
+      return section.articleQuote
+        ? renderArticleQuote(section.articleQuote)
+        : null;
+    default:
+      return null;
+  }
+}
+
+const renderArticleTitle = ({ eyebrow, title }: ITitleArticleSection) => (
+  <div className={styles.container}>
+    <Text type="labelRegular"> {eyebrow}</Text>
+    <Text type="h1">{title}</Text>
+  </div>
+);
+
+const renderArticleParagraph = ({
+  title,
+  textContent,
+}: IParagraphArticleSection) => (
+  <div className={styles.container}>
+    <div className={styles.paragraphWrapper}>
+      <Text type="h4"> {title} </Text>
+      <Text type="bodySmall">{textContent}</Text>
+    </div>
+  </div>
+);
+
+const renderArticleQuote = ({ author, quote }: IQuoteArticleSection) => (
+  <div className={styles.container}>
+    <Text className={styles.authorText} type="labelRegular">
+      {author}
+    </Text>
+    <Text type="bodyXl">{quote}</Text>
+  </div>
+);

--- a/src/components/sections/articleSection/ArticleSection.tsx
+++ b/src/components/sections/articleSection/ArticleSection.tsx
@@ -44,7 +44,7 @@ const renderArticleParagraph = ({
 }: IParagraphArticleSection) => (
   <div className={styles.container}>
     <div className={styles.paragraphWrapper}>
-      <Text type="h4"> {title} </Text>
+      <Text type="h4" as="h2"> {title} </Text>
       <Text type="bodySmall">{textContent}</Text>
     </div>
   </div>

--- a/src/components/sections/articleSection/articleSection.module.css
+++ b/src/components/sections/articleSection/articleSection.module.css
@@ -1,0 +1,30 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: var(--container-padding);
+  max-width: var(--max-content-width-medium);
+  justify-self: center;
+  width: 100%;
+  margin: 8rem auto;
+
+  @media (max-width: 1091px) {
+    margin: 6rem auto;
+  }
+
+  @media (max-width: 425px) {
+    margin: 4rem auto;
+  }
+}
+
+.paragraphWrapper {
+  max-width: 40.5rem;
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
+  align-self: center;
+}
+
+.authorText {
+  color: var(--text-placeholder);
+}

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -2,6 +2,7 @@ import { QueryResponseInitial } from "@sanity/react-loader";
 
 import Article from "src/components/sections/article/Article";
 import ArticlePreview from "src/components/sections/article/ArticlePreview";
+import ArticleSection from "src/components/sections/articleSection/ArticleSection";
 import CompensationCalculator from "src/components/sections/compensation-calculator/CompensationCalculator";
 import ContactBox from "src/components/sections/contact-box/ContactBox";
 import CustomerCasesEntry from "src/components/sections/customerCasesEntry/CustomerCasesEntry";
@@ -23,10 +24,10 @@ import LogoSaladPreview from "src/components/sections/logoSalad/LogoSaladPreview
 import Openness from "src/components/sections/openness/Openness";
 import { Locale } from "src/i18n/routing";
 import {
-  ArticleSection,
   CustomerCasesEntrySection,
   GridSection,
   HeroSection,
+  IArticle,
   ImageSection,
   ImageSplitSection,
   LogoSaladSection,
@@ -74,8 +75,8 @@ const renderLogoSaladSection = (
   );
 };
 
-const renderArticleSection = (
-  section: ArticleSection,
+const renderArticle = (
+  section: IArticle,
   sectionIndex: number,
   isDraftMode: boolean,
   initialData: QueryResponseInitial<PageBuilder>,
@@ -175,12 +176,7 @@ const SectionRenderer = ({
         initialData,
       );
     case "article":
-      return renderArticleSection(
-        section,
-        sectionIndex,
-        isDraftMode,
-        initialData,
-      );
+      return renderArticle(section, sectionIndex, isDraftMode, initialData);
     case "imageSection":
       return renderImageSection(
         section,
@@ -223,6 +219,8 @@ const SectionRenderer = ({
       return <Generosity section={section} language={language} />;
     case "learningSection":
       return <Learning section={section} />;
+    case "articleSection":
+      return <ArticleSection section={section} />;
     default:
       return null;
   }

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -21,7 +21,7 @@ export interface LogoSaladSection {
   supporting: string;
 }
 
-export interface ArticleSection {
+export interface IArticle {
   _type: "article";
   _key: string;
   tag?: string;
@@ -29,6 +29,30 @@ export interface ArticleSection {
   richText?: PortableTextBlock[];
   link?: ILink;
   imageExtended: ImageExtendedProps;
+}
+
+export interface IArticleSection {
+  _type: "articleSection";
+  _key: string;
+  articleSectionType: "title" | "paragraph" | "quote";
+  articleTitle?: ITitleArticleSection;
+  articleParagraph?: IParagraphArticleSection;
+  articleQuote?: IQuoteArticleSection;
+}
+
+export interface ITitleArticleSection {
+  eyebrow?: string;
+  title?: string;
+}
+
+export interface IParagraphArticleSection {
+  title?: string;
+  textContent?: string;
+}
+
+export interface IQuoteArticleSection {
+  author?: string;
+  quote?: string;
 }
 
 export interface ImageSection {
@@ -64,6 +88,7 @@ export interface GridSection {
     image: IImage;
   }[];
 }
+
 export interface ContactBoxSection {
   _type: "contactBox";
   _key: string;
@@ -167,7 +192,8 @@ export interface LearningSection {
 export type Section =
   | HeroSection
   | LogoSaladSection
-  | ArticleSection
+  | IArticle
+  | IArticleSection
   | ImageSection
   | ImageSplitSection
   | GridSection

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -116,6 +116,26 @@ const SECTIONS_FRAGMENT = groq`
       "articleTag": ${translatedFieldFragment("articleTag")},
       "articleTitle": ${translatedFieldFragment("articleTitle")},
       "articleSubtitle": ${translatedFieldFragment("articleSubtitle")},
+    },
+     _type == "articleSection" => {
+     ..., 
+      "articleSectionType": articleSectionType,
+      
+        "articleTitle": articleTitle {
+          ..., 
+          "title": ${translatedFieldFragment("title")},
+          "eyebrow": ${translatedFieldFragment("eyebrow")},
+        },
+        "articleParagraph": articleParagraph {
+          ..., 
+          "title": ${translatedFieldFragment("title")},
+          "textContent": ${translatedFieldFragment("textContent")},
+        },
+        "articleQuote": articleQuote {
+          ..., 
+          "author": ${translatedFieldFragment("author")},
+          "quote": ${translatedFieldFragment("quote")},
+        } 
     }
   }
 `;

--- a/studio/schemas/documents/pageBuilder.ts
+++ b/studio/schemas/documents/pageBuilder.ts
@@ -3,6 +3,7 @@ import { defineField, defineType } from "sanity";
 import { isInternationalizedString } from "studio/lib/interfaces/global";
 import { titleID } from "studio/schemas/fields/text";
 import article from "studio/schemas/objects/sections/article";
+import { articleSection } from "studio/schemas/objects/sections/articleSection";
 import { compensationCalculator } from "studio/schemas/objects/sections/compensation-calculator";
 import contactBox from "studio/schemas/objects/sections/contact-box";
 import { customerCasesEntry } from "studio/schemas/objects/sections/customerCasesEntry";
@@ -60,6 +61,7 @@ const pageBuilder = defineType({
         opennessSection,
         generositySection,
         learningSection,
+        articleSection,
       ],
     }),
     defineField({

--- a/studio/schemas/objects/sections/articleSection.ts
+++ b/studio/schemas/objects/sections/articleSection.ts
@@ -1,0 +1,137 @@
+import { EditIcon } from "@sanity/icons";
+import { defineField } from "sanity";
+
+import { allTranslations } from "studio/utils/i18n";
+
+const articleSectionID = "articleSection";
+
+interface Parent {
+  textTitle: string;
+  articleSectionType?: string;
+}
+
+export const articleSection = defineField({
+  name: articleSectionID,
+  title: "Article Section",
+  type: "object",
+  icon: EditIcon,
+  fields: [
+    {
+      name: "articleSectionType",
+      title: "Article Section Type",
+      description:
+        "Please select the type of article section you want to add. The fields below will vary depending on the selected type.",
+      type: "string",
+      options: {
+        list: [
+          { title: "Title", value: "title" },
+          { title: "Paragraph", value: "paragraph" },
+          { title: "Quote", value: "quote" },
+        ],
+        layout: "radio",
+      },
+      initialValue: "title",
+      validation: (rule) =>
+        rule.custom((value, context) => {
+          const parent = context.parent as Parent;
+          if (parent?.textTitle && !value) {
+            return "Article section type is required";
+          }
+          return true;
+        }),
+    },
+    {
+      name: "articleTitle",
+      title: "Title Article Section",
+      type: "object",
+      description:
+        "This section will display a title and, if provided, an eyebrow text above.",
+      fields: [
+        {
+          name: "eyebrow",
+          title: "Eyebrow",
+          type: "internationalizedArrayString",
+        },
+        {
+          name: "title",
+          title: "Title",
+          type: "internationalizedArrayString",
+        },
+      ],
+      hidden: ({ parent }: { parent: Parent }) =>
+        parent?.articleSectionType !== "title",
+    },
+    {
+      name: "articleParagraph",
+      title: "Paragraph Article Section",
+      description: "This section will display as a text block.",
+      type: "object",
+      fields: [
+        {
+          name: "title",
+          title: "Title",
+          type: "internationalizedArrayString",
+        },
+        {
+          name: "textContent",
+          title: "Text Content",
+          type: "internationalizedArrayText",
+        },
+      ],
+      hidden: ({ parent }: { parent: Parent }) =>
+        parent?.articleSectionType !== "paragraph",
+    },
+    {
+      name: "articleQuote",
+      title: "Quote Article Section",
+      description: "This section will display as a quote with author above.",
+      type: "object",
+      fields: [
+        {
+          name: "author",
+          title: "Author",
+          type: "internationalizedArrayString",
+        },
+        {
+          name: "quote",
+          title: "Quote",
+          type: "internationalizedArrayString",
+        },
+      ],
+      hidden: ({ parent }: { parent: Parent }) =>
+        parent?.articleSectionType !== "quote",
+    },
+  ],
+  preview: {
+    select: {
+      title: "articleTitle.titleText",
+      paragraph: "articleParagraph.title",
+      quote: "articleQuote.quote",
+      articleSectionType: "articleSectionType",
+    },
+    prepare(selection) {
+      const { title, paragraph, quote, articleSectionType } = selection;
+      if (articleSectionType === "title") {
+        return {
+          title: allTranslations(title) || undefined,
+          subtitle: "Article section type: " + articleSectionType,
+        };
+      }
+      if (articleSectionType === "paragraph") {
+        return {
+          title: allTranslations(paragraph) || undefined,
+          subtitle: "Article section type: " + articleSectionType,
+        };
+      }
+      if (articleSectionType === "quote") {
+        return {
+          title: allTranslations(quote) || undefined,
+          subtitle: "Article section type: " + articleSectionType,
+        };
+      }
+      return {
+        title: "Article section type: " + articleSectionType,
+      };
+    },
+  },
+});


### PR DESCRIPTION
Added different article section types to easier add text content to pages. 

**Structure in Sanity** 
<img width="795" alt="Screenshot 2025-01-23 at 09 05 57" src="https://github.com/user-attachments/assets/cb1ad01b-e028-4fb0-a1b1-091375f42fcc" />
<img width="732" alt="Screenshot 2025-01-23 at 09 06 08" src="https://github.com/user-attachments/assets/53a8a039-2740-4558-a987-365247166d02" />
<img width="726" alt="Screenshot 2025-01-23 at 09 06 20" src="https://github.com/user-attachments/assets/c5744535-2343-48d2-98f9-4e02ccdc0519" />


**How article sections will look like**
<img width="1025" alt="Screenshot 2025-01-23 at 09 18 00" src="https://github.com/user-attachments/assets/b38d12e7-2e52-4374-b411-ebb245f2b709" />
<img width="1057" alt="Screenshot 2025-01-23 at 09 18 13" src="https://github.com/user-attachments/assets/bc7d3f43-f7e5-4978-8264-2fdec1791b1b" />
<img width="693" alt="Screenshot 2025-01-23 at 09 18 22" src="https://github.com/user-attachments/assets/549917c9-a07d-4174-b855-16127b7f92ee" />

