### PR TITLE
fix: adds new design to CustomLink

### DIFF
--- a/src/components/link/link.module.css
+++ b/src/components/link/link.module.css
@@ -17,11 +17,11 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  text-decoration: none;
   gap: 0.5rem;
   font-size: 1.125rem;
   font-weight: 300;
   transition: gap 100ms ease-in-out;
+  text-decoration: underline;
 
   @media (width >= 1024px) {
     font-size: 1.25rem;
@@ -29,7 +29,13 @@
 
   &:hover {
     gap: 1rem;
-    font-weight: 400;
+    text-decoration: none;
+  }
+
+  &:focus-visible {
+    border-radius: 0.5rem;
+    outline: 2px solid var(--surface-yellow);
+    outline-offset: 1px;
   }
 
   &::after {
@@ -49,7 +55,7 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  text-decoration: none;
+  text-decoration: underline;
   gap: 0.5rem;
   font-family: var(--font-britti-sans);
   font-size: 1.125rem;
@@ -58,6 +64,17 @@
 
   @media (width >= 1024px) {
     font-size: 1.25rem;
+  }
+
+  &:hover {
+    text-decoration: none;
+    gap: 1rem;
+  }
+
+  &:focus-visible {
+    border-radius: 0.5rem;
+    outline: 2px solid var(--surface-yellow);
+    outline-offset: 1px;
   }
 
   &::after {


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [X] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [X] New functions that can be used in multiple components has been put in a `utils` directory
- [X] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Adds underline to both internal and external link which disappears on hover, animation on arrow and a yellow border on focus. 