### PR TITLE
feat: improve accessibility for images

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -109,10 +109,7 @@
     "other": "Other",
     "socialMedia": "Places we share",
     "contact": "General contact",
-    "illustration": {
-      "leftCharacter": "Happy smiling character illustration",
-      "rightCharacter": "Happy smiling character illustration"
-    }
+    "characterIllustration": "Happy smiling character illustration"
   },
   "gridSection": {
     "video": "Video",

--- a/messages/en.json
+++ b/messages/en.json
@@ -46,6 +46,11 @@
       "resultLabel": "Your annual salary",
       "notice": "Note! All Variants receive a salary increase on January 1st every year. While we wait for new salary statistics from Tekna, you will find last year's salary data."
     },
+    "graphs": {
+      "bonusChart": "Historical bonus amounts by year",
+      "salaryChart": "Salary progression over time with future projections",
+      "pensionChart": "Pension contribution comparison"
+    },
     "degreeOptions": {
       "bachelor": "Bachelor",
       "master": "Master"
@@ -103,7 +108,11 @@
     "mainMenu": "Main menu",
     "other": "Other",
     "socialMedia": "Places we share",
-    "contact": "General contact"
+    "contact": "General contact",
+    "illustration": {
+      "leftCharacter": "Happy smiling character illustration",
+      "rightCharacter": "Happy smiling character illustration"
+    }
   },
   "gridSection": {
     "video": "Video",

--- a/messages/no.json
+++ b/messages/no.json
@@ -41,6 +41,11 @@
       "bonusResult": "+ bonus",
       "resultLabel": "Din årslønn"
     },
+    "graphs": {
+      "bonusChart": "Historiske bonusbeløp per år",
+      "salaryChart": "Lønnsutvikling over tid med fremtidige prognoser",
+      "pensionChart": "Sammenligning av pensjonsinnskudd"
+    },
     "degreeOptions": {
       "bachelor": "Bachelor",
       "master": "Master"
@@ -102,7 +107,11 @@
     "mainMenu": "Hovedmeny",
     "other": "Annet",
     "socialMedia": "Steder vi deler",
-    "contact": "Generell kontakt"
+    "contact": "Generell kontakt",
+    "illustration": {
+      "leftCharacter": "Glad smilende karakter illustrasjon",
+      "rightCharacter": "Glad smilende karakter illustrasjon"
+    }
   },
   "gridSection": {
     "video": "Video",

--- a/messages/no.json
+++ b/messages/no.json
@@ -108,10 +108,7 @@
     "other": "Annet",
     "socialMedia": "Steder vi deler",
     "contact": "Generell kontakt",
-    "illustration": {
-      "leftCharacter": "Glad smilende karakter illustrasjon",
-      "rightCharacter": "Glad smilende karakter illustrasjon"
-    }
+    "characterIllustration": "Glad smilende karakter illustrasjon"
   },
   "gridSection": {
     "video": "Video",

--- a/messages/se.json
+++ b/messages/se.json
@@ -42,6 +42,11 @@
       "resultLabel": "Din årslön",
       "notice": "Obs! Alla varianter får en löneökning den 1 januari varje år. Medan vi väntar på ny lönestatistik från Tekna hittar du förra årets lönedata."
     },
