### PR TITLE
fix: event registration unsubscribe typo

### DIFF
--- a/src/utils/translations/no.json
+++ b/src/utils/translations/no.json
@@ -38,7 +38,7 @@
       "emailConfirmation": "Vi sender kun epost til deg som en påminnelse eller om det er endringer",
       "registerAnother": "Ønsker du å melde på flere?",
       "linkText": "Vis skjema.",
-      "unsubscribeNote": "For avmelding se se vår",
+      "unsubscribeNote": "For avmelding se vår",
       "forEvent": "for arrangementer",
       "imgAlt": "blå boks med glad ansikt"
     }


### PR DESCRIPTION
## Description
Remove duplicate word se in event registration unsubscribe norwegian translation

## Checklist

<!-- All must be checked before you merge -->

- [x] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
