### PR TITLE
feat(event): Internalized rich text field

### DIFF
--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -3,11 +3,11 @@ import Link from "next/link";
 import React from "react";
 
 import Badge from "src/components/badge/Badge";
-import TextSection from "src/components/customerCases/customerCase/sections/text/TextSection";
 import EventInformation from "src/components/eventInformation/eventInformation";
 import EventRegistration from "src/components/hubspot/eventRegistration/eventRegistration";
 import { SanityImage } from "src/components/image/SanityImage";
 import PageHeader from "src/components/navigation/header/PageHeader";
+import { RichText } from "src/components/richText/RichText";
 import Events from "src/components/sections/events/Events";
 import Text from "src/components/text/Text";
 import EventSpeakers from "src/components/utils/eventSpeakers/eventSpeakers";
@@ -91,11 +91,13 @@ export default async function EventPage({ params }: EventPageProps) {
     eventImage,
     subtitle,
     consultants,
-    text,
+    richTextInternalized,
     recordID,
     submitButtonText,
     time,
   } = data.event;
+
+  console.log(richTextInternalized);
 
   const consultantsFirstNames =
     consultants?.map((n) => n.employeeFirstName) ?? [];
@@ -155,12 +157,8 @@ export default async function EventPage({ params }: EventPageProps) {
               />
             )}
           </div>
