### PR TITLE
fix(sec): update csp with missing value

### DIFF
--- a/src/middlewares/nonceMiddleware.ts
+++ b/src/middlewares/nonceMiddleware.ts
@@ -9,13 +9,13 @@ const contentSecurityPolicy = (nonce: string) => {
   const csp = `
     default-src 'self';
     connect-src 'self' https://variant.innocraft.cloud/ https://g.nav.no/api/v1/;
-    script-src 'self' 'unsafe-inline' 'nonce-${nonce}' 'strict-dynamic' https://variant.innocraft.cloud/ https://vercel.live/ ${
+    script-src 'self' 'unsafe-inline' 'nonce-${nonce}' 'strict-dynamic' ${
       process.env.NODE_ENV !== "production" ? "'unsafe-eval'" : ""
     };
     style-src 'self' 'unsafe-inline';
     img-src 'self' data: https://cdn.sanity.io/;
     media-src 'self';
-    frame-src 'self';
+    frame-src 'self' https://vercel.live/;
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';


### PR DESCRIPTION
- Adds missing `https://vercel.live/` to `frame-src`
- Change domain list for `script-src` since `nonce` + `'strict-dynamic'` makes it obsolete https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src#strict-dynamic