### PR TITLE
fix(eventRegistration): adds field for button text to sanity

### DIFF
--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -161,7 +161,7 @@ export default async function EventPage({ params }: EventPageProps) {
               _type: "eventRegistration",
               _key: _key,
               recordID: recordID.toString(),
-              submitButtonText: submitButtonText ?? "",
+              submitButtonText: submitButtonText,
               date: date,
               interests: tags.map((tag) => tag.tag),
             }}

--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -161,9 +161,7 @@ export default async function EventPage({ params }: EventPageProps) {
               _type: "eventRegistration",
               _key: _key,
               recordID: recordID.toString(),
-              submitButtonText:
-                submitButtonText ||
-                (params.locale === "en" ? "Register interest" : "Meld meg på"),
+              submitButtonText: submitButtonText ?? "",
               date: date,
               interests: tags.map((tag) => tag.tag),
             }}

--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -92,6 +92,7 @@ export default async function EventPage({ params }: EventPageProps) {
     consultants,
     richText,
     recordID,
+    submitButtonText,
     time,
   } = data.event;
 
@@ -160,6 +161,9 @@ export default async function EventPage({ params }: EventPageProps) {
               _type: "eventRegistration",
               _key: _key,
               recordID: recordID.toString(),
+              submitButtonText:
+                submitButtonText ||
+                (params.locale === "en" ? "Register interest" : "Meld meg på"),
               date: date,
               interests: tags.map((tag) => tag.tag),
             }}

--- a/src/components/hubspot/eventRegistration/eventRegistration.tsx
+++ b/src/components/hubspot/eventRegistration/eventRegistration.tsx
@@ -244,7 +244,7 @@ export default function EventRegistration({
               >
                 {isLoading
                   ? t("eventRegistration.submitting")
-                  : t("eventRegistration.submit")}
+                  : section.submitButtonText}
               </button>
             </form>
           )}

--- a/src/components/hubspot/eventRegistration/eventRegistration.tsx
+++ b/src/components/hubspot/eventRegistration/eventRegistration.tsx
@@ -46,7 +46,7 @@ export default function EventRegistration({
     }[]
   >([]);
 
-  const { recordID, date, interests } = section;
+  const { recordID, submitButtonText, date, interests } = section;
 
   const today = new Date();
   const oneDay = 24 * 60 * 60 * 1000;
@@ -244,7 +244,7 @@ export default function EventRegistration({
               >
                 {isLoading
                   ? t("eventRegistration.submitting")
-                  : section.submitButtonText}
+                  : submitButtonText || t("eventRegistration.submit")}
               </button>
             </form>
           )}

--- a/studio/lib/interfaces/eventPosting.ts
+++ b/studio/lib/interfaces/eventPosting.ts
@@ -17,6 +17,7 @@ export interface IEventPosting {
   consultants: Consultants[];
   createInternalPage: boolean;
   recordID: number;
+  submitButtonText?: string;
   eventImage?: IImage;
   subtitle?: string;
   richText?: PortableTextBlock[];

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -236,6 +236,7 @@ export interface EventRegistrationSection {
   _type: "eventRegistration";
   _key: string;
   recordID: string;
+  submitButtonText: string;
   date: string;
   interests: string[];
 }

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -236,7 +236,7 @@ export interface EventRegistrationSection {
   _type: "eventRegistration";
   _key: string;
   recordID: string;
-  submitButtonText: string;
+  submitButtonText: string | undefined;
   date: string;
   interests: string[];
 }

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -112,6 +112,7 @@ export const EVENT_BY_KEY_QUERY = groq`
     "event": eventPostingsArray[_key == $key][0] {
       _key,
       recordID,
+      "submitButtonText": ${translatedFieldFragment("submitButtonText")},
       "eventTitle": ${translatedFieldFragment("eventTitle")},
       "eventDescription": ${translatedFieldFragment("eventDescription")},
       "locations": locations[]{

--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -164,6 +164,13 @@ const eventPosting = defineType({
       hidden: ({ parent }) => !parent?.createInternalPage,
     },
     {
+      name: "submitButtonText",
+      type: "internationalizedArrayString",
+      title: "Submit Button Text",
+      description: "The text displayed on the submit button.",
+      hidden: ({ parent }) => !parent?.createInternalPage || !parent?.recordID,
+    },
+    {
       ...image,
       name: "eventImage",
       title: "Event image",


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [X] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [X] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [X] New functions that can be used in multiple components has been put in a `utils` directory
- [X] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Verdiene for fallback er satt i frontend, om det er beste løsning er eg usikker på.  