### PR TITLE
fix: adds correct font to button

### DIFF
--- a/src/components/sections/employees/employees.module.css
+++ b/src/components/sections/employees/employees.module.css
@@ -97,6 +97,7 @@
 }
 
 .showMore__button {
+  font: inherit;
   line-height: 1;
   display: flex;
   align-items: center;
@@ -109,6 +110,7 @@
   text-decoration: none;
   z-index: 2;
   position: relative;
+  cursor: pointer;
 }
 
 .showMore__button img {


### PR DESCRIPTION
The issue seems to be connected to the button not inheriting the correct font, and therefore using Arial as the default in the browser. The button now inherits the britti font. 

The button does not have any obvious hover functions, so added a cursor to make it seem clickable. 