### PR TITLE
fix(header): shows dots only when headerLink

### DIFF
--- a/src/components/link/CustomLink.tsx
+++ b/src/components/link/CustomLink.tsx
@@ -50,7 +50,6 @@ const CustomLink = ({
           scroll={scroll}
         >
           {link.linkTitle}
-          <span className={styles.dot} />
         </Link>
       </div>
     ) : (
@@ -61,7 +60,7 @@ const CustomLink = ({
         scroll={scroll}
       >
         {link.linkTitle}
-        <span className={styles.dot} />
+        {type === "headerLink" && <span className={styles.dot} />}
       </Link>
     ))
   );


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [X] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [X] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [X] New functions that can be used in multiple components has been put in a `utils` directory
- [X] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Fjerner span fra type link og brukes kun span når typen er headerLink. 