### PR TITLE
Fix calculator year/degree bug

### DIFF
--- a/src/components/sections/compensation-calculator/Calculator.tsx
+++ b/src/components/sections/compensation-calculator/Calculator.tsx
@@ -41,18 +41,21 @@ export default function Calculator({
     defaultValue: getMaybeMaxYear(salaries) ?? new Date().getFullYear(),
     parse: (value) => (value ? parseInt(value, 10) : null),
     serialize: (value) => (value ? value.toString() : ""),
+    clearOnDefault: false,
   });
 
   const [degree, setDegree] = useQueryState<Degree>("degree", {
     defaultValue: "master",
     parse: (value) => (value as Degree) ?? null,
     serialize: (value) => value ?? "",
+    clearOnDefault: false,
   });
 
   const [salary, setSalary] = useQueryState<number | null>("salary", {
     defaultValue: getDefaultSalary(salaries, year),
     parse: (value) => (value ? parseFloat(value) : null),
     serialize: (value) => (value ? value.toString() : ""),
+    clearOnDefault: false,
   });
 
   // Update calculatedSalary whenever year, degree, or salaries change


### PR DESCRIPTION
there was a bug where if the user was in the default year, and swapped the degrees, the salary would not update correctly. This is fixed by always having the default value in the url params using nuqs.