### PR TITLE
fix(eventRegistration): makes button text display correct language

### DIFF
--- a/src/components/hubspot/eventRegistration/eventRegistration.tsx
+++ b/src/components/hubspot/eventRegistration/eventRegistration.tsx
@@ -240,7 +240,7 @@ export default function EventRegistration({
               >
                 {isLoading
                   ? t("eventRegistration.submitting")
-                  : "Meld interesse"}
+                  : t("eventRegistration.submit")}
               </button>
             </form>
           )}


### PR DESCRIPTION
Fikset en liten bug hvor teksten på knappen i eventRegistration hadde norsk teskt når språket på nettsiden var satt til engelsk. 