### PR TITLE
fix(eventRegistration): removes fixed size on text and adds correct t…

### DIFF
--- a/src/components/forms/checkboxColor/checkboxColor.module.css
+++ b/src/components/forms/checkboxColor/checkboxColor.module.css
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  font-size: 1.5rem;
 }
 
 .input {

--- a/src/components/forms/checkboxColor/checkboxColor.tsx
+++ b/src/components/forms/checkboxColor/checkboxColor.tsx
@@ -19,7 +19,7 @@ const CheckboxColor = ({
   return (
     <>
       <label
-        className={`${styles.container} ${textStyles.caption} ${styles.label}`}
+        className={`${styles.container} ${textStyles.bodyBig} ${styles.label}`}
         htmlFor={name}
       >
         <input

--- a/src/components/forms/inputFieldColor/inputFieldColor.module.css
+++ b/src/components/forms/inputFieldColor/inputFieldColor.module.css
@@ -1,7 +1,6 @@
 .container {
   display: flex;
   flex-direction: column;
-  font-size: 1.5rem;
 }
 
 .label {
@@ -27,7 +26,6 @@
   border-radius: 0.75rem;
   padding: 0.75rem 1.25rem;
   width: 100%;
-  font-size: 1.5rem;
 }
 
 .error {

--- a/src/components/forms/inputFieldColor/inputFieldColor.tsx
+++ b/src/components/forms/inputFieldColor/inputFieldColor.tsx
@@ -35,7 +35,7 @@ const InputFieldColor = ({
 
   return (
     <div className={styles.container}>
-      <label htmlFor={name} className={`${textStyles.caption} ${styles.label}`}>
+      <label htmlFor={name} className={`${textStyles.h4} ${styles.label}`}>
         {labelText}
       </label>
       <div className={styles.inputContainer}>
@@ -48,7 +48,7 @@ const InputFieldColor = ({
           type={type}
           max={type === "number" ? max : undefined}
           min={type === "number" ? min : undefined}
-          className={styles.input}
+          className={`${textStyles.bodyBig} ${styles.input}`}
           spellCheck={spellCheck}
           value={value}
           onChange={handleChange}

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -65,6 +65,11 @@
   font-style: normal;
   font-weight: 450;
   line-height: 133.3%;
+
+  @media (width <= 425px) {
+    font-size: 1.25rem;
+    line-height: 120%;
+  }
 }
 
 .h5 {


### PR DESCRIPTION
Tekststørrelsene tar utgangspunkt i hva som er designet i Figma.

h4 er endret slik at den også tilpasser størrelsen på teksten på mobil. 

Størrelsen på RichText ble kommentert som for liten i issue, men er ikke endret enda på grunn av at den brukes flere steder på nettsiden. Blir nok et eget issue på den senere.