### PR TITLE
removed unused field and added translation for location and tags

### DIFF
--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -1,7 +1,7 @@
 import { defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
-import { firstTranslation } from "studio/utils/i18n";
+import { allTranslations, firstTranslation } from "studio/utils/i18n";
 
 export const eventPostingID = "eventPosting";
 
@@ -27,7 +27,31 @@ const eventPosting = defineType({
       title: "Locations",
       name: "locations",
       type: "array",
-      of: [{ type: "string" }],
+      of: [
+        {
+          title: "Location",
+          name: "location",
+          type: "object",
+          fields: [
+            {
+              name: "locationObject",
+              type: "internationalizedArrayString",
+              title: "Location",
+            },
+          ],
+          preview: {
+            select: {
+              title: "locationObject",
+            },
+            prepare(selection) {
+              const { title } = selection;
+              return {
+                title: allTranslations(title) || "No location",
+              };
+            },
+          },
+        },
+      ],
     },
     {
       title: "Date",
@@ -36,11 +60,24 @@ const eventPosting = defineType({
       description: "Where is the role located?",
     },
     {
-      title: "Subject tags",
+      title: "Subject Tags",
       name: "tags",
       type: "array",
-      of: [{ type: "string" }],
-      description: "Tag tags to event and separate them with ,",
+      description: "Add tags to categorize the event.",
+      of: [
+        {
+          title: "Tag",
+          name: "tags",
+          type: "object",
+          fields: [
+            {
+              name: "tag",
+              type: "internationalizedArrayString",
+              title: "Tag",
+            },
+          ],
+        },
+      ],
     },
     {
       title: "Connected consultants",

--- a/studio/schemas/objects/sections/events.ts
+++ b/studio/schemas/objects/sections/events.ts
@@ -27,12 +27,6 @@ export const events = defineField({
         "Enter the subtitle that will be displayed below the title in the events section.",
     },
     {
-      name: "intro",
-      type: "internationalizedArrayString",
-      title: "Intro",
-      description: "Intro text on event segment ",
-    },
-    {
       name: "eventPostingsArray",
       title: "Event Postings",
       type: "array",


### PR DESCRIPTION
This is still a work in progress!

- For event postings, we need translations for the tag and location. I have updated the schema in Sanity, but queries and interfaces still need to be updated.

- Event section should be completely hidden if there are no events coming up. 

- Buttons for contact point also need to support translation.

- Consider to reduce the button size used in split section. 