### PR TITLE
feat: adds punch line component for sales pitches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@visx/visx": "^3.12.0",
         "auto-changelog": "^2.5.0",
         "husky": "^9.1.7",
+        "motion": "^12.23.22",
         "negotiator": "^0.6.3",
         "next": "^14.2.15",
         "next-intl": "^3.24.0",
@@ -14439,6 +14440,32 @@
         "node": "*"
       }
     },
+    "node_modules/motion": {
+      "version": "12.23.22",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.22.tgz",
+      "integrity": "sha512-iSq6X9vLHbeYwmHvhK//+U74ROaPnZmBuy60XZzqNl0QtZkWfoZyMDHYnpKuWFv0sNMqHgED8aCXk94LCoQPGg==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.22",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/motion-dom": {
       "version": "11.16.4",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.16.4.tgz",
@@ -14452,6 +14479,48 @@
       "version": "11.16.0",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.16.0.tgz",
       "integrity": "sha512-ngdWPjg31rD4WGXFi0eZ00DQQqKKu04QExyv/ymlC+3k+WIgYVFbt6gS5JsFPbJODTF/r8XiE/X+SsoT9c0ocw==",
+      "license": "MIT"
+    },
+    "node_modules/motion/node_modules/framer-motion": {
+      "version": "12.23.22",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.22.tgz",
+      "integrity": "sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.21",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion/node_modules/motion-dom": {
+      "version": "12.23.21",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.21.tgz",
+      "integrity": "sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion/node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
       "license": "MIT"
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@visx/visx": "^3.12.0",
     "auto-changelog": "^2.5.0",
     "husky": "^9.1.7",
+    "motion": "^12.23.22",
     "negotiator": "^0.6.3",
     "next": "^14.2.15",
     "next-intl": "^3.24.0",

--- a/src/app/studio/layout.tsx
+++ b/src/app/studio/layout.tsx
@@ -11,7 +11,8 @@ export default async function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      {/* Override padding from global.css. Hackish but just for studio, as the padding is annoying */}
+      <body style={{ padding: "0 !important" }}>
         {children}
         {draftMode().isEnabled && <LiveVisualEditing />}
       </body>

--- a/src/components/sections/punchLineBox/FadedText.tsx
+++ b/src/components/sections/punchLineBox/FadedText.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  AnimatePresence,
+  type HTMLMotionProps,
+  type Transition,
+  motion,
+} from "motion/react";
+import * as React from "react";
+
+import { cn } from "src/utils/css";
+
+import style from "./punchLineBox.module.css";
+
+type FadingTextProps = {
+  transition?: Transition;
+  key: string;
+  containerClassName?: string;
+} & HTMLMotionProps<"div">;
+
+function FadingText({
+  children,
+  transition = { duration: 0.3, ease: "easeOut", delay: 0.7 },
+  containerClassName,
+  ...props
+}: FadingTextProps) {
+  return (
+    <div className={cn(style.overflowHidden, containerClassName)}>
+      <AnimatePresence mode="wait">
+        <motion.div
+          transition={transition}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          {...props}
+        >
+          {children}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export { FadingText, type FadingTextProps };

--- a/src/components/sections/punchLineBox/FadingText.tsx
+++ b/src/components/sections/punchLineBox/FadingText.tsx
@@ -6,7 +6,6 @@ import {
   type Transition,
   motion,
 } from "motion/react";
-import * as React from "react";
 
 import { cn } from "src/utils/css";
 
@@ -14,20 +13,22 @@ import style from "./punchLineBox.module.css";
 
 type FadingTextProps = {
   transition?: Transition;
-  key: string;
+  animationKey: string;
   containerClassName?: string;
 } & HTMLMotionProps<"div">;
 
 function FadingText({
   children,
-  transition = { duration: 0.3, ease: "easeOut", delay: 0.7 },
+  animationKey,
+  transition = { duration: 0.3, ease: "easeOut", delay: 0.2 },
   containerClassName,
   ...props
 }: FadingTextProps) {
   return (
     <div className={cn(style.overflowHidden, containerClassName)}>
-      <AnimatePresence mode="wait">
+      <AnimatePresence mode="wait" initial={false}>
         <motion.div
+          key={animationKey}
           transition={transition}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}

--- a/src/components/sections/punchLineBox/PunchLineBox.tsx
+++ b/src/components/sections/punchLineBox/PunchLineBox.tsx
@@ -1,0 +1,10 @@
+import { PunchLineBoxSection } from "studio/lib/interfaces/pages";
+
+export interface PunchLineBoxProps {
+  section: PunchLineBoxSection;
+  language: string;
+}
+
+export default function PunchLineBox({ section }: PunchLineBoxProps) {
+  return <div>{section.mainPunchLine}</div>;
+}

--- a/src/components/sections/punchLineBox/PunchLineBox.tsx
+++ b/src/components/sections/punchLineBox/PunchLineBox.tsx
@@ -1,38 +1,34 @@
-"use client";
-import { useEffect, useState } from "react";
-
+import Smiley from "src/components/smiley/Smiley";
+import { fetchEmployeesByEmails } from "src/utils/employees";
 import { PunchLineBoxSection } from "studio/lib/interfaces/pages";
+
+import style from "./punchLineBox.module.css";
+import PunchLineBoxClient from "./PunchLineBoxClient";
+import { pickRandomSentence } from "./utils";
 
 export interface PunchLineBoxProps {
   section: PunchLineBoxSection;
-  language: string;
 }
 
-export default function PunchLineBox({ section }: PunchLineBoxProps) {
-  console.log(section);
-  const randomSentence = usePickPeriodicallyRandomSentence(section.sentences);
-  return <div>{randomSentence.mainPunchLine}</div>;
-}
+export default async function PunchLineBox({ section }: PunchLineBoxProps) {
+  const contactPoints = await fetchEmployeesByEmails(
+    section.sentences.map((sentence) => sentence.email),
+  );
 
-function usePickPeriodicallyRandomSentence(
-  sentences: PunchLineBoxSection["sentences"],
-  intervalInSeconds: number = 10,
-) {
-  const [randomSentence, setRandomSentence] = useState<
-    PunchLineBoxSection["sentences"][number]
-  >(pickRandomSentence(sentences));
+  if (!contactPoints.ok) {
+    return null;
+  }
 
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      setRandomSentence(pickRandomSentence(sentences));
-    }, intervalInSeconds * 1000);
-
-    return () => clearInterval(intervalId);
-  }, [sentences, intervalInSeconds]);
-
-  return randomSentence;
-}
-
-function pickRandomSentence(sentences: PunchLineBoxSection["sentences"]) {
-  return sentences[Math.floor(Math.random() * sentences.length)];
+  return (
+    <article className={style.punchLineBox}>
+      <Smiley smileyType="shock" smileySide="right" />
+      <div className={style.content}>
+        <PunchLineBoxClient
+          section={section}
+          initialSentence={pickRandomSentence(section.sentences)}
+          contactPoints={contactPoints.value}
+        />
+      </div>
+    </article>
+  );
 }

