### PR TITLE
Arrow direction fix for internal/external links

### DIFF
--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -1,0 +1,6 @@
+import { defineCliConfig } from "sanity/cli";
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+
+export default defineCliConfig({ api: { projectId, dataset } });

--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -1,6 +1,0 @@
-import { defineCliConfig } from "sanity/cli";
-
-const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
-const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
-
-export default defineCliConfig({ api: { projectId, dataset } });

--- a/src/components/eventPosting/eventPosting.module.css
+++ b/src/components/eventPosting/eventPosting.module.css
@@ -31,6 +31,8 @@
       position: absolute;
       top: 1rem;
       right: 1rem;
+    }
+    &[target="_blank"].eventPosting::after {
       transform: rotate(-45deg);
     }
   }


### PR DESCRIPTION
Endret retning på pil avhengig om det er ekstern eller intern lenke. 
<img width="1491" height="868" alt="Screenshot 2025-09-17 at 15 18 42" src="https://github.com/user-attachments/assets/5524612e-78e2-4d1c-a2e1-4748f367b8ad" />

Issue: #1306 

## Checklist

<!-- All must be checked before you merge -->

- [x] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
