### PR TITLE
1290 event tags should not allow address

### DIFF
--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -85,6 +85,7 @@ export default async function EventPage({ params }: EventPageProps) {
     eventTitle,
     date,
     locations,
+    address,
     tags,
     _key,
     eventImage,
@@ -129,6 +130,7 @@ export default async function EventPage({ params }: EventPageProps) {
             date={date}
             time={time}
             locations={locations}
+            address={address}
             fontsize="labelLarge"
           />
         </div>

--- a/src/components/eventInformation/eventInformation.tsx
+++ b/src/components/eventInformation/eventInformation.tsx
@@ -10,6 +10,7 @@ interface EventInformationProps {
   date?: string;
   time?: string;
   locations?: ILocation[];
+  address?: string | undefined;
   fontsize?: TextType;
 }
 
@@ -17,6 +18,7 @@ export default function EventInformation({
   date,
   time,
   locations,
+  address,
   fontsize = "labelRegular",
 }: EventInformationProps) {
   function sortAlphabetically(list: string[]) {
@@ -32,6 +34,7 @@ export default function EventInformation({
       {date && <Text type={fontsize}>{formatDate(date)}</Text>}
       {time && <Text type={fontsize}>{time}</Text>}
       {locations && <Text type={fontsize}>{eventPostingLocations}</Text>}
+      {address && <Text type={fontsize}>{address}</Text>}
     </div>
   );
 }

--- a/src/components/eventInformation/eventInformation.tsx
+++ b/src/components/eventInformation/eventInformation.tsx
@@ -10,7 +10,7 @@ interface EventInformationProps {
   date?: string;
   time?: string;
   locations?: ILocation[];
-  address?: string | undefined;
+  address?: string;
   fontsize?: TextType;
 }
 

--- a/studio/lib/interfaces/eventPosting.ts
+++ b/studio/lib/interfaces/eventPosting.ts
@@ -9,6 +9,7 @@ export interface IEventPosting {
   _key: string;
   eventTitle: string;
   locations: ILocation[];
+  address?: string;
   externalLink: string;
   eventDescription: string;
   date: string;

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -112,6 +112,7 @@ export const EVENT_BY_KEY_QUERY = groq`
     "event": eventPostingsArray[_key == $key][0] {
       _key,
       recordID,
+      address,
       "submitButtonText": ${translatedFieldFragment("submitButtonText")},
       "eventTitle": ${translatedFieldFragment("eventTitle")},
       "eventDescription": ${translatedFieldFragment("eventDescription")},

--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -35,6 +35,8 @@ const eventPosting = defineType({
       title: "Locations",
       name: "locations",
       type: "array",
+      description:
+        "Which city is the event located in? Do not include address here.",
       validation: validateInternationalizedArray("Location", "locationString"),
 
       of: [
@@ -64,10 +66,17 @@ const eventPosting = defineType({
       ],
     },
     {
+      title: "Address",
+      name: "address",
+      type: "string",
+      description:
+        "The address of the event (e.g. Kongens gate 36). Don't include postal code.",
+    },
+    {
       title: "Date",
       name: "date",
       type: "date",
-      description: "Where is the role located?",
+      description: "The date of the event (e.g. 2025-10-02).",
     },
     {
       title: "Time",

--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -77,6 +77,7 @@ const eventPosting = defineType({
       name: "date",
       type: "date",
       description: "The date of the event (e.g. 2025-10-02).",
+      validation: (rule) => rule.required(),
     },
     {
       title: "Time",


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [X] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [X] New functions that can be used in multiple components has been put in a `utils` directory
- [X] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Event er ikkje tatt i bruk av Sverige enda, så det bude ikkje påvirker dei.

Adresse er lagt til på hver arrangements-side, men vises ikkje i listen over arrangementer.  