-          {text && (
-            <div>
-              {text.map((section) => {
-                return <TextSection key={section._key} section={section} />;
-              })}
-            </div>
+          {richTextInternalized && (
+            <div>{<RichText value={richTextInternalized} />}</div>
           )}
         </div>
         {recordID && (

--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -155,9 +155,7 @@ export default async function EventPage({ params }: EventPageProps) {
               />
             )}
           </div>
-          {richTextInternalized && (
-            <div>{<RichText value={richTextInternalized} />}</div>
-          )}
+          {richTextInternalized && <RichText value={richTextInternalized} />}
         </div>
         {recordID && (
           <EventRegistration

--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -3,11 +3,11 @@ import Link from "next/link";
 import React from "react";
 
 import Badge from "src/components/badge/Badge";
+import TextSection from "src/components/customerCases/customerCase/sections/text/TextSection";
 import EventInformation from "src/components/eventInformation/eventInformation";
 import EventRegistration from "src/components/hubspot/eventRegistration/eventRegistration";
 import { SanityImage } from "src/components/image/SanityImage";
 import PageHeader from "src/components/navigation/header/PageHeader";
-import { RichText } from "src/components/richText/RichText";
 import Events from "src/components/sections/events/Events";
 import Text from "src/components/text/Text";
 import EventSpeakers from "src/components/utils/eventSpeakers/eventSpeakers";
@@ -91,7 +91,7 @@ export default async function EventPage({ params }: EventPageProps) {
     eventImage,
     subtitle,
     consultants,
-    richText,
+    text,
     recordID,
     submitButtonText,
     time,
@@ -155,7 +155,13 @@ export default async function EventPage({ params }: EventPageProps) {
               />
             )}
           </div>
-          {richText && <RichText value={richText} />}
+          {text && (
+            <div>
+              {text.map((section) => {
+                return <TextSection key={section._key} section={section} />;
+              })}
+            </div>
+          )}
         </div>
         {recordID && (
           <EventRegistration

--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -97,8 +97,6 @@ export default async function EventPage({ params }: EventPageProps) {
     time,
   } = data.event;
 
-  console.log(richTextInternalized);
-
   const consultantsFirstNames =
     consultants?.map((n) => n.employeeFirstName) ?? [];
 

--- a/src/components/customerCases/customerCase/sections/text/textSection.module.css
+++ b/src/components/customerCases/customerCase/sections/text/textSection.module.css
@@ -6,7 +6,6 @@
 
 .content {
   max-width: var(--max-content-width-medium);
-  word-wrap: break-word;
 }
 
 .content.framed {

--- a/src/components/customerCases/customerCase/sections/text/textSection.module.css
+++ b/src/components/customerCases/customerCase/sections/text/textSection.module.css
@@ -6,6 +6,7 @@
 
 .content {
   max-width: var(--max-content-width-medium);
+  word-wrap: break-word;
 }
 
 .content.framed {

--- a/studio/lib/interfaces/eventPosting.ts
+++ b/studio/lib/interfaces/eventPosting.ts
@@ -1,5 +1,6 @@
+import { PortableTextBlock } from "sanity";
+
 import { Consultants } from "studioShared/lib/interfaces/customerCases";
-import { TextBlock } from "studioShared/lib/interfaces/textBlock";
 
 import { IImage } from "./media";
 import { SeoData } from "./seo";
@@ -20,7 +21,8 @@ export interface IEventPosting {
   submitButtonText?: string;
   eventImage?: IImage;
   subtitle?: string;
-  text?: TextBlock[];
+  richTextInternalized?: PortableTextBlock[];
+
   seo?: SeoData;
 }
 

--- a/studio/lib/interfaces/eventPosting.ts
+++ b/studio/lib/interfaces/eventPosting.ts
@@ -22,7 +22,6 @@ export interface IEventPosting {
   eventImage?: IImage;
   subtitle?: string;
   richTextInternalized?: PortableTextBlock[];
-
   seo?: SeoData;
 }
 

--- a/studio/lib/interfaces/eventPosting.ts
+++ b/studio/lib/interfaces/eventPosting.ts
@@ -1,6 +1,5 @@
-import { PortableTextBlock } from "sanity";
-
 import { Consultants } from "studioShared/lib/interfaces/customerCases";
+import { TextBlock } from "studioShared/lib/interfaces/textBlock";
 
 import { IImage } from "./media";
 import { SeoData } from "./seo";
@@ -21,7 +20,7 @@ export interface IEventPosting {
   submitButtonText?: string;
   eventImage?: IImage;
   subtitle?: string;
-  richText?: PortableTextBlock[];
+  text?: TextBlock[];
   seo?: SeoData;
 }
 

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -135,11 +135,7 @@ export const EVENT_BY_KEY_QUERY = groq`
       createInternalPage,
       "eventImage": eventImage { ${INTERNATIONALIZED_IMAGE_FRAGMENT} },
       "subtitle": ${translatedFieldFragment("subtitle")},
-      "text": text[]{
-        ...,
-        "sectionTitle": ${translatedFieldFragment("sectionTitle")},
-        "text": ${translatedFieldFragment("text")}
-      },
+      "richTextInternalized": ${translatedFieldFragment("richTextInternalized")},
       ${SEO_FRAGMENT}
     }
   }

--- a/studio/lib/queries/specialPages.ts
+++ b/studio/lib/queries/specialPages.ts
@@ -135,7 +135,11 @@ export const EVENT_BY_KEY_QUERY = groq`
       createInternalPage,
       "eventImage": eventImage { ${INTERNATIONALIZED_IMAGE_FRAGMENT} },
       "subtitle": ${translatedFieldFragment("subtitle")},
-      richText,
+      "text": text[]{
+        ...,
+        "sectionTitle": ${translatedFieldFragment("sectionTitle")},
+        "text": ${translatedFieldFragment("text")}
+      },
       ${SEO_FRAGMENT}
     }
   }

--- a/studio/schemas/fields/text.ts
+++ b/studio/schemas/fields/text.ts
@@ -100,6 +100,6 @@ export const richTextInternalizedID = "richTextInternalized";
 
 export const richTextInternalized = defineField({
   name: richTextInternalizedID,
-  title: "Rich text Inernalized",
+  title: "Rich text internalized",
   type: "internationalizedArrayRichText",
 });

--- a/studio/schemas/fields/text.ts
+++ b/studio/schemas/fields/text.ts
@@ -95,3 +95,11 @@ export const richText = defineField({
   ],
   description: "Add and format rich text content.",
 });
+
+export const richTextInternalizedID = "richTextInternalized";
+
+export const richTextInternalized = defineField({
+  name: richTextInternalizedID,
+  title: "Rich text Inernalized",
+  type: "internationalizedArrayRichText",
+});

--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -2,6 +2,7 @@ import { defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
 import image from "studio/schemas/fields/media";
+import { richTextInternalized } from "studio/schemas/fields/text";
 import { allTranslations, firstTranslation } from "studio/utils/i18n";
 import {
   validateInternationalizedArray,
@@ -194,9 +195,7 @@ const eventPosting = defineType({
       hidden: ({ parent }) => !parent?.createInternalPage,
     },
     {
-      name: "richTextInternalized",
-      title: "Rich text field",
-      type: "internationalizedArrayRichText",
+      ...richTextInternalized,
       description: "Adds text under the page",
       hidden: ({ parent }) => !parent?.createInternalPage,
     },

--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -2,12 +2,12 @@ import { defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
 import image from "studio/schemas/fields/media";
-import { richText } from "studio/schemas/fields/text";
 import { allTranslations, firstTranslation } from "studio/utils/i18n";
 import {
   validateInternationalizedArray,
   validateInternationalizedField,
 } from "studio/utils/internationalizedFieldValidator";
+import textBlock from "studioShared/schemas/objects/textBlock";
 
 import seoWithoutImage from "./seoWithoutImage";
 
@@ -195,7 +195,11 @@ const eventPosting = defineType({
       hidden: ({ parent }) => !parent?.createInternalPage,
     },
     {
-      ...richText,
+      name: "text",
+      title: "Blocks of text",
+      type: "array",
+      description: "Adds text blocks to the page",
+      of: [textBlock],
       hidden: ({ parent }) => !parent?.createInternalPage,
     },
     {

--- a/studio/schemas/objects/eventPosting.ts
+++ b/studio/schemas/objects/eventPosting.ts
@@ -7,7 +7,6 @@ import {
   validateInternationalizedArray,
   validateInternationalizedField,
 } from "studio/utils/internationalizedFieldValidator";
-import textBlock from "studioShared/schemas/objects/textBlock";
 
 import seoWithoutImage from "./seoWithoutImage";
 
@@ -195,11 +194,10 @@ const eventPosting = defineType({
       hidden: ({ parent }) => !parent?.createInternalPage,
     },
     {
-      name: "text",
-      title: "Blocks of text",
-      type: "array",
-      description: "Adds text blocks to the page",
-      of: [textBlock],
+      name: "richTextInternalized",
+      title: "Rich text field",
+      type: "internationalizedArrayRichText",
+      description: "Adds text under the page",
       hidden: ({ parent }) => !parent?.createInternalPage,
     },
     {


### PR DESCRIPTION
## Description
Changes `eventPosting` schema to use internalized rich text field instead of just rich text field. Also added `richTextInternalized` as a field for reuse

## Screenshots
<img width="765" height="922" alt="image" src="https://github.com/user-attachments/assets/9946c86c-c0d3-4b15-b499-da5731ad6ee1" />


## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
