### PR TITLE
fix: all events counter shows the correct number of total upcoming events

### DIFF
--- a/src/components/sections/events/EventsClient.tsx
+++ b/src/components/sections/events/EventsClient.tsx
@@ -83,7 +83,7 @@ export default function EventsClient({
         {section.hideLocationFilters !== true && (
           <OfficeSelector
             locations={allLocations}
-            eventPostingsCount={filteredEventPostings.length}
+            eventPostingsCount={activeEventPostings.length}
             eventPostingsPerLocation={eventPostingsPerLocation}
             onFilterChange={setLocationFilter}
             textColor={textColor}


### PR DESCRIPTION
From issue [#1277](https://github.com/varianter/variant.no/issues/1277): Counter on arrangement button