### PR TITLE
Fix 1326 - Dateformatting and subtitle to SEO-image

### DIFF
--- a/public/_assets/dot-white.svg
+++ b/public/_assets/dot-white.svg
@@ -1,0 +1,5 @@
+<svg width="6" height="7" viewBox="0 0 6 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="dot">
+<rect id="Rectangle 11" y="0.5" width="6" height="6" rx="3" fill="#FFFFFF"/>
+</g>
+</svg>

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -3,6 +3,8 @@ import { join } from "node:path";
 
 import { ImageResponse } from "next/og";
 
+import formatDate from "src/components/utils/formatDate";
+import formatLongStrings from "src/components/utils/formatLongStrings";
 import { IEventPosting } from "studio/lib/interfaces/eventPosting";
 import { EVENT_BY_KEY_QUERY } from "studio/lib/queries/specialPages";
 import { loadStudioQuery } from "studio/lib/store";
@@ -39,50 +41,27 @@ export async function GET(request: Request) {
     language: language,
   });
 
-  const options: Intl.DateTimeFormatOptions = {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  };
-
   const { eventTitle, subtitle, date, time, locations } = data.event;
+  const dotWhiteSrc = `${new URL(request.url).origin}/_assets/dot-white.svg`;
+  const variantLogoWhiteSrc = `${new URL(request.url).origin}/_assets/variant-logo-white.svg`;
   return new ImageResponse(
     (
       <div style={backgroundStyle}>
         <div style={blueBackgroundStyle}>
           <h1 style={titleStyle}>{eventTitle}</h1>
-          <p style={subTitleStyle}>
-            {(() => {
-              const text = (subtitle ? subtitle : "") || "\u00A0";
-              return text.length > 80 ? text.slice(0, 147) + "..." : text;
-            })()}
-          </p>
+          <p style={subTitleStyle}>{formatLongStrings(80, subtitle)}</p>
           <div style={eventInfoContainerStyle}>
-            <p style={eventInfoStyle}>
-              {new Date(date).toLocaleDateString("nb-NO", options)}
-            </p>
-            <img
-              style={dot}
-              alt="text seperator dot"
-              src={`${new URL(request.url).origin}/_assets/dot-white.svg`}
-            />
+            <p style={eventInfoStyle}>{formatDate(date)}</p>
+            <img style={dot} alt="text seperator dot" src={dotWhiteSrc} />
             <p style={eventInfoStyle}>{time}</p>
-            <img
-              style={dot}
-              alt="text seperator dot"
-              src={`${new URL(request.url).origin}/_assets/dot-white.svg`}
-            />
+            <img style={dot} alt="text seperator dot" src={dotWhiteSrc} />
             {locations.map((location, index) => (
               <p key={index} style={eventInfoStyle}>
                 {location.locationString}
               </p>
             ))}
           </div>
-          <img
-            style={imgStyle}
-            alt="Variant logo"
-            src={`${new URL(request.url).origin}/_assets/variant-logo-white.svg`}
-          />
+          <img style={imgStyle} alt="Variant logo" src={variantLogoWhiteSrc} />
         </div>
       </div>
     ),

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -10,6 +10,7 @@ import { loadStudioQuery } from "studio/lib/store";
 import {
   backgroundStyle,
   blueBackgroundStyle,
+  dot,
   eventInfoContainerStyle,
   eventInfoStyle,
   imgStyle,
@@ -37,15 +38,34 @@ export async function GET(request: Request) {
     language: language,
   });
 
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  };
+
   const { eventTitle, date, time, locations } = data.event;
   return new ImageResponse(
     (
       <div style={backgroundStyle}>
         <div style={blueBackgroundStyle}>
           <h1 style={titleStyle}>{eventTitle}</h1>
+          {/* {subtitle && <p> {subtitle} </p>} */}
           <div style={eventInfoContainerStyle}>
-            <p style={eventInfoStyle}>{date}</p>
+            <p style={eventInfoStyle}>
+              {new Date(date).toLocaleDateString("nb-NO", options)}
+            </p>
+            <img
+              style={dot}
+              alt="text seperator dot"
+              src={`${new URL(request.url).origin}/_assets/dot-white.svg`}
+            />
             <p style={eventInfoStyle}>{time}</p>
+            <img
+              style={dot}
+              alt="text seperator dot"
+              src={`${new URL(request.url).origin}/_assets/dot-white.svg`}
+            />
             {locations.map((location, index) => (
               <p key={index} style={eventInfoStyle}>
                 {location.locationString}

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -14,6 +14,7 @@ import {
   eventInfoContainerStyle,
   eventInfoStyle,
   imgStyle,
+  subTitleStyle,
   titleStyle,
 } from "./style";
 
@@ -44,13 +45,18 @@ export async function GET(request: Request) {
     day: "2-digit",
   };
 
-  const { eventTitle, date, time, locations } = data.event;
+  const { eventTitle, subtitle, date, time, locations } = data.event;
   return new ImageResponse(
     (
       <div style={backgroundStyle}>
         <div style={blueBackgroundStyle}>
           <h1 style={titleStyle}>{eventTitle}</h1>
-          {/* {subtitle && <p> {subtitle} </p>} */}
+          <p style={subTitleStyle}>
+            {(() => {
+              const text = (subtitle ? subtitle : "") || "\u00A0";
+              return text.length > 80 ? text.slice(0, 147) + "..." : text;
+            })()}
+          </p>
           <div style={eventInfoContainerStyle}>
             <p style={eventInfoStyle}>
               {new Date(date).toLocaleDateString("nb-NO", options)}

--- a/src/app/api/og/style.ts
+++ b/src/app/api/og/style.ts
@@ -51,5 +51,10 @@ export const imgStyle: CSSProperties = {
   height: "42px",
   position: "absolute",
   bottom: "80px",
-  left: "116px",
+  left: "100px",
+};
+
+export const dot: CSSProperties = {
+  width: "0.5rem",
+  height: "0.5rem",
 };

--- a/src/app/api/og/style.ts
+++ b/src/app/api/og/style.ts
@@ -32,12 +32,23 @@ export const titleStyle: CSSProperties = {
   fontFamily: "Britti Sans Regular",
 };
 
+export const subTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "48px",
+  fontFamily: "Britti Sans Regular",
+  color: "#FFFFFF",
+  minHeight: "24px",
+  marginBottom: "2rem",
+  height: "auto",
+};
+
 export const eventInfoContainerStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
   gap: "2rem",
   width: "100%",
-  height: "100%",
+  height: "auto",
+  marginTop: "2rem",
 };
 
 export const eventInfoStyle: CSSProperties = {
@@ -50,7 +61,7 @@ export const imgStyle: CSSProperties = {
   width: "175px",
   height: "42px",
   position: "absolute",
-  bottom: "80px",
+  bottom: "70px",
   left: "100px",
 };
 

--- a/src/components/utils/formatLongStrings.ts
+++ b/src/components/utils/formatLongStrings.ts
@@ -1,0 +1,7 @@
+export default function formatLongStrings(
+  maxLength: number,
+  textString?: string,
+) {
+  const text = (textString ? textString : "") || "\u00A0";
+  return text.length > maxLength ? text.slice(0, maxLength) + "..." : text;
+}


### PR DESCRIPTION
Endret formatet på dato til europeisk standard og lagt til subtitle dersom det finnes. Trunkerer dersom teksten blir for lang.

Uten: 
<img width="867" height="479" alt="Screenshot 2025-09-19 at 10 59 38" src="https://github.com/user-attachments/assets/ba0e4d54-7f47-46c7-a4ba-13129e43e558" />

Med subtitle:
<img width="706" height="441" alt="Screenshot 2025-09-19 at 10 59 12" src="https://github.com/user-attachments/assets/046c429d-c3a7-4a43-b0f9-3026f64b20c0" />

Trunkering: 
<img width="764" height="424" alt="Screenshot 2025-09-19 at 11 00 26" src="https://github.com/user-attachments/assets/2cff7af3-a0c6-40af-aee2-f014bc6bc866" />

Relaterer til task #1326  

## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
