### PR TITLE
fix(customerCase): removes centered text

### DIFF
--- a/src/components/customerCases/customerCase/sections/text/textSection.module.css
+++ b/src/components/customerCases/customerCase/sections/text/textSection.module.css
@@ -1,7 +1,6 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 0.5rem;
 }
 


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [X] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [X] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [X] New functions that can be used in multiple components has been put in a `utils` directory
- [X] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Virker som TextSection kun brukes i SplitSection som også sentrerer innholdet, og derfor fjernet eg sentrering i selve TextSection wrapper som ser ut til å løse problemet.  