### PR TITLE
feat: Remove button tag from event page

### DIFF
--- a/src/app/(main)/[locale]/event/[...key]/event.module.css
+++ b/src/app/(main)/[locale]/event/[...key]/event.module.css
@@ -8,14 +8,11 @@
   padding-bottom: var(--padding-xl);
 }
 
-.badge {
-  width: fit-content;
-}
-
 .eventInfo {
   display: flex;
   flex-direction: column;
   gap: var(--padding-m);
+  padding-top: var(--padding-m);
 }
 
 .title {

--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from "next";
-import Link from "next/link";
 import React from "react";
 
 import Badge from "src/components/badge/Badge";
@@ -118,12 +117,6 @@ export default async function EventPage({ params }: EventPageProps) {
       />
       <div className={styles.contentWrapper}>
         <div className={styles.eventInfo}>
-          <Link href={`/${params.locale}/events`}>
-            <Badge badgeColor="#3840FF" className={styles.badge}>
-              Event
-            </Badge>
-          </Link>
-
           <Text type="h1">{eventTitle}</Text>
           <Text type="bodyXl">{subtitle}</Text>
           <EventInformation


### PR DESCRIPTION
## Checklist
Removed tag that works as a button from eventpage. 

<img width="1432" height="798" alt="Screenshot 2025-10-02 at 12 27 30" src="https://github.com/user-attachments/assets/1bcd07c5-ddd6-4268-9ef5-f2e92003583b" />

Relates to: #1294  

<!-- All must be checked before you merge -->

- [x] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
