### PR TITLE
fix lineheights and space distribution between elements

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -49,7 +49,7 @@ export async function GET(request: Request) {
       <div style={backgroundStyle}>
         <div style={blueBackgroundStyle}>
           <h1 style={titleStyle}>{eventTitle}</h1>
-          <p style={subTitleStyle}>{formatLongStrings(80, subtitle)}</p>
+          <p style={subTitleStyle}>{formatLongStrings(86, subtitle)}</p>
           <div style={eventInfoContainerStyle}>
             <p style={eventInfoStyle}>{formatDate(date)}</p>
             <img style={dot} alt="text seperator dot" src={dotWhiteSrc} />

--- a/src/app/api/og/style.ts
+++ b/src/app/api/og/style.ts
@@ -1,14 +1,11 @@
 import { CSSProperties } from "react";
 
 export const backgroundStyle: CSSProperties = {
-  height: "100%",
-  width: "100%",
   display: "flex",
   flexDirection: "column",
-  alignItems: "flex-start",
-  justifyContent: "center",
-  padding: "1rem",
   backgroundColor: "#FFFFFF",
+  padding: "1rem",
+  width: "100%",
   fontSize: 60,
   fontFamily: "Britti Sans Regular",
   fontWeight: 700,
@@ -18,9 +15,9 @@ export const backgroundStyle: CSSProperties = {
 export const blueBackgroundStyle: CSSProperties = {
   display: "flex",
   flexDirection: "column",
-  gap: "6rem",
-  width: "100%",
   height: "100%",
+  width: "100%",
+  alignContent: "space-between",
   backgroundColor: "#3840FF",
   borderRadius: "48px 48px 200px 48px",
   padding: "64px 100px",
@@ -30,25 +27,32 @@ export const titleStyle: CSSProperties = {
   margin: 0,
   fontSize: "86px",
   fontFamily: "Britti Sans Regular",
+  maxHeight: "172px",
+  overflow: "hidden",
 };
 
 export const subTitleStyle: CSSProperties = {
   margin: 0,
   fontSize: "48px",
+  lineHeight: "57px",
   fontFamily: "Britti Sans Regular",
   color: "#FFFFFF",
   minHeight: "24px",
+  marginTop: "1rem",
   marginBottom: "2rem",
-  height: "auto",
+  maxHeight: "144px",
+  overflow: "hidden",
 };
 
 export const eventInfoContainerStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
-  gap: "2rem",
+  gap: "1.5rem",
   width: "100%",
   height: "auto",
-  marginTop: "2rem",
+  position: "absolute",
+  bottom: "70px",
+  left: "100px",
 };
 
 export const eventInfoStyle: CSSProperties = {

--- a/src/components/utils/formatLongStrings.ts
+++ b/src/components/utils/formatLongStrings.ts
@@ -3,5 +3,9 @@ export default function formatLongStrings(
   textString?: string,
 ) {
   const text = (textString ? textString : "") || "\u00A0";
-  return text.length > maxLength ? text.slice(0, maxLength) + "..." : text;
+
+  return text.length > maxLength
+    ? text.slice(0, maxLength).match(/^.*(?=[\s\u00A0][^\s\u00A0]*$)|^.*$/) +
+        "..."
+    : text;
 }


### PR DESCRIPTION
## Checklist

This is mainly fixes from the previous fix:  https://github.com/varianter/variant.no/pull/1331

This pr let the title take two lines and instead of truncate in middle of a word it truncates before. 

<img width="814" height="481" alt="Screenshot 2025-09-25 at 09 22 36" src="https://github.com/user-attachments/assets/f4fd9b0c-8d49-44a9-8d86-ba2664a69a8c" />

<!-- All must be checked before you merge -->

- [x] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
