### PR TITLE
Added redirects for swedish domain

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,6 +24,120 @@ const nextConfig = {
   experimental: {
     taint: true,
   },
+  async redirects() {
+    return [
+      {
+        source: "/tjanster",
+        destination: "/se/tjanster",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/jobs",
+        destination: "/se/jobs",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/om-variant",
+        destination: "/",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/varianter",
+        destination: "/se/varianter",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/varianter/goteborg",
+        destination: "/se/varianter?location=g%C3%B6teborg",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/varianter/linkoping",
+        destination: "/se/varianter?location=link%C3%B6ping",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/varianter/stockholm",
+        destination: "/se/varianter?location=stockholm",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/tjanster/digital",
+        destination: "/se/tjanster",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/tjanster/strategi",
+        destination: "/se/tjanster",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+      {
+        source: "/tjanster/kultur",
+        destination: "/se/tjanster",
+        has: [
+          {
+            type: "host",
+            value: "variant.se",
+          },
+        ],
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default withNextIntl(withBundleAnalyzer(nextConfig));


### PR DESCRIPTION
* Chose next.js because it's fast, easy to use and SEO friendly. 
* Added host: variant.se to make sure only urls on se domain gets redirected
* Tested with localhost