### PR TITLE
Footer fix

### DIFF
--- a/src/components/navigation/footer/Footer.tsx
+++ b/src/components/navigation/footer/Footer.tsx
@@ -96,7 +96,8 @@ const Footer = ({
                 </FooterSection>
               )}
               {navigationData.footer?.some(
-                (section) => section.linksAndContent,
+                (section) =>
+                  section.linksAndContent && section.linksAndContent.length > 0,
               ) && (
                 <FooterSection title={t("other")}>
                   {renderOtherLinks(navigationData)}

--- a/src/components/navigation/footer/Footer.tsx
+++ b/src/components/navigation/footer/Footer.tsx
@@ -4,7 +4,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { ReactNode } from "react";
 
 import CustomLink from "src/components/link/CustomLink";
 import SoMeLink from "src/components/link/SoMeLink";
@@ -129,25 +128,17 @@ const Footer = ({
 };
 
 const renderOtherLinks = (data: Navigation) => {
-  return renderList(
-    data.footer?.map((footer) =>
-      footer.linksAndContent?.map((link: ILink) => (
-        <li key={link._key}>
-          <CustomLink link={link} type="footerLink" />
-        </li>
-      )),
-    ),
+  return data.footer?.map((footer) =>
+    footer.linksAndContent?.map((link: ILink) => (
+      <CustomLink key={link._key} link={link} type="footerLink" />
+    )),
   );
 };
 
 const renderPageLinks = (data: Navigation) => {
-  return renderList(
-    data.main.map((p: ILink) => (
-      <li key={p._key}>
-        <CustomLink link={p} type="footerLink" />
-      </li>
-    )),
-  );
+  return data.main.map((p: ILink) => (
+    <CustomLink key={p._key} link={p} type="footerLink" />
+  ));
 };
 
 const renderSoMe = (data: Navigation, soMeData: SocialMediaProfiles) => {
@@ -156,13 +147,9 @@ const renderSoMe = (data: Navigation, soMeData: SocialMediaProfiles) => {
     socialMediaSections &&
     socialMediaSections.length > 0 &&
     soMeData.soMeLinkArray &&
-    renderList(
-      soMeData.soMeLinkArray.map((link: SocialMediaLink) => (
-        <li key={link._key}>
-          <SoMeLink link={link} />
-        </li>
-      )),
-    )
+    soMeData.soMeLinkArray.map((link: SocialMediaLink) => (
+      <SoMeLink key={link._key} link={link} />
+    ))
   );
 };
 
@@ -170,9 +157,5 @@ const filterSectionsByType = (
   data: Navigation,
   type: "content" | "socialMedia",
 ) => data.footer?.filter((section) => section.sectionType === type);
-
-const renderList = (children: ReactNode) => (
-  <ul className={styles.linkColumn}>{children}</ul>
-);
 
 export default Footer;

--- a/src/components/navigation/footer/footer.module.css
+++ b/src/components/navigation/footer/footer.module.css
@@ -33,26 +33,6 @@
   }
 }
 
-.list {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
-.linkColumn {
-  composes: list;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  min-width: 160px;
-  max-width: 300px;
-
-  @media (min-width: 1024px) {
-    min-width: 260px;
-    max-width: 440px;
-  }
-}
-
 .nav {
   width: 100%;
   display: flex;
@@ -124,29 +104,6 @@
     flex-direction: row;
     justify-content: space-between;
     width: 100%;
-  }
-}
-
-.grey_links__language {
-  composes: list;
-  display: flex;
-  gap: 1rem;
-}
-
-.credits {
-  composes: list;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  flex-wrap: wrap;
-
-  & > li {
-    text-wrap: nowrap;
-  }
-
-  @media (min-width: 1408px) {
-    flex-direction: row;
-    gap: 2.5rem;
   }
 }
 

--- a/src/components/navigation/footer/footerSection/FooterSection.tsx
+++ b/src/components/navigation/footer/footerSection/FooterSection.tsx
@@ -15,7 +15,7 @@ export const FooterSection = ({ title, children }: IFooterSection) => {
   return (
     <div className={styles.footerSection}>
       <TextTertiary>{title}</TextTertiary>
-      <ul className={styles.footerSectionLinks}>
+      <ul className={styles.linkColumn}>
         {childrenArray.map((child, index) => (
           <li key={index}>{child}</li>
         ))}

--- a/src/components/navigation/footer/footerSection/footerSection.module.css
+++ b/src/components/navigation/footer/footerSection/footerSection.module.css
@@ -10,14 +10,22 @@
   }
 }
 
-.footerSectionLinks {
+.list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.linkColumn {
+  composes: list;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0;
-  margin: 0;
+  gap: 0.5rem;
+  min-width: 160px;
+  max-width: 300px;
 
-  & > li {
-    list-style: none;
+  @media (min-width: 1024px) {
+    min-width: 260px;
+    max-width: 440px;
   }
 }

--- a/studio/lib/queries/siteSettings.ts
+++ b/studio/lib/queries/siteSettings.ts
@@ -23,7 +23,7 @@ export const NAV_QUERY = groq`
     },
     "footer": footer[] {
       ...,
-      linksAndContent[] {
+      linksAndContent[!(_type == "richTextObject")] {
         ...,
         ${TRANSLATED_LINK_FRAGMENT}
       },


### PR DESCRIPTION
Filter out rich text added to links and other elements in the footer. We don’t want them to appear in the list of links, as they create an extra gap or dont trigger 'Other' to disappear when no links are present.

<img width="1305" alt="Screenshot 2025-02-05 at 09 01 33" src="https://github.com/user-attachments/assets/25dc6448-348e-47a8-89a8-a20f88be4f90" />
