### PR TITLE
docs: add section about the changelog in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
   - [Testing](#testing)
 - [Key Dependencies](#key-dependencies)
 - [Documentation and Resources](#documentation-and-resources)
+- [Changelog](#changelog)
 - [Credits](#credits)
 
 ## Key Features
@@ -227,6 +228,11 @@ Sanity Preview, or Presentation, is not yet fully supported in this project. Bug
 ## Documentation and Resources
 
 - [Importing production data for local development](./docs/import-sanity-dataset.md)
+
+## Changelog
+
+Changelog can be found in [CHANGELOG.md](./CHANGELOG.md).
+This changelog is generated with the help of [auto-changelog](https://github.com/cookpete/auto-changelog) and can be generated using the script `npm run changelog`.
 
 ## Credits
 


### PR DESCRIPTION
## Description
Adds section about the changelog in the README

## Checklist

<!-- All must be checked before you merge -->

- [x] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
