### PR TITLE
feat: remove show locations prop from EventInformation

### DIFF
--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -128,7 +128,6 @@ export default async function EventPage({ params }: EventPageProps) {
             date={date}
             time={time}
             locations={locations}
-            showLocations={true}
             fontsize="labelLarge"
           />
         </div>

--- a/src/components/eventInformation/eventInformation.tsx
+++ b/src/components/eventInformation/eventInformation.tsx
@@ -10,7 +10,6 @@ interface EventInformationProps {
   date?: string;
   time?: string;
   locations?: ILocation[];
-  showLocations?: boolean;
   fontsize?: TextType;
 }
 
@@ -18,7 +17,6 @@ export default function EventInformation({
   date,
   time,
   locations,
-  showLocations,
   fontsize = "labelRegular",
 }: EventInformationProps) {
   function sortAlphabetically(list: string[]) {
@@ -33,9 +31,7 @@ export default function EventInformation({
     <div className={styles.eventInformation}>
       {date && <Text type={fontsize}>{formatDate(date)}</Text>}
       {time && <Text type={fontsize}>{time}</Text>}
-      {locations && showLocations && (
-        <Text type={fontsize}>{eventPostingLocations}</Text>
-      )}
+      {locations && <Text type={fontsize}>{eventPostingLocations}</Text>}
     </div>
   );
 }

--- a/src/components/eventPosting/EventPosting.tsx
+++ b/src/components/eventPosting/EventPosting.tsx
@@ -53,8 +53,7 @@ export default function EventPosting({
       <EventInformation
         date={eventPosting.date}
         time={eventPosting.time}
-        locations={eventPosting.locations}
-        showLocations={showLocations}
+        locations={showLocations ? eventPosting.locations : undefined}
       />
       <Text type="h3" className={styles.eventTitle}>
         {eventPosting.eventTitle}

--- a/src/components/eventsPage/eventsPage.tsx
+++ b/src/components/eventsPage/eventsPage.tsx
@@ -61,7 +61,6 @@ export default async function EventsPage({
                 <EventPosting
                   eventPosting={event}
                   key={event._key}
-                  showLocations={true}
                   language={params.locale}
                 />
               ))}
@@ -83,7 +82,6 @@ export default async function EventsPage({
                 <EventPosting
                   eventPosting={event}
                   key={event._key}
-                  showLocations={true}
                   language={params.locale}
                 />
               ))}


### PR DESCRIPTION
Litt usikker på om vi skal ha med `showLocations`? Kanskje det er bedre å bare si hvis det er locations så sendes den med, hvis ikke så vises den ikke? Eventuelt sette `showLocations` default til true