--- a/src/components/sections/punchLineBox/PunchLineBox.tsx
+++ b/src/components/sections/punchLineBox/PunchLineBox.tsx
@@ -1,3 +1,6 @@
+"use client";
+import { useEffect, useState } from "react";
+
 import { PunchLineBoxSection } from "studio/lib/interfaces/pages";
 
 export interface PunchLineBoxProps {
@@ -6,5 +9,30 @@ export interface PunchLineBoxProps {
 }
 
 export default function PunchLineBox({ section }: PunchLineBoxProps) {
-  return <div>{section.mainPunchLine}</div>;
+  console.log(section);
+  const randomSentence = usePickPeriodicallyRandomSentence(section.sentences);
+  return <div>{randomSentence.mainPunchLine}</div>;
+}
+
+function usePickPeriodicallyRandomSentence(
+  sentences: PunchLineBoxSection["sentences"],
+  intervalInSeconds: number = 10,
+) {
+  const [randomSentence, setRandomSentence] = useState<
+    PunchLineBoxSection["sentences"][number]
+  >(pickRandomSentence(sentences));
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setRandomSentence(pickRandomSentence(sentences));
+    }, intervalInSeconds * 1000);
+
+    return () => clearInterval(intervalId);
+  }, [sentences, intervalInSeconds]);
+
+  return randomSentence;
+}
+
+function pickRandomSentence(sentences: PunchLineBoxSection["sentences"]) {
+  return sentences[Math.floor(Math.random() * sentences.length)];
 }