+    "graphs": {
+      "bonusChart": "Historiska bonusbelopp per år",
+      "salaryChart": "Löneutveckling över tid med framtida prognoser",
+      "pensionChart": "Jämförelse av pensionsinsatser"
+    },
     "degreeOptions": {
       "bachelor": "Bachelor",
       "master": "Master"
@@ -103,7 +108,11 @@
     "mainMenu": "Huvudmeny",
     "other": "Övrigt",
     "socialMedia": "Platser vi delar",
-    "contact": "Kontakt"
+    "contact": "Kontakt",
+    "illustration": {
+      "leftCharacter": "Glad leende karaktär illustration",
+      "rightCharacter": "Glad leende karaktär illustration"
+    }
   },
   "gridSection": {
     "video": "Video",

--- a/messages/se.json
+++ b/messages/se.json
@@ -109,10 +109,7 @@
     "other": "Övrigt",
     "socialMedia": "Platser vi delar",
     "contact": "Kontakt",
-    "illustration": {
-      "leftCharacter": "Glad leende karaktär illustration",
-      "rightCharacter": "Glad leende karaktär illustration"
-    }
+    "characterIllustration": "Glad leende karaktär illustration"
   },
   "gridSection": {
     "video": "Video",

--- a/src/advanced-calculator/Graphs/BonusGraph.tsx
+++ b/src/advanced-calculator/Graphs/BonusGraph.tsx
@@ -2,6 +2,7 @@ import { Group } from "@visx/group";
 import { ParentSize } from "@visx/responsive";
 import { scaleBand, scaleLinear } from "@visx/scale";
 import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 import { useInView } from "react-intersection-observer";
 
@@ -25,6 +26,7 @@ function BonusGraph({
   parentWidth,
   parentHeight,
 }: BarsProps) {
+  const t = useTranslations("compensation.graphs");
   const [visible, setVisible] = useState(false);
   const { ref, inView } = useInView({
     /* Optional options */
@@ -68,7 +70,10 @@ function BonusGraph({
       width={parentWidth}
       height={parentHeight}
       style={{ overflow: "visible", display: "block" }}
+      role="img"
+      aria-labelledby="bonus-chart-title"
     >
+      <title id="bonus-chart-title">{t("bonusChart")}</title>
       <Group top={verticalMargin}>
         {yearlyBonusesForLocation.map((d, index) => {
           const text = getText(d);

--- a/src/advanced-calculator/Graphs/PensionGraph.tsx
+++ b/src/advanced-calculator/Graphs/PensionGraph.tsx
@@ -2,6 +2,7 @@ import { Group } from "@visx/group";
 import { ParentSize } from "@visx/responsive";
 import { scaleBand, scaleLinear } from "@visx/scale";
 import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 
 import styles from "src/advanced-calculator/calculator.module.css";
@@ -27,6 +28,7 @@ type BarData = {
 };
 
 function PensionGraph({ data, parentWidth, parentHeight }: BarsProps) {
+  const t = useTranslations("compensation.graphs");
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -67,7 +69,10 @@ function PensionGraph({ data, parentWidth, parentHeight }: BarsProps) {
       width={parentWidth}
       height={parentHeight}
       style={{ overflow: "visible" }}
+      role="img"
+      aria-labelledby="pension-chart-title"
     >
+      <title id="pension-chart-title">{t("pensionChart")}</title>
       <Group top={verticalMargin}>
         {data.map((d, index) => {
           const text = getText(d);

--- a/src/advanced-calculator/Graphs/SalaryGraph.tsx
+++ b/src/advanced-calculator/Graphs/SalaryGraph.tsx
@@ -31,6 +31,7 @@ const SalaryGraph = ({
   parentHeight: number;
   parentWidth: number;
 }) => {
+  const t = useTranslations("compensation.graphs");
   const height = parentHeight;
   const width = parentWidth;
   const padding = {
@@ -81,7 +82,10 @@ const SalaryGraph = ({
         width={width}
         height={height}
         style={{ overflow: "visible" }}
+        role="img"
+        aria-labelledby="salary-chart-title"
       >
+        <title id="salary-chart-title">{t("salaryChart")}</title>
         <rect
           x={padding.left}
           y={padding.top}

--- a/src/components/navigation/footer/footerIllustration/FooterIllustration.tsx
+++ b/src/components/navigation/footer/footerIllustration/FooterIllustration.tsx
@@ -8,7 +8,7 @@ interface FooterIllustrationProps {
 }
 
 export const FooterIllustration = ({ color }: FooterIllustrationProps) => {
-  const t = useTranslations("footer.illustration");
+  const t = useTranslations("footer");
 
   return (
     <div className={styles.footerIllustrations}>
@@ -22,7 +22,7 @@ export const FooterIllustration = ({ color }: FooterIllustrationProps) => {
         role="img"
         aria-labelledby="left-illustration-title"
       >
-        <title id="left-illustration-title">{t("leftCharacter")}</title>
+        <title id="left-illustration-title">{t("characterIllustration")}</title>
         <path
           fillRule="evenodd"
           clipRule="evenodd"
@@ -60,7 +60,9 @@ export const FooterIllustration = ({ color }: FooterIllustrationProps) => {
         role="img"
         aria-labelledby="right-illustration-title"
       >
-        <title id="right-illustration-title">{t("rightCharacter")}</title>
+        <title id="right-illustration-title">
+          {t("characterIllustration")}
+        </title>
         <path
           fillRule="evenodd"
           clipRule="evenodd"

--- a/src/components/navigation/footer/footerIllustration/FooterIllustration.tsx
+++ b/src/components/navigation/footer/footerIllustration/FooterIllustration.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "next-intl";
 import React from "react";
 
 import styles from "./footerIllustration.module.css";
@@ -7,6 +8,8 @@ interface FooterIllustrationProps {
 }
 
 export const FooterIllustration = ({ color }: FooterIllustrationProps) => {
+  const t = useTranslations("footer.illustration");
+
   return (
     <div className={styles.footerIllustrations}>
       <svg
@@ -16,7 +19,10 @@ export const FooterIllustration = ({ color }: FooterIllustrationProps) => {
         height="71"
         viewBox="0 0 147 71"
         fill="none"
+        role="img"
+        aria-labelledby="left-illustration-title"
       >
+        <title id="left-illustration-title">{t("leftCharacter")}</title>
         <path
           fillRule="evenodd"
           clipRule="evenodd"
@@ -51,7 +57,10 @@ export const FooterIllustration = ({ color }: FooterIllustrationProps) => {
         height="84"
         viewBox="0 0 215 84"
         fill="none"
+        role="img"
+        aria-labelledby="right-illustration-title"
       >
+        <title id="right-illustration-title">{t("rightCharacter")}</title>
         <path
           fillRule="evenodd"
           clipRule="evenodd"

--- a/studio/lib/queries/admin.ts
+++ b/studio/lib/queries/admin.ts
@@ -1,5 +1,6 @@
 import { groq } from "next-sanity";
 
+import { INTERNATIONALIZED_IMAGE_FRAGMENT } from "./pages";
 import { translatedFieldFragment } from "./utils/i18n";
 
 //Parent Company
@@ -60,7 +61,8 @@ export const EVENT_POSTINGS_QUERY = groq`
       "externalLink": externalLink,
       createInternalPage,
       recordID,
-      time
+      time,
+      "eventImage": eventImage { ${INTERNATIONALIZED_IMAGE_FRAGMENT} }
     }
   }
 `;

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -3,7 +3,7 @@ import { groq } from "next-sanity";
 import { LANGUAGE_FIELD_FRAGMENT, TRANSLATED_LINK_FRAGMENT } from "./i18n";
 import { translatedFieldFragment } from "./utils/i18n";
 
-const INTERNATIONALIZED_IMAGE_FRAGMENT = groq`
+export const INTERNATIONALIZED_IMAGE_FRAGMENT = groq`
   asset,
   "metadata": asset -> metadata {
     lqip
@@ -130,14 +130,16 @@ const SECTIONS_FRAGMENT = groq`
     },
     _type == "employeeHighlight" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")},
-      "description": ${translatedFieldFragment("description")}
+      "description": ${translatedFieldFragment("description")},
+      "employeePhoto": employeePhoto { ${INTERNATIONALIZED_IMAGE_FRAGMENT} }
     },
     _type == "customerCasesEntry" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")}
     },
     _type == "opennessSection" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")},
-      "description": ${translatedFieldFragment("description")}
+      "description": ${translatedFieldFragment("description")},
+      "image": image { ${INTERNATIONALIZED_IMAGE_FRAGMENT} }
     },
     _type == "generositySection" => {
       ...,
@@ -163,6 +165,7 @@ const SECTIONS_FRAGMENT = groq`
       ...,
       "basicTitle": ${translatedFieldFragment("basicTitle")},
       "description": ${translatedFieldFragment("description")},
+      "image": image { ${INTERNATIONALIZED_IMAGE_FRAGMENT} },
       "articleTag": ${translatedFieldFragment("articleTag")},
       "articleTitle": ${translatedFieldFragment("articleTitle")},
       "articleSubtitle": ${translatedFieldFragment("articleSubtitle")}

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -5,7 +5,7 @@ import {
   TRANSLATED_LINK_FRAGMENT,
   TRANSLATED_SLUG_VALUE_FRAGMENT,
 } from "./i18n";
-import { SEO_FRAGMENT } from "./pages";
+import { INTERNATIONALIZED_IMAGE_FRAGMENT, SEO_FRAGMENT } from "./pages";
 import { translatedFieldFragment } from "./utils/i18n";
 
 export const COMPENSATIONS_PAGE_BY_SLUG_QUERY = groq`
@@ -131,7 +131,7 @@ export const EVENT_BY_KEY_QUERY = groq`
         "url": ${translatedFieldFragment("slug")}
       },
       createInternalPage,
-      eventImage,
+      "eventImage": eventImage { ${INTERNATIONALIZED_IMAGE_FRAGMENT} },
       "subtitle": ${translatedFieldFragment("subtitle")},
       richText,
       ${SEO_FRAGMENT}

--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -1,6 +1,7 @@
 import { defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
+import image from "studio/schemas/fields/media";
 import { richText } from "studio/schemas/fields/text";
 import { allTranslations, firstTranslation } from "studio/utils/i18n";
 import {
@@ -163,13 +164,10 @@ const eventPosting = defineType({
       hidden: ({ parent }) => !parent?.createInternalPage,
     },
     {
+      ...image,
       name: "eventImage",
       title: "Event image",
-      type: "image",
       description: "An image representing the event",
-      options: {
-        hotspot: true,
-      },
       hidden: ({ parent }) => !parent?.createInternalPage,
     },
     {

--- a/studio/schemas/objects/sections/employeeHighlight.ts
+++ b/studio/schemas/objects/sections/employeeHighlight.ts
@@ -2,6 +2,7 @@ import { HighlightIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
+import image from "studio/schemas/fields/media";
 import { titleID } from "studio/schemas/fields/text";
 import { firstTranslation } from "studio/utils/i18n";
 
@@ -32,13 +33,10 @@ export const employeeHighlightSection = defineField({
       description: "The body text in the section.",
     },
     {
+      ...image,
       name: "employeePhoto",
-      type: "image",
       title: "Employee photo",
       description: "A photo of the employee,",
-      options: {
-        hotspot: true,
-      },
     },
   ],
   preview: {

--- a/studio/schemas/objects/sections/learning.ts
+++ b/studio/schemas/objects/sections/learning.ts
@@ -1,6 +1,7 @@
 import { BulbOutlineIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
+import image from "studio/schemas/fields/media";
 import { titleID } from "studio/schemas/fields/text";
 
 const learningID = "learningSection";
@@ -20,13 +21,8 @@ export const learningSection = defineField({
       validation: (rule) => rule.required(),
     },
     {
-      name: "image",
-      type: "image",
-      title: "Image",
+      ...image,
       description: "An image representing learning in Variant",
-      options: {
-        hotspot: true,
-      },
       validation: (rule) => rule.required(),
     },
     {

--- a/studio/schemas/objects/sections/openness.ts
+++ b/studio/schemas/objects/sections/openness.ts
@@ -1,6 +1,7 @@
 import { SparkleIcon } from "@sanity/icons";
 import { defineField } from "sanity";
 
+import image from "studio/schemas/fields/media";
 import { titleID } from "studio/schemas/fields/text";
 const opennessID = "opennessSection";
 
@@ -19,13 +20,8 @@ export const opennessSection = defineField({
       validation: (rule) => rule.required(),
     },
     {
-      name: "image",
-      type: "image",
-      title: "Image",
+      ...image,
       description: "Add an image to the section",
-      options: {
-        hotspot: true,
-      },
       validation: (rule) => rule.required(),
     },
     {


### PR DESCRIPTION
From issue [#1122](https://github.com/varianter/variant.no/issues/1122): All images need alt text

Accessibility is improved with localized alt text for images and a title element for SVGs. English and Norwegian alt texts can be set for each image in Sanity Studio where the image is used. The translations for the SVG titles can be adjusted in the messages/ directory.

Some images still do not contain alt texts (such as Ruter). I suspect that these are set in the shared studio, which I don't currently have access to.