### PR TITLE
fix: gap between tag elements in eventPostings

### DIFF
--- a/src/components/eventPosting/EventPosting.tsx
+++ b/src/components/eventPosting/EventPosting.tsx
@@ -62,16 +62,11 @@ export default function EventPosting({
 
       <div className={`${styles.flex} ${styles.eventCardBottomfield}`}>
         {eventPostingTags.length > 0 && (
-          <div>
+          <div className={styles.badgeWrapper}>
             {eventPostingTags
               .filter((tag) => tag)
               .map((tag, index) => (
-                <Badge
-                  key={index}
-                  className={styles.themes}
-                  badgeColor="#FAFAFA"
-                  borderColor="#2D2D2D"
-                >
+                <Badge key={index} badgeColor="#FAFAFA" borderColor="#2D2D2D">
                   {tag}
                 </Badge>
               ))}

--- a/src/components/eventPosting/eventPosting.module.css
+++ b/src/components/eventPosting/eventPosting.module.css
@@ -32,6 +32,7 @@
       top: 1rem;
       right: 1rem;
     }
+
     &[target="_blank"].eventPosting::after {
       transform: rotate(-45deg);
     }
@@ -50,8 +51,10 @@
   flex-wrap: wrap;
 }
 
-.themes {
-  margin-left: var(--padding-xs);
+.badgeWrapper {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .eventCardBottomfield {


### PR DESCRIPTION
## Checklist

Fix spacing issues with tag-row as described here:  https://variantas.slack.com/archives/C09CT5VP6V9/p1759396367458469


<!-- All must be checked before you merge -->

- [x] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
