### PR TITLE
chore: rename h1 to titleXL in Text

### DIFF
--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -117,7 +117,7 @@ export default async function EventPage({ params }: EventPageProps) {
       />
       <div className={styles.contentWrapper}>
         <div className={styles.eventInfo}>
-          <Text type="h1">{eventTitle}</Text>
+          <Text type="titleXL">{eventTitle}</Text>
           <Text type="bodyXl">{subtitle}</Text>
           <EventInformation
             date={date}

--- a/src/components/customerCases/CustomerCases.tsx
+++ b/src/components/customerCases/CustomerCases.tsx
@@ -32,7 +32,7 @@ const CustomerCases = async ({ customerCasesPage }: CustomerCasesProps) => {
   return (
     <div className={styles.wrapper}>
       <div className={styles.content}>
-        <Text type="h1"> {customerCasesPage.basicTitle} </Text>
+        <Text type="titleXL"> {customerCasesPage.basicTitle} </Text>
         {sharedCustomerCases && sharedCustomerCases.data.length > 0 ? (
           sharedCustomerCases.data.map((customerCase) => (
             <div key={customerCase._id} className={styles.caseWrapper}>

--- a/src/components/customerCases/customerCase/CustomerCase.tsx
+++ b/src/components/customerCases/customerCase/CustomerCase.tsx
@@ -90,7 +90,7 @@ function ColoredTitle({
 }) {
   if (!colorPart)
     return (
-      <Text type={"h1"} className={styles.mainTitle}>
+      <Text type={"titleXL"} className={styles.mainTitle}>
         {title}
       </Text>
     );
@@ -104,7 +104,7 @@ function ColoredTitle({
 
   return (
     <div className={styles.titleWrapper}>
-      <Text type={"h1"} className={styles.mainTitle}>
+      <Text type={"titleXL"} className={styles.mainTitle}>
         <span>{preColorText}</span>
         <span style={{ color: color }}>{colorText}</span>
         <span>{postColorText}</span>

--- a/src/components/eventsPage/eventsPage.tsx
+++ b/src/components/eventsPage/eventsPage.tsx
@@ -46,7 +46,7 @@ export default async function EventsPage({
   return (
     <>
       <section className={styles.eventSection} aria-labelledby={allEventsId}>
-        <Text type="h1" id={allEventsId} className="visually-hidden">
+        <Text type="titleXL" id={allEventsId} className="visually-hidden">
           {t("all_events")}
         </Text>
 

--- a/src/components/informationSection/InformationSection.tsx
+++ b/src/components/informationSection/InformationSection.tsx
@@ -16,7 +16,7 @@ const InformationSection = ({ title, body, link }: InformationSectionProps) => {
   return (
     <section className={styles.wrapper}>
       <div className={styles.info}>
-        <Text type="h1">{title}</Text>
+        <Text type="titleXL">{title}</Text>
         <span>
           {body.split("\n").map((line, index) => (
             <Text key={index}>

--- a/src/components/legal/Legal.tsx
+++ b/src/components/legal/Legal.tsx
@@ -36,7 +36,7 @@ const Legal = ({ document }: { document: LegalDocument }) => {
   return (
     <div>
       <div className={styles.hero}>
-        <Text type="h1">{document.basicTitle}</Text>
+        <Text type="titleXL">{document.basicTitle}</Text>
       </div>
       <div className={styles.wrapper}>
         <div className={styles.body}>

--- a/src/components/sections/employees/Employees.tsx
+++ b/src/components/sections/employees/Employees.tsx
@@ -34,7 +34,7 @@ export default async function Employees({ language, section }: EmployeesProps) {
   return (
     <div className={styles.wrapper}>
       <div className={styles.employees}>
-        <Text type="h1">{section.basicTitle}</Text>
+        <Text type="titleXL">{section.basicTitle}</Text>
 
         <Suspense fallback={<EmployeeListSkeleton />}>
           <EmployeeList

--- a/src/components/sections/hero/Hero.tsx
+++ b/src/components/sections/hero/Hero.tsx
@@ -18,7 +18,7 @@ export const Hero = ({ hero, isLanding = false }: HeroProps) => {
       {isLanding ? (
         <div className={styles.landingPageSecondary}>
           {hero.eyebrow && <Text type="bodyBig">{hero.eyebrow}</Text>}
-          {hero.title && <Text type="h1">{hero.title}</Text>}
+          {hero.title && <Text type="titleXL">{hero.title}</Text>}
           {hero.description && (
             <Text type="h6" as="p">
               {hero.description}
@@ -34,7 +34,7 @@ export const Hero = ({ hero, isLanding = false }: HeroProps) => {
         // This section is prepared for a custom hero section for pages that are not landing pages.
         <div className={styles.secondary}>
           {hero.eyebrow && <Text type="bodyBig">{hero.eyebrow}</Text>}
-          {hero.title && <Text type="h1">{hero.title}</Text>}
+          {hero.title && <Text type="titleXL">{hero.title}</Text>}
           {hero.description && (
             <Text type="h4" as="p">
               {hero.description}

--- a/src/components/sections/textContent/TextContent.tsx
+++ b/src/components/sections/textContent/TextContent.tsx
@@ -35,7 +35,7 @@ export default function TextContent({ section }: textContentProps) {
 const renderTextTitle = ({ eyebrow, title }: ITextTitle) => (
   <div className={styles.container}>
     <Text type="bodyNormal"> {eyebrow} </Text>
-    <Text type="h1">{title}</Text>
+    <Text type="titleXL">{title}</Text>
   </div>
 );
 

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -1,7 +1,7 @@
 import styles from "./text.module.css";
 
 export type TextType =
-  | "h1"
+  | "titleXL"
   | "h2"
   | "h3"
   | "h4"
@@ -23,7 +23,7 @@ export type TextType =
   | "italic";
 
 const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
-  h1: "h1",
+  titleXL: "h1",
   h2: "h2",
   h3: "h3",
   h4: "h4",
@@ -46,7 +46,7 @@ const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
 };
 
 const classMap: { [key in TextType]?: string } = {
-  h1: styles.h1,
+  titleXL: styles.titleXL,
   h2: styles.h2,
   h3: styles.h3,
   h4: styles.h4,

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,4 +1,4 @@
-:where(.desktopLink, .h1, .h2, .h3, .h4, .h5, .h6, .bodyXl) {
+:where(.desktopLink, .titleXL, .h2, .h3, .h4, .h5, .h6, .bodyXl) {
   margin: 0;
   font-family: var(--font-britti-sans);
 }
@@ -16,7 +16,7 @@
   line-height: 140%;
 }
 
-.h1 {
+.titleXL {
   font-size: 4.5rem;
   font-style: normal;
   font-weight: 450;


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [X] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [X] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [X] New functions that can be used in multiple components has been put in a `utils` directory
- [X] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Har endret h1 til titleXL alle steder hvor Text.tsx har blitt brukt. 

H1 brukes nå to steder: route.tsx og extractLeadText. Burde h1 taggen i route.tsx erstattes med Text? I extractLeadText defineres egne typer for rik tekst, så denne bør vell forbli slik? Har ikkje klart å finne kor denne eventuelt brukes. 
