### PR TITLE
fix(footerIllustration): increases the viewport width for phone

### DIFF
--- a/src/components/navigation/footer/footerIllustration/footerIllustration.module.css
+++ b/src/components/navigation/footer/footerIllustration/footerIllustration.module.css
@@ -32,7 +32,7 @@
     }
   }
 
-  @media (width <= 425px) {
+  @media (width <= 440px) {
     padding-left: 1.25rem;
     gap: 0;
   }


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [X] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [X] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [X] New functions that can be used in multiple components has been put in a `utils` directory
- [X] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Sånn eg skjønner det basert på litt lett googling så er dei største mobilene i dag 440px i viewport bredde. Endret derfor @media taggen for mobil til det. Spørsmålet er jo då om dette er noe som bør endres gjennomgående på hele nettsiden?