### PR TITLE
fix: properly use alts for logo salad logos

### DIFF
--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -154,7 +154,10 @@ const SECTIONS_FRAGMENT = groq`
       }
     },
     _type == "logoSalad" => {
-      "title": ${translatedFieldFragment("title")}
+      "title": ${translatedFieldFragment("title")},
+      "logos": logos[] {
+        ${INTERNATIONALIZED_IMAGE_FRAGMENT}
+      }
     },
     _type == "learningSection" => {
       ...,


### PR DESCRIPTION
Alt text for logos in logo salad
[#1175](https://github.com/varianter/variant.no/issues/1175)

This should fix the problem where the alt text for the logos appear as "[object Object],[object Object]".