--- a/src/components/sections/punchLineBox/PunchLineBox.tsx
+++ b/src/components/sections/punchLineBox/PunchLineBox.tsx
@@ -25,7 +25,7 @@ export default async function PunchLineBox({ section }: PunchLineBoxProps) {
       <div className={style.content}>
         <PunchLineBoxClient
           section={section}
-          initialSentence={pickRandomSentence(section.sentences)}
+          initialSentence={pickRandomSentence(section.sentences)[0]}
           contactPoints={contactPoints.value}
         />
       </div>

--- a/src/components/sections/punchLineBox/PunchLineBoxClient.tsx
+++ b/src/components/sections/punchLineBox/PunchLineBoxClient.tsx
@@ -5,7 +5,7 @@ import Text from "src/components/text/Text";
 import { ChewbaccaEmployee } from "src/types/employees";
 import { PunchLineBoxSection } from "studio/lib/interfaces/pages";
 
-import { FadingText } from "./FadedText";
+import { FadingText } from "./FadingText";
 import style from "./punchLineBox.module.css";
 import { RotatingText } from "./RotatingText";
 import { pickRandomSentence } from "./utils";
@@ -14,23 +14,29 @@ export interface PunchLineBoxProps {
   section: PunchLineBoxSection;
   initialSentence: PunchLineBoxSection["sentences"][number];
   contactPoints: ChewbaccaEmployee[];
+  intervalInSeconds?: number;
 }
 
 export default function PunchLineBoxClient({
   section,
   initialSentence,
   contactPoints,
+  intervalInSeconds = 10,
 }: PunchLineBoxProps) {
-  const randomSentence = usePickPeriodicallyRandomSentence(
+  const [randomSentence, key] = usePickPeriodicallyRandomSentence(
     section.sentences,
     initialSentence,
+    intervalInSeconds,
   );
   return (
     <>
       <Text type="h2">
-        <RotatingText text={randomSentence.mainPunchLine} />
+        <RotatingText
+          animationKey={`${key}-title`}
+          text={randomSentence.mainPunchLine}
+        />
       </Text>
-      <FadingText key={randomSentence.mainPunchLine}>
+      <FadingText animationKey={`${key}-line`}>
         <ActionLineTemplate
           email={randomSentence.email}
           contactPoints={contactPoints}
@@ -80,17 +86,20 @@ function usePickPeriodicallyRandomSentence(
   sentences: PunchLineBoxSection["sentences"],
   initialSentence: PunchLineBoxSection["sentences"][number],
   intervalInSeconds: number = 10,
-) {
+): [PunchLineBoxSection["sentences"][number], number] {
   const [randomSentence, setRandomSentence] =
     useState<PunchLineBoxSection["sentences"][number]>(initialSentence);
+  const [key, setKey] = useState<number>(0);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      setRandomSentence(pickRandomSentence(sentences));
+      const [randomSentence, key] = pickRandomSentence(sentences);
+      setRandomSentence(randomSentence);
+      setKey(key);
     }, intervalInSeconds * 1000);
 
     return () => clearInterval(intervalId);
   }, [sentences, intervalInSeconds]);
 
-  return randomSentence;
+  return [randomSentence, key];
 }

--- a/src/components/sections/punchLineBox/PunchLineBoxClient.tsx
+++ b/src/components/sections/punchLineBox/PunchLineBoxClient.tsx
@@ -1,0 +1,96 @@
+"use client";
+import { Fragment, useEffect, useState } from "react";
+
+import Text from "src/components/text/Text";
+import { ChewbaccaEmployee } from "src/types/employees";
+import { PunchLineBoxSection } from "studio/lib/interfaces/pages";
+
+import { FadingText } from "./FadedText";
+import style from "./punchLineBox.module.css";
+import { RotatingText } from "./RotatingText";
+import { pickRandomSentence } from "./utils";
+
+export interface PunchLineBoxProps {
+  section: PunchLineBoxSection;
+  initialSentence: PunchLineBoxSection["sentences"][number];
+  contactPoints: ChewbaccaEmployee[];
+}
+
+export default function PunchLineBoxClient({
+  section,
+  initialSentence,
+  contactPoints,
+}: PunchLineBoxProps) {
+  const randomSentence = usePickPeriodicallyRandomSentence(
+    section.sentences,
+    initialSentence,
+  );
+  return (
+    <>
+      <Text type="h2">
+        <RotatingText text={randomSentence.mainPunchLine} />
+      </Text>
+      <FadingText key={randomSentence.mainPunchLine}>
+        <ActionLineTemplate
+          email={randomSentence.email}
+          contactPoints={contactPoints}
+        >
+          {randomSentence.actionLine}
+        </ActionLineTemplate>
+      </FadingText>
+    </>
+  );
+}
+
+function ActionLineTemplate({
+  children,
+  email,
+  contactPoints,
+}: {
+  children: string;
+  email: string;
+  contactPoints: ChewbaccaEmployee[];
+}) {
+  const contactPoint = contactPoints?.find((cp) => cp.email === email);
+  const matches = children.matchAll(/([^\\[]*)(\[\[contact\]\])([^\\[]*)/gm);
+
+  const newChildren = matches
+    .map((match, i) => {
+      return [
+        <Fragment key={i + "-1"}>{match[1]}</Fragment>,
+        !contactPoint ? (
+          <Fragment key={i + "-2"}>Variant</Fragment>
+        ) : (
+          <a
+            key={i + "-2"}
+            href={`mailto:${contactPoint?.email}`}
+            className={style.actionLink}
+          >
+            {contactPoint?.name}
+          </a>
+        ),
+        <Fragment key={i + "-3"}>{match[3]}</Fragment>,
+      ];
+    })
+    .toArray();
+  return <Text type="bodyBig">{newChildren.flat()}</Text>;
+}
+
+function usePickPeriodicallyRandomSentence(
+  sentences: PunchLineBoxSection["sentences"],
+  initialSentence: PunchLineBoxSection["sentences"][number],
+  intervalInSeconds: number = 10,
+) {
+  const [randomSentence, setRandomSentence] =
+    useState<PunchLineBoxSection["sentences"][number]>(initialSentence);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setRandomSentence(pickRandomSentence(sentences));
+    }, intervalInSeconds * 1000);
+
+    return () => clearInterval(intervalId);
+  }, [sentences, intervalInSeconds]);
+
+  return randomSentence;
+}

