### PR TITLE
hides the footer section title if there are no children links

### DIFF
--- a/src/components/navigation/footer/Footer.tsx
+++ b/src/components/navigation/footer/Footer.tsx
@@ -95,7 +95,9 @@ const Footer = ({
                   {renderPageLinks(navigationData)}
                 </FooterSection>
               )}
-              {navigationData.footer && (
+              {navigationData.footer?.some(
+                (section) => section.linksAndContent,
+              ) && (
                 <FooterSection title={t("other")}>
                   {renderOtherLinks(navigationData)}
                 </FooterSection>


### PR DESCRIPTION
Previously, the title of the footer section was shown even though there links in the section. Now the title will be hidden