### PR TITLE
Hero banner bug fix

### DIFF
--- a/src/app/(main)/[locale]/[...path]/page.tsx
+++ b/src/app/(main)/[locale]/[...path]/page.tsx
@@ -103,7 +103,7 @@ async function Page({ params }: Props) {
                       section={section}
                       isDraftMode={isDraftMode}
                       initialData={queryResponse}
-                      isLandingPage={false}
+                      isLandingPage={true}
                       sectionIndex={index}
                     />
                   ))}

--- a/src/app/(main)/[locale]/[...path]/page.tsx
+++ b/src/app/(main)/[locale]/[...path]/page.tsx
@@ -103,7 +103,7 @@ async function Page({ params }: Props) {
                       section={section}
                       isDraftMode={isDraftMode}
                       initialData={queryResponse}
-                      isLandingPage={true}
+                      isLandingPage={false}
                       sectionIndex={index}
                     />
                   ))}

--- a/src/components/sections/hero/Hero.tsx
+++ b/src/components/sections/hero/Hero.tsx
@@ -17,16 +17,24 @@ export const Hero = ({ hero, isLanding = false }: HeroProps) => {
     <div className={styles.wrapper}>
       {isLanding ? (
         <div className={styles.secondary}>
-          <Text type="bodyBig"> {hero.title}</Text>
-          <Text type="h1">{hero.description}</Text>
-          <div className={styles.image}>
-            <SanityImage image={hero.image} />
-          </div>
+          {hero.title && <Text type="bodyBig">{hero.title}</Text>}
+          {hero.description && <Text type="h1">{hero.description}</Text>}
+          {hero.image && (
+            <div className={styles.image}>
+              <SanityImage image={hero.image} />
+            </div>
+          )}
         </div>
       ) : (
-        // If splashy segments are added to the hero section in the landing page, this serves as a great fallback option.
-        <div className={styles.primary}>
-          <Text type="h1">{hero.description}</Text>
+        // This section is prepared for a custom hero section for pages that are not landing pages.
+        <div className={styles.secondary}>
+          {hero.title && <Text type="bodyBig">{hero.title}</Text>}
+          {hero.description && <Text type="h1">{hero.description}</Text>}
+          {hero.image && (
+            <div className={styles.image}>
+              <SanityImage image={hero.image} />
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Changed page to be a landing page to make the hero banner act like it's supposed to do on landing pages.

Is there a reason the page was set to not be a landing page? In that case I need to find another solution.

The hero banner is written to only output a title if it's placed outside of a landing page. When we already have the Text Component section, do we need this logic? 