--- a/src/components/sections/punchLineBox/PunchLineBoxClient.tsx
+++ b/src/components/sections/punchLineBox/PunchLineBoxClient.tsx
@@ -60,8 +60,8 @@ function ActionLineTemplate({
   const contactPoint = contactPoints?.find((cp) => cp.email === email);
   const matches = children.matchAll(/([^\\[]*)(\[\[contact\]\])([^\\[]*)/gm);
 
-  const newChildren = matches
-    .map((match, i) => {
+  const newChildren = Array.from(
+    matches.map((match, i) => {
       return [
         <Fragment key={i + "-1"}>{match[1]}</Fragment>,
         !contactPoint ? (
@@ -77,8 +77,8 @@ function ActionLineTemplate({
         ),
         <Fragment key={i + "-3"}>{match[3]}</Fragment>,
       ];
-    })
-    .toArray();
+    }),
+  );
   return <Text type="bodyBig">{newChildren.flat()}</Text>;
 }
 

--- a/src/components/sections/punchLineBox/RotatingText.tsx
+++ b/src/components/sections/punchLineBox/RotatingText.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+  AnimatePresence,
+  type HTMLMotionProps,
+  type Transition,
+  motion,
+} from "motion/react";
+import * as React from "react";
+
+import { cn } from "src/utils/css";
+
+import style from "./punchLineBox.module.css";
+
+type RotatingTextProps = {
+  text: string | string[];
+  duration?: number;
+  transition?: Transition;
+  y?: number;
+  containerClassName?: string;
+} & HTMLMotionProps<"div">;
+
+function RotatingText({
+  text,
+  y = -50,
+  duration = 2000,
+  transition = { duration: 0.3, ease: "easeOut" },
+  containerClassName,
+  ...props
+}: RotatingTextProps) {
+  const [index, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!Array.isArray(text)) return;
+    const interval = setInterval(() => {
+      setIndex((prevIndex) => (prevIndex + 1) % text.length);
+    }, duration);
+    return () => clearInterval(interval);
+  }, [text, duration]);
+
+  const currentText = Array.isArray(text) ? text[index] : text;
+
+  return (
+    <div className={cn(style.overflowHidden, containerClassName)}>
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={currentText}
+          transition={transition}
+          initial={{ opacity: 0, y: -y }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y }}
+          {...props}
+        >
+          {currentText}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export { RotatingText, type RotatingTextProps };

--- a/src/components/sections/punchLineBox/RotatingText.tsx
+++ b/src/components/sections/punchLineBox/RotatingText.tsx
@@ -13,54 +13,37 @@ import { cn } from "src/utils/css";
 import style from "./punchLineBox.module.css";
 
 type RotatingTextProps = {
-  text: string | string[];
+  text: string;
   duration?: number;
   transition?: Transition;
   y?: number;
   containerClassName?: string;
+  animationKey: string;
 } & HTMLMotionProps<"div">;
 
 function RotatingText({
   text,
   y = -50,
-  duration = 2000,
+  animationKey,
   transition = { duration: 0.3, ease: "easeOut" },
   containerClassName,
   ...props
 }: RotatingTextProps) {
-  const [index, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    if (!Array.isArray(text)) return;
-    const interval = setInterval(() => {
-      setIndex((prevIndex) => (prevIndex + 1) % text.length);
-    }, duration);
-    return () => clearInterval(interval);
-  }, [text, duration]);
-
-  const currentText = Array.isArray(text) ? text[index] : text;
-
   return (
-    <span
-      className={cn(
-        style.textOverflow,
-        style.overflowHidden,
-        containerClassName,
-      )}
-    >
-      <AnimatePresence mode="wait">
-        <motion.span
-          key={currentText}
+    <div className={cn(style.overflowHidden, containerClassName)}>
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={animationKey}
           transition={transition}
           initial={{ opacity: 0, y: -y }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y }}
           {...props}
         >
-          {currentText}
-        </motion.span>
+          {text}
+        </motion.div>
       </AnimatePresence>
-    </span>
+    </div>
   );
 }
 

--- a/src/components/sections/punchLineBox/RotatingText.tsx
+++ b/src/components/sections/punchLineBox/RotatingText.tsx
@@ -41,9 +41,15 @@ function RotatingText({
   const currentText = Array.isArray(text) ? text[index] : text;
 
   return (
-    <div className={cn(style.overflowHidden, containerClassName)}>
+    <span
+      className={cn(
+        style.textOverflow,
+        style.overflowHidden,
+        containerClassName,
+      )}
+    >
       <AnimatePresence mode="wait">
-        <motion.div
+        <motion.span
           key={currentText}
           transition={transition}
           initial={{ opacity: 0, y: -y }}
@@ -52,9 +58,9 @@ function RotatingText({
           {...props}
         >
           {currentText}
-        </motion.div>
+        </motion.span>
       </AnimatePresence>
-    </div>
+    </span>
   );
 }
 

--- a/src/components/sections/punchLineBox/punchLineBox.module.css
+++ b/src/components/sections/punchLineBox/punchLineBox.module.css
@@ -1,0 +1,39 @@
+.overflowHidden {
+  overflow: hidden;
+}
+
+.actionLink {
+  color: var(--text-link);
+}
+
+.actionLink:hover {
+  text-decoration: underline;
+}
+
+.actionLink:focus-visible {
+  text-decoration: underline;
+}
+
+.actionLink:active {
+  text-decoration: underline;
+}
+
+.punchLineBox {
+  margin: 1rem auto;
+  padding: var(--padding-m) var(--padding-l) var(--padding-l);
+  width: 100%;
+  max-width: var(--max-content-width-large);
+  background-color: var(--surface-green-subtle);
+  border-radius: var(--radius-small) calc(var(--radius-large) * 4)
+    var(--radius-small) var(--radius-small);
+  display: flex;
+  flex-direction: column;
+}
+
+.content {
+  margin-top: auto;
+  min-height: 12rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+}

--- a/src/components/sections/punchLineBox/punchLineBox.module.css
+++ b/src/components/sections/punchLineBox/punchLineBox.module.css
@@ -2,6 +2,11 @@
   overflow: hidden;
 }
 
+.textOverflow {
+  overflow-wrap: break-word;
+  hyphens: auto;
+}
+
 .actionLink {
   color: var(--text-link);
 }

--- a/src/components/sections/punchLineBox/utils.ts
+++ b/src/components/sections/punchLineBox/utils.ts
@@ -1,0 +1,5 @@
+export function pickRandomSentence(
+  sentences: PunchLineBoxSection["sentences"],
+) {
+  return sentences[Math.floor(Math.random() * sentences.length)];
+}

--- a/src/components/sections/punchLineBox/utils.ts
+++ b/src/components/sections/punchLineBox/utils.ts
@@ -1,5 +1,8 @@
+import { PunchLineBoxSection } from "studio/lib/interfaces/pages";
+
 export function pickRandomSentence(
   sentences: PunchLineBoxSection["sentences"],
-) {
-  return sentences[Math.floor(Math.random() * sentences.length)];
+): [PunchLineBoxSection["sentences"][number], number] {
+  const key = Math.floor(Math.random() * sentences.length);
+  return [sentences[key], key];
 }

--- a/src/components/smiley/Smiley.tsx
+++ b/src/components/smiley/Smiley.tsx
@@ -1,0 +1,42 @@
+import { CSSProperties } from "react";
+
+import styles from "./smiley.module.css";
+
+const smileys = {
+  shock: {
+    url: "url(/_assets/smiley-face-shock.svg)",
+    height: "4.1875rem",
+    width: "4.1875rem",
+  },
+  happy: {
+    url: "url(/_assets/smiley-face-happy.svg)",
+    width: "4.86119rem",
+    height: "4.86119rem",
+  },
+  smug: {
+    url: "url(/_assets/smiley-face-smug.svg)",
+    width: "4.375rem",
+    height: "4.375rem",
+  },
+} as const;
+
+export type SmileyType = keyof typeof smileys;
+export type SmileyAlign = "left" | "right";
+
+export type SmileyBoxProps = {
+  smileyType?: SmileyType;
+  smileySide?: SmileyAlign;
+};
+
+export default function Smiley({ smileySide, smileyType }: SmileyBoxProps) {
+  const smiley = smileys[smileyType ?? "happy"];
+  const cssVariables = {
+    "--smiley-url": smiley.url,
+    "--smiley-width": smiley.width,
+    "--smiley-height": smiley.height,
+    "--smiley-align":
+      (smileySide ?? "left") === "left" ? "flex-start" : "flex-end",
+  } as CSSProperties;
+
+  return <div style={cssVariables} className={styles.smiley} />;
+}

--- a/src/components/smiley/smiley.module.css
+++ b/src/components/smiley/smiley.module.css
@@ -1,0 +1,13 @@
+.smiley {
+  align-self: var(--smiley-align);
+
+  &::before {
+    content: "";
+    display: block;
+    width: var(--smiley-width);
+    height: var(--smiley-height);
+    mask: var(--smiley-url) no-repeat center;
+    mask-size: cover;
+    background-color: var(--text-primary);
+  }
+}

--- a/src/components/smileyBox/SmileyBox.tsx
+++ b/src/components/smileyBox/SmileyBox.tsx
@@ -1,26 +1,9 @@
 import { CSSProperties } from "react";
 
+import Smiley, { SmileyAlign, SmileyType } from "src/components/smiley/Smiley";
 import Text from "src/components/text/Text";
 
 import styles from "./smileyBox.module.css";
-
-const smileys = {
-  shock: {
-    url: "url(/_assets/smiley-face-shock.svg)",
-    height: "4.1875rem",
-    width: "4.1875rem",
-  },
-  happy: {
-    url: "url(/_assets/smiley-face-happy.svg)",
-    width: "4.86119rem",
-    height: "4.86119rem",
-  },
-  smug: {
-    url: "url(/_assets/smiley-face-smug.svg)",
-    width: "4.375rem",
-    height: "4.375rem",
-  },
-} as const;
 
 const backgroundColors = {
   green: "#dafbdc",
@@ -30,8 +13,8 @@ const backgroundColors = {
 
 type SmileyBoxProps = {
   backgroundColor?: keyof typeof backgroundColors;
-  smileyType?: keyof typeof smileys;
-  smileySide?: "left" | "right";
+  smileyType?: SmileyType;
+  smileySide?: SmileyAlign;
   description: string;
 };
 
@@ -41,19 +24,13 @@ export default function SmileyBox({
   smileyType,
   description,
 }: SmileyBoxProps) {
-  const smiley = smileys[smileyType ?? "happy"];
   const cssVariables = {
-    "--smiley-url": smiley.url,
-    "--smiley-width": smiley.width,
-    "--smiley-height": smiley.height,
     "--smiley-background-color": backgroundColors[backgroundColor ?? "green"],
-    "--smiley-align":
-      (smileySide ?? "left") === "left" ? "flex-start" : "flex-end",
   } as CSSProperties;
 
   return (
     <div className={styles.wrapper} style={cssVariables}>
-      <div className={styles.smiley} />
+      <Smiley smileySide={smileySide} smileyType={smileyType} />
       <div className={styles.description}>
         <Text type={"h3"}>{description}</Text>
       </div>

--- a/src/components/smileyBox/smileyBox.module.css
+++ b/src/components/smileyBox/smileyBox.module.css
@@ -21,20 +21,6 @@
   }
 }
 
-.smiley {
-  align-self: var(--smiley-align);
-
-  &::before {
-    content: "";
-    display: block;
-    width: var(--smiley-width);
-    height: var(--smiley-height);
-    mask: var(--smiley-url) no-repeat center;
-    mask-size: cover;
-    background-color: var(--text-primary);
-  }
-}
-
 .description {
   align-self: stretch;
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -110,6 +110,7 @@ html {
   --surface-blue: var(--Blue-500);
   --surface-green: var(--Green-400);
   --surface-green-light: var(--Green-100);
+  --surface-green-subtle: var(--Green-50);
   --surface-blue-light: var(--Blue-200);
   --surface-red-light: var(--Red-100);
   --surface-yellow-light: var(--Yellow-50);

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -23,6 +23,7 @@ import Learning from "src/components/sections/learning/Learning";
 import { LogoSalad } from "src/components/sections/logoSalad/LogoSalad";
 import LogoSaladPreview from "src/components/sections/logoSalad/LogoSaladPreview";
 import Openness from "src/components/sections/openness/Openness";
+import PunchLineBox from "src/components/sections/punchLineBox/PunchLineBox";
 import SplitSection from "src/components/sections/splitSection/SplitSection";
 import TextContent from "src/components/sections/textContent/TextContent";
 import { Locale } from "src/i18n/routing";
@@ -192,6 +193,8 @@ const SectionRenderer = ({
         initialData,
         language as Locale,
       );
+    case "punchLineBox":
+      return <PunchLineBox section={section} language={language} />;
     case "contactBox":
       return <ContactBox section={section} language={language} />;
     case "employees":

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -194,7 +194,7 @@ const SectionRenderer = ({
         language as Locale,
       );
     case "punchLineBox":
-      return <PunchLineBox section={section} language={language} />;
+      return <PunchLineBox section={section} />;
     case "contactBox":
       return <ContactBox section={section} language={language} />;
     case "employees":

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -197,9 +197,11 @@ export interface EmployeeHighlightItem {
 export interface PunchLineBoxSection {
   _type: "punchLineBox";
   _key: string;
-  mainPunchLine?: string;
-  actionLine?: string;
-  email?: string;
+  sentences: {
+    mainPunchLine: string;
+    actionLine: string;
+    email: string;
+  }[];
 }
 
 export interface EmployeeHighlightSection {

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -194,6 +194,14 @@ export interface EmployeeHighlightItem {
   phone?: string;
 }
 
+export interface PunchLineBoxSection {
+  _type: "punchLineBox";
+  _key: string;
+  mainPunchLine?: string;
+  actionLine?: string;
+  email?: string;
+}
+
 export interface EmployeeHighlightSection {
   _type: "employeeHighlight";
   _key: string;
@@ -262,6 +270,7 @@ export type Section =
   | JobsSection
   | EventsSection
   | OpennessSection
+  | PunchLineBoxSection
   | GenerositySection
   | LearningSection
   | HandbookSection

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -151,10 +151,13 @@ const SECTIONS_FRAGMENT = groq`
       "description": ${translatedFieldFragment("description")},
       "image": image { ${INTERNATIONALIZED_IMAGE_FRAGMENT} }
     },
-    _type == "opennessSection" => {
+    _type == "punchLineBox" => {
+      "sentences": sentences[] {
       ...,
-      "mainPunchLine": ${translatedFieldFragment("basicTitle")},
-      "actionLine": ${translatedFieldFragment("description")}
+        "mainPunchLine": ${translatedFieldFragment("mainPunchLine")},
+        "actionLine": ${translatedFieldFragment("actionLine")},
+        "email": ${translatedFieldFragment("email")}
+      }
     },
     _type == "generositySection" => {
       ...,

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -153,10 +153,9 @@ const SECTIONS_FRAGMENT = groq`
     },
     _type == "punchLineBox" => {
       "sentences": sentences[] {
-      ...,
+        ...,
         "mainPunchLine": ${translatedFieldFragment("mainPunchLine")},
         "actionLine": ${translatedFieldFragment("actionLine")},
-        "email": ${translatedFieldFragment("email")}
       }
     },
     _type == "generositySection" => {

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -151,6 +151,11 @@ const SECTIONS_FRAGMENT = groq`
       "description": ${translatedFieldFragment("description")},
       "image": image { ${INTERNATIONALIZED_IMAGE_FRAGMENT} }
     },
+    _type == "opennessSection" => {
+      ...,
+      "mainPunchLine": ${translatedFieldFragment("basicTitle")},
+      "actionLine": ${translatedFieldFragment("description")}
+    },
     _type == "generositySection" => {
       ...,
       "basicTitle": ${translatedFieldFragment("basicTitle")},

--- a/studio/schema.ts
+++ b/studio/schema.ts
@@ -26,6 +26,7 @@ import { compensationCalculator } from "./schemas/objects/sections/compensation-
 import { employeeHighlightSection } from "./schemas/objects/sections/employeeHighlight";
 import { fieldGrid } from "./schemas/objects/sections/fieldGrid";
 import { fields } from "./schemas/objects/sections/fields";
+import { punchLineBox } from "./schemas/objects/sections/punchLineBox";
 import seo from "./schemas/objects/seo";
 import { socialMedia } from "./schemas/objects/socialMedia";
 
@@ -57,6 +58,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     eventPostings,
     employeeHighlightSection,
     compensationCalculator,
+    punchLineBox,
     fields,
     fieldGrid,
   ],

--- a/studio/schemas/documents/pageBuilder.ts
+++ b/studio/schemas/documents/pageBuilder.ts
@@ -19,6 +19,7 @@ import { jobs } from "studio/schemas/objects/sections/jobs";
 import { learningSection } from "studio/schemas/objects/sections/learning";
 import logoSalad from "studio/schemas/objects/sections/logoSalad";
 import { opennessSection } from "studio/schemas/objects/sections/openness";
+import { punchLineBox } from "studio/schemas/objects/sections/punchLineBox";
 import splitSection from "studio/schemas/objects/sections/splitSection";
 import { textContent } from "studio/schemas/objects/sections/textContent";
 import seo from "studio/schemas/objects/seo";
@@ -64,6 +65,7 @@ const pageBuilder = defineType({
         opennessSection,
         generositySection,
         learningSection,
+        punchLineBox,
         textContent,
         handbookSection,
         splitSection,

--- a/studio/schemas/objects/sections/punchLineBox.ts
+++ b/studio/schemas/objects/sections/punchLineBox.ts
@@ -34,6 +34,8 @@ export const punchLineBox = defineField({
             {
               name: "actionLine",
               title: "Take Action Line",
+              description:
+                "Description of what the visitor should do (send email, contact etc). [[contact]] will be replaced with the contact point's name and link to email.",
               type: "internationalizedArrayString",
               validation: (rule) =>
                 rule

--- a/studio/schemas/objects/sections/punchLineBox.ts
+++ b/studio/schemas/objects/sections/punchLineBox.ts
@@ -12,42 +12,68 @@ export const punchLineBox = defineField({
   icon: BoltIcon,
   fields: [
     {
-      name: "mainPunchLine",
-      title: "Main Punch Line",
-      type: "internationalizedArrayString",
-      validation: (rule) =>
-        rule
-          .required()
-          .custom<
-            { value: string; _type: string; _key: string }[]
-          >(max200ValidationRule),
+      name: "sentences",
+      title: "Sentences",
+      description: "Collection of punch line sentences to show.",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          fields: [
+            {
+              name: "mainPunchLine",
+              title: "Main Punch Line",
+              type: "internationalizedArrayString",
+              validation: (rule) =>
+                rule
+                  .required()
+                  .custom<
+                    { value: string; _type: string; _key: string }[]
+                  >(max200ValidationRule),
+            },
+            {
+              name: "actionLine",
+              title: "Take Action Line",
+              type: "internationalizedArrayString",
+              validation: (rule) =>
+                rule
+                  .required()
+                  .custom<
+                    { value: string; _type: string; _key: string }[]
+                  >(max200ValidationRule),
+            },
+            defineField({
+              name: "email",
+              title: "Enter the email address for contact point",
+              type: "email",
+              initialValue: "mb@variant.no",
+            }),
+          ],
+          validation: (rule) =>
+            rule.required().error("A list of punch lines is required."),
+          preview: {
+            select: {
+              mainPunchLine: "mainPunchLine",
+            },
+            prepare(selection) {
+              const { mainPunchLine } = selection;
+              return {
+                title: allTranslations(mainPunchLine) ?? undefined,
+              };
+            },
+          },
+        },
+      ],
     },
-    {
-      name: "actionLine",
-      title: "Take Action Line",
-      type: "internationalizedArrayString",
-      validation: (rule) =>
-        rule
-          .required()
-          .custom<
-            { value: string; _type: string; _key: string }[]
-          >(max200ValidationRule),
-    },
-    defineField({
-      name: "email",
-      title: "Enter the email address for contact point",
-      type: "email",
-      initialValue: "mb@variant.no",
-    }),
   ],
   preview: {
     select: {
-      mainPunchLine: "mainPunchLine",
+      sentences: "sentences",
     },
     prepare(selection) {
-      const { mainPunchLine } = selection;
+      const { sentences } = selection;
       return {
-        title: allTranslations(mainPunchLine) ?? undefined,
+        title: `${sentences.length} punch lines`,
       };
     },
   },

--- a/studio/schemas/objects/sections/punchLineBox.ts
+++ b/studio/schemas/objects/sections/punchLineBox.ts
@@ -1,0 +1,73 @@
+import { BoltIcon } from "@sanity/icons";
+import { defineField } from "sanity";
+
+import { allTranslations } from "studio/utils/i18n";
+
+const punchLineId = "punchLineBox";
+
+export const punchLineBox = defineField({
+  name: punchLineId,
+  title: "Punch Line Box",
+  type: "object",
+  icon: BoltIcon,
+  fields: [
+    {
+      name: "mainPunchLine",
+      title: "Main Punch Line",
+      type: "internationalizedArrayString",
+      validation: (rule) =>
+        rule
+          .required()
+          .custom<
+            { value: string; _type: string; _key: string }[]
+          >(max200ValidationRule),
+    },
+    {
+      name: "actionLine",
+      title: "Take Action Line",
+      type: "internationalizedArrayString",
+      validation: (rule) =>
+        rule
+          .required()
+          .custom<
+            { value: string; _type: string; _key: string }[]
+          >(max200ValidationRule),
+    },
+    defineField({
+      name: "email",
+      title: "Enter the email address for contact point",
+      type: "email",
+      initialValue: "mb@variant.no",
+    }),
+  ],
+  preview: {
+    select: {
+      mainPunchLine: "mainPunchLine",
+    },
+    prepare(selection) {
+      const { mainPunchLine } = selection;
+      return {
+        title: allTranslations(mainPunchLine) ?? undefined,
+      };
+    },
+  },
+});
+
+function max200ValidationRule(
+  value: { value: string; _type: string; _key: string }[],
+) {
+  if (!value) return true;
+
+  const invalidItems = value.filter(
+    (item) => typeof item.value === "string" && item.value.length > 200,
+  );
+
+  if (invalidItems.length > 0) {
+    return invalidItems.map((item) => ({
+      message: "Title cannot be more than 200 characters long.",
+      path: [{ _key: item._key }, "value"],
+    }));
+  }
+
+  return true;
+}


### PR DESCRIPTION
Vi trenger en måte å posisjonere oss på med nye ting. Her er tanken for å skape interesse og få folk nysgjerrige. Nå eksempel er AI og hva vi kan tilby innen det

<img width="1296" height="387" alt="Screenshot 2025-10-02 at 15 33 28" src="https://github.com/user-attachments/assets/4eda58af-1b43-419c-9f48-b626edbd8f43" />
<img width="1507" height="685" alt="Screenshot 2025-10-02 at 15 20 21" src="https://github.com/user-attachments/assets/32febf0c-2afc-412d-8352-21dc086e5586" />


## Checklist

<!-- All must be checked before you merge -->

- [x] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
