### PR TITLE
New way to add events to event section

### DIFF
--- a/src/components/eventPosting/EventPosting.tsx
+++ b/src/components/eventPosting/EventPosting.tsx
@@ -1,12 +1,11 @@
 import Badge from "src/components/badge/Badge";
 import Text from "src/components/text/Text";
-import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
 import { IEventPosting } from "studio/lib/interfaces/eventPosting";
 
 import styles from "./eventPosting.module.css";
 
 function sortAlphabetically(list: string[]) {
-  return list.sort((a, b) => a.localeCompare(b ?? "") ?? 0);
+  return list.filter(Boolean).sort((a, b) => a.localeCompare(b));
 }
 
 interface EventPostingProps {
@@ -19,18 +18,12 @@ export default function EventPosting({
   showLocations = true,
 }: EventPostingProps) {
   const eventPostingLocations = sortAlphabetically(
-    eventPosting.locations.map(
-      (location: CompanyLocation) => location.companyLocationName,
-    ),
+    eventPosting.locations ?? [],
   ).join(", ");
 
-  let consultantsFirstNames;
-
-  if (eventPosting.consultants) {
-    consultantsFirstNames = eventPosting.consultants.map(
-      (n) => n.employeeFirstName,
-    );
-  }
+  const consultantsFirstNames = eventPosting.consultants?.map(
+    (n) => n.employeeFirstName,
+  );
 
   const Wrapper = eventPosting.externalLink ? "a" : "div";
 
@@ -45,49 +38,48 @@ export default function EventPosting({
     >
       <div className={styles.flex}>
         {eventPosting.date && (
-          <Text type={"labelRegular"}>{eventPosting.date}</Text>
+          <Text type="labelRegular">{eventPosting.date}</Text>
         )}
         {eventPosting.date && showLocations && <span> · </span>}
         {showLocations && (
-          <Text type={"labelRegular"}>{eventPostingLocations}</Text>
+          <Text type="labelRegular">{eventPostingLocations}</Text>
         )}
       </div>
-      <Text type={"h3"} className={styles.eventTitle}>
+
+      <Text type="h3" className={styles.eventTitle}>
         {eventPosting.eventTitle}
       </Text>
+      <Text type="bodySmall">{eventPosting.eventDescription}</Text>
 
-      <Text type={"bodySmall"}>{eventPosting.eventDescription}</Text>
       <div className={`${styles.flex} ${styles.eventCardBottomfield}`}>
         <div>
-          {eventPosting.tags &&
-            eventPosting.tags
-              .filter((tag) => tag)
-              .map((tag, index) => (
-                <Badge
-                  key={index}
-                  className={styles.themes}
-                  badgeColor={"#FAFAFA"}
-                  borderColor={"#2D2D2D"}
-                >
-                  {tag.trim()}
-                </Badge>
-              ))}
+          {eventPosting.tags?.filter(Boolean).map((tag, index) => (
+            <Badge
+              key={index}
+              className={styles.themes}
+              badgeColor="#FAFAFA"
+              borderColor="#2D2D2D"
+            >
+              {tag.trim()}
+            </Badge>
+          ))}
         </div>
-        {consultantsFirstNames && (
+
+        {consultantsFirstNames?.length > 0 && (
           <div className={`${styles.flex} ${styles.consultants}`}>
-            <Text type={"labelRegular"}>
+            <Text type="labelRegular">
               <span>【 </span>
             </Text>
             {consultantsFirstNames.map((name) => (
               <Text
                 key={name}
                 className={styles.dotSeperator}
-                type={"labelRegular"}
+                type="labelRegular"
               >
                 {name}
               </Text>
             ))}
-            <Text type={"labelRegular"}>
+            <Text type="labelRegular">
               <span> 】</span>
             </Text>
           </div>

--- a/src/components/officeSelector/OfficeSelector.tsx
+++ b/src/components/officeSelector/OfficeSelector.tsx
@@ -3,48 +3,28 @@ import { useState } from "react";
 
 import { Tag } from "src/components/tag";
 import Text from "src/components/text/Text";
-import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
 
 import styles from "./officeSelector.module.css";
 
 interface OfficeSelectorProps {
-  companyLocations: CompanyLocation[];
+  locations: string[];
   eventPostingsCount: number;
   eventPostingsPerLocation: Record<string, number>;
-  hiddenLocations?: Set<string>;
-  onFilterChange: (location: CompanyLocation | null) => void;
+  onFilterChange: (location: string | null) => void;
 }
 
-const defaultHiddenLocations = new Set([
-  "Norge",
-  "Norway",
-  "Sverige",
-  "Sweden",
-]);
-
-function sortAlphabetically(locations: CompanyLocation[]) {
-  return locations.sort(
-    (a, b) =>
-      a?.companyLocationName.localeCompare(b.companyLocationName ?? "") ?? 0,
-  );
+function sortAlphabetically(locations: string[]) {
+  return locations.sort((a, b) => a.localeCompare(b));
 }
 
 export default function OfficeSelector({
-  companyLocations,
+  locations,
   eventPostingsCount,
   eventPostingsPerLocation,
-  hiddenLocations = defaultHiddenLocations,
   onFilterChange,
 }: OfficeSelectorProps) {
-  const [locationFilter, setLocationFilter] = useState<CompanyLocation | null>(
-    null,
-  );
-
-  const filteredLocations = companyLocations.filter(
-    (location) => !hiddenLocations.has(location.companyLocationName),
-  );
-
-  const handleFilterChange = (location: CompanyLocation | null) => {
+  const [locationFilter, setLocationFilter] = useState<string | null>(null);
+  const handleFilterChange = (location: string | null) => {
     setLocationFilter(location);
     onFilterChange(location);
   };
@@ -61,15 +41,15 @@ export default function OfficeSelector({
         text={`${t("all")} (${eventPostingsCount})`}
         background="dark"
       />
-      {sortAlphabetically(filteredLocations).map(
+      {sortAlphabetically(locations).map(
         (location) =>
-          eventPostingsPerLocation[location.companyLocationName] > 0 && (
+          eventPostingsPerLocation[location] > 0 && (
             <Tag
-              key={location._id}
+              key={location}
               active={locationFilter === location}
               type="button"
               onClick={() => handleFilterChange(location)}
-              text={`${location.companyLocationName} (${eventPostingsPerLocation[location.companyLocationName] || 0})`}
+              text={`${location} (${eventPostingsPerLocation[location] || 0})`}
               background="dark"
             />
           ),

--- a/src/components/sections/events/EventPostingList.tsx
+++ b/src/components/sections/events/EventPostingList.tsx
@@ -3,21 +3,18 @@
 import { useEffect, useMemo, useState } from "react";
 
 import EventPosting from "src/components/eventPosting/EventPosting";
-import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
 import { IEventPosting } from "studio/lib/interfaces/eventPosting";
 
 import styles from "./events.module.css";
 
 interface EventPostingListProps {
   eventPostings: IEventPosting[];
-  companyLocations: CompanyLocation[];
 }
 
 export default function EventPostingList({
   eventPostings,
-  companyLocations,
 }: EventPostingListProps) {
-  const [locationFilter] = useState<CompanyLocation | null>(null);
+  const [locationFilter] = useState<string | null>(null);
   const [filteredEventPostings, setFilteredEventPostings] =
     useState<IEventPosting[]>(eventPostings);
 
@@ -26,20 +23,21 @@ export default function EventPostingList({
       Object.fromEntries(
         eventPostings.map((eventPosting) => [
           eventPosting._key,
-          eventPosting.locations.map(
-            (location) => location.companyLocationName,
-          ),
+          eventPosting.locations ?? [],
         ]),
       ),
     [eventPostings],
   );
 
   const eventPostingsPerLocation = Object.fromEntries(
-    companyLocations.map((location) => [location.companyLocationName, 0]),
+    eventPostings.flatMap((eventPosting) =>
+      eventPosting.locations.map((location) => [location, 0]),
+    ),
   );
+
   for (const eventPosting of eventPostings) {
     for (const location of eventPosting.locations) {
-      eventPostingsPerLocation[location.companyLocationName]++;
+      eventPostingsPerLocation[location]++;
     }
   }
 
@@ -48,10 +46,8 @@ export default function EventPostingList({
       setFilteredEventPostings(eventPostings);
     } else {
       setFilteredEventPostings(
-        eventPostings?.filter((eventPosting) =>
-          eventPostingLocations[eventPosting._key].includes(
-            locationFilter.companyLocationName,
-          ),
+        eventPostings.filter((eventPosting) =>
+          eventPostingLocations[eventPosting._key].includes(locationFilter),
         ),
       );
     }
@@ -59,7 +55,7 @@ export default function EventPostingList({
 
   return (
     <div className={styles.eventPostings}>
-      {filteredEventPostings?.map((eventPosting: IEventPosting) => (
+      {filteredEventPostings.map((eventPosting) => (
         <EventPosting
           eventPosting={eventPosting}
           key={eventPosting._key}

--- a/src/components/sections/events/Events.tsx
+++ b/src/components/sections/events/Events.tsx
@@ -1,10 +1,6 @@
-import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
-import { IEventPostings } from "studio/lib/interfaces/eventPosting";
+import { IEventPosting } from "studio/lib/interfaces/eventPosting";
 import { EventsSection } from "studio/lib/interfaces/pages";
-import {
-  COMPANY_LOCATIONS_QUERY,
-  EVENT_POSTINGS_QUERY,
-} from "studio/lib/queries/admin";
+import { EVENT_POSTINGS_QUERY } from "studio/lib/queries/admin";
 import { loadStudioQuery } from "studio/lib/store";
 
 import styles from "./events.module.css";
@@ -16,27 +12,27 @@ export interface EventsProps {
 }
 
 export default async function Events({ language, section }: EventsProps) {
-  const { data: eventPostings } = await loadStudioQuery<IEventPostings | null>(
-    EVENT_POSTINGS_QUERY,
-    {
-      language,
-    },
-  );
+  // Check if eventPostingsArray in section has events
+  const hasLocalEvents =
+    section.eventPostingsArray && section.eventPostingsArray.length > 0;
 
-  const { data: companyLocations } = await loadStudioQuery<CompanyLocation[]>(
-    COMPANY_LOCATIONS_QUERY,
-    {},
-  );
+  let eventPostings: IEventPosting[] = [];
+
+  if (hasLocalEvents) {
+    eventPostings = section.eventPostingsArray.map((event) => ({
+      ...event,
+    }));
+  } else {
+    const { data } = await loadStudioQuery<{
+      eventPostingsArray: IEventPosting[];
+    }>(EVENT_POSTINGS_QUERY, { language });
+    eventPostings = data?.eventPostingsArray ?? [];
+  }
 
   return (
-    eventPostings &&
-    companyLocations && (
+    eventPostings && (
       <div className={styles.wrapper}>
-        <EventsClient
-          section={section}
-          eventPostings={eventPostings.eventPostingsArray}
-          companyLocations={companyLocations}
-        />
+        <EventsClient section={section} eventPostings={eventPostings} />
       </div>
     )
   );

--- a/src/components/sections/events/EventsClient.tsx
+++ b/src/components/sections/events/EventsClient.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 
 import OfficeSelector from "src/components/officeSelector/OfficeSelector";
 import Text from "src/components/text/Text";
-import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
 import { IEventPosting } from "studio/lib/interfaces/eventPosting";
 import { EventsSection } from "studio/lib/interfaces/pages";
 
@@ -14,44 +13,35 @@ import styles from "./events.module.css";
 interface EventsClientProps {
   section: EventsSection;
   eventPostings: IEventPosting[];
-  companyLocations: CompanyLocation[];
 }
 
 export default function EventsClient({
   section,
   eventPostings,
-  companyLocations,
 }: EventsClientProps) {
-  const [locationFilter, setLocationFilter] = useState<CompanyLocation | null>(
-    null,
+  const [locationFilter, setLocationFilter] = useState<string | null>(null);
+
+  const allLocations = Array.from(
+    new Set(eventPostings.flatMap((event) => event.locations)),
   );
 
-  // Count events per location
-  const eventPostingsPerLocation = companyLocations.reduce(
+  const eventPostingsPerLocation = allLocations.reduce(
     (acc, location) => {
-      acc[location.companyLocationName] = eventPostings.filter((eventPosting) =>
-        eventPosting.locations.some(
-          (loc) => loc.companyLocationName === location.companyLocationName,
-        ),
+      acc[location] = eventPostings.filter((event) =>
+        event.locations.includes(location),
       ).length;
       return acc;
     },
     {} as Record<string, number>,
   );
 
-  // Filter events by locations
-  const filteredEventPostings =
-    locationFilter === null
-      ? eventPostings
-      : eventPostings.filter((eventPosting) =>
-          eventPosting.locations.some(
-            (location) =>
-              location.companyLocationName ===
-              locationFilter.companyLocationName,
-          ),
-        );
+  const filteredEventPostings = eventPostings
+    .filter((event) => new Date(event.date) >= new Date()) // Filter away old events
+    .filter(
+      (event) =>
+        locationFilter === null || event.locations.includes(locationFilter),
+    );
 
-  // Function to only show 3 events
   const limitedEventPostings = filteredEventPostings.sort(
     (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
   );
@@ -65,18 +55,15 @@ export default function EventsClient({
         </Text>
 
         <OfficeSelector
-          companyLocations={companyLocations}
+          locations={allLocations}
           eventPostingsCount={eventPostings.length}
           eventPostingsPerLocation={eventPostingsPerLocation}
-          onFilterChange={(location) => setLocationFilter(location)}
+          onFilterChange={setLocationFilter}
         />
       </div>
 
       <div className={styles.eventsSection}>
-        <EventPostingList
-          eventPostings={limitedEventPostings}
-          companyLocations={companyLocations}
-        />
+        <EventPostingList eventPostings={limitedEventPostings} />
       </div>
     </>
   );

--- a/studio/lib/interfaces/eventPosting.ts
+++ b/studio/lib/interfaces/eventPosting.ts
@@ -1,10 +1,9 @@
-import { CompanyLocation } from "studio/lib/interfaces/companyDetails";
 import { Consultants } from "studioShared/lib/interfaces/customerCases";
 
 export interface IEventPosting {
   _key: string;
   eventTitle: string;
-  locations: CompanyLocation[];
+  locations: string[];
   externalLink: string;
   eventDescription: string;
   date: string;

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -1,5 +1,6 @@
 import { PortableTextBlock } from "sanity";
 
+import { IEventPosting } from "./eventPosting";
 import { Slug } from "./global";
 import { IImage, ImageExtendedProps } from "./media";
 import { ILink } from "./navigation";
@@ -119,6 +120,7 @@ export interface EventsSection {
   _key: string;
   basicTitle: string;
   subtitle: string;
+  eventPostingsArray: IEventPosting[];
 }
 
 export enum CompensationCalculatorBackground {

--- a/studio/lib/queries/admin.ts
+++ b/studio/lib/queries/admin.ts
@@ -44,15 +44,16 @@ export const EVENT_POSTINGS_QUERY = groq`
   *[_type == "eventPostings"][0] {
     eventPostingsArray[] {
       _key, 
-      externalLink,
-      "eventTitle": ${translatedFieldFragment("eventTitle")}, 
-      locations[] -> {
-        ...
-      }, 
-      date, 
-      eventDescription, 
-      tags,
-      consultants,
+      "eventTitle": ${translatedFieldFragment("eventTitle")},
+      "eventDescription": ${translatedFieldFragment("eventDescription")},
+      "locations": locations[],
+      "date": date,
+      "tags": tags[],
+      "consultants": consultants[]{
+        employeeEmail,
+        employeeFirstName
+      },
+      "externalLink": externalLink
     }
   }
 `;

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -76,7 +76,20 @@ const SECTIONS_FRAGMENT = groq`
     },
     _type == "events" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")},
-      "subtitle": ${translatedFieldFragment("subtitle")}
+      "subtitle": ${translatedFieldFragment("subtitle")},
+      "eventPostingsArray": eventPostingsArray[] {
+        ...,
+        "eventTitle": ${translatedFieldFragment("eventTitle")},
+        "eventDescription": ${translatedFieldFragment("eventDescription")},
+        "locations": locations[],
+        "date": date,
+        "tags": tags[],
+        "consultants": consultants[]{
+          employeeEmail,
+          employeeFirstName
+        },
+        "externalLink": externalLink
+      }
     },
     _type == "employeeHighlight" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")},

--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -1,7 +1,6 @@
 import { defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
-import { companyLocationID } from "studio/schemas/documents/admin/companyLocation";
 import { firstTranslation } from "studio/utils/i18n";
 
 export const eventPostingID = "eventPosting";
@@ -21,21 +20,14 @@ const eventPosting = defineType({
     {
       title: "Event description",
       name: "eventDescription",
-      type: "text",
+      type: "internationalizedArrayString",
       description: "Describe the event",
     },
     {
       title: "Locations",
       name: "locations",
       type: "array",
-      description: "The date of the event",
-      of: [
-        {
-          type: "reference",
-          to: [{ type: companyLocationID }],
-        },
-      ],
-      validation: (rule) => rule.required(),
+      of: [{ type: "string" }],
     },
     {
       title: "Date",

--- a/studio/schemas/objects/sections/events.ts
+++ b/studio/schemas/objects/sections/events.ts
@@ -2,6 +2,7 @@ import { UlistIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { titleID } from "studio/schemas/fields/text";
+import { eventPostingID } from "studio/schemas/objects/eventPosting";
 
 const eventsID = "events";
 
@@ -30,6 +31,12 @@ export const events = defineField({
       type: "internationalizedArrayString",
       title: "Intro",
       description: "Intro text on event segment ",
+    },
+    {
+      name: "eventPostingsArray",
+      title: "Event Postings",
+      type: "array",
+      of: [{ type: eventPostingID }],
     },
   ],
   preview: {

--- a/studio/schemas/objects/sections/events.ts
+++ b/studio/schemas/objects/sections/events.ts
@@ -36,6 +36,8 @@ export const events = defineField({
       name: "eventPostingsArray",
       title: "Event Postings",
       type: "array",
+      description:
+        "Add events to this block to override the global events you find in Admin/EventPostings. Only the events you add to this section will be presented. Remember to regularly remove old events. If you wan't to add a global event and present it with other global events, you can go to 'Admin' and 'Event Postings' and add events there.",
       of: [{ type: eventPostingID }],
     },
   ],


### PR DESCRIPTION
PR'en inneholder:
* Erstattet companylocations med en liste med string-locations istedenfor
* Lagt til funksjonalitet for at man kan legge inn eventer direkte i seksjonen. Det fungerer nå slik at man fortsatt kan legge til en tom seksjon på en page, og da henter den eventer fra Admin. Men ved å opprette et event i seksjonen overstyrer man Admin-eventene, slik at man får en egen liste. På den måten kan man fortsatt legge inn en generell arrangement-liste som viser alle arrangementer i admin, dersom det skulle bli behov for det.
* Eventer som har vært blir nå filtrert bort 