### PR TITLE
chore: rename h2 type to titleL in Text.tsx

### DIFF
--- a/src/components/compensations/Compensations.tsx
+++ b/src/components/compensations/Compensations.tsx
@@ -24,7 +24,7 @@ export default async function Compensations({
   return (
     <div className={styles.outerWrapper}>
       <div className={styles.wrapper}>
-        <Text type="h2">{compensations.basicTitle}</Text>
+        <Text type="titleL">{compensations.basicTitle}</Text>
         <RichText value={compensations.richText} />
         <SplitSection
           section={compensations.splitSection}

--- a/src/components/compensations/components/benefits/Benefits.tsx
+++ b/src/components/compensations/components/benefits/Benefits.tsx
@@ -71,7 +71,7 @@ export default function Benefits({
       default:
         return (
           <div>
-            <Text type="h2">{benefit.basicTitle}</Text>
+            <Text type="titleL">{benefit.basicTitle}</Text>
             <RichText value={benefit.richText} />
           </div>
         );

--- a/src/components/compensations/components/benefits/BonusSection.tsx
+++ b/src/components/compensations/components/benefits/BonusSection.tsx
@@ -16,7 +16,7 @@ const bonusSection = ({
 }: BonusSectionProps) => {
   return (
     <div>
-      <Text type="h2">{benefit.basicTitle}</Text>
+      <Text type="titleL">{benefit.basicTitle}</Text>
       <RichText value={benefit.richText} />
       {yearlyBonusesForLocation && (
         <BonusGraphParent yearlyBonusesForLocation={yearlyBonusesForLocation} />

--- a/src/components/compensations/components/benefits/PensionSection.tsx
+++ b/src/components/compensations/components/benefits/PensionSection.tsx
@@ -81,7 +81,7 @@ export default function Pension({
   return (
     <>
       <div className={styles.sectionText}>
-        <Text type="h2">{benefit.basicTitle}</Text>
+        <Text type="titleL">{benefit.basicTitle}</Text>
         <RichText value={benefit.richText} />
       </div>
 

--- a/src/components/compensations/components/benefits/SalarySection.tsx
+++ b/src/components/compensations/components/benefits/SalarySection.tsx
@@ -50,7 +50,7 @@ export default function SalarySection({
   return (
     <>
       <div className={styles.sectionText}>
-        <Text type="h2">{benefit.basicTitle}</Text>
+        <Text type="titleL">{benefit.basicTitle}</Text>
         <RichText value={benefit.richText} />
       </div>
       <div style={{ gridColumn: "1 / -1" }}>

--- a/src/components/customerCases/CustomerCases.tsx
+++ b/src/components/customerCases/CustomerCases.tsx
@@ -41,7 +41,7 @@ const CustomerCases = async ({ customerCasesPage }: CustomerCasesProps) => {
               </div>
               <div className={styles.caseTextWrapper}>
                 <Link href={`${customerCasesPage.slug}/${customerCase.slug}`}>
-                  <Text type="h2">{customerCase.basicTitle}</Text>
+                  <Text type="titleL">{customerCase.basicTitle}</Text>
                 </Link>
                 {customerCase.description && (
                   <Text>{customerCase.description}</Text>

--- a/src/components/customerCases/customerCase/featuredCases/FeaturedCases.tsx
+++ b/src/components/customerCases/customerCase/featuredCases/FeaturedCases.tsx
@@ -21,7 +21,7 @@ export default function FeaturedCases({
   return (
     featuredCases.length > 0 && (
       <div className={styles.wrapper}>
-        <Text type={"h2"}>{t("featured_cases.projects")}</Text>
+        <Text type={"titleL"}>{t("featured_cases.projects")}</Text>
         <div className={styles.content}>
           {featuredCases.map((featuredCase) => (
             <Link

--- a/src/components/customerCases/customerCase/sections/results/ResultsBlock.tsx
+++ b/src/components/customerCases/customerCase/sections/results/ResultsBlock.tsx
@@ -48,7 +48,7 @@ function StackedHighlights({ section, blockColor }: ResultsBlockProps) {
           {section.resultsList?.map((result) => (
             <div className={styles.highlightCard} key={result._key}>
               <div className={styles.innerContent}>
-                <Text type="h2" className={styles.result}>
+                <Text type="titleL" className={styles.result}>
                   {result.result}
                 </Text>
                 <p className={styles.subtitle}>{result.description}</p>

--- a/src/components/employeePage/EmployeePage.tsx
+++ b/src/components/employeePage/EmployeePage.tsx
@@ -40,7 +40,7 @@ export default async function EmployeePage({
               </div>
             )}
             <div className={styles.employeeInfo}>
-              <Text type={"h2"}>{employee.name}</Text>
+              <Text type={"titleL"}>{employee.name}</Text>
               {employee.email && (
                 <Text type={"bodyBig"} className={styles.employeeEmail}>
                   <a href={`mailto:${employee.email}`}>{employee.email}</a>

--- a/src/components/eventsPage/eventsPage.tsx
+++ b/src/components/eventsPage/eventsPage.tsx
@@ -52,7 +52,7 @@ export default async function EventsPage({
 
         {sortedFutureEventPostings.length > 0 && (
           <section aria-labelledby={futureEventsId}>
-            <Text type="h2" id={futureEventsId}>
+            <Text type="titleL" id={futureEventsId}>
               {t("future_events")}
             </Text>
 
@@ -73,7 +73,7 @@ export default async function EventsPage({
             className={styles.eventSection}
             aria-labelledby={pastEventsId}
           >
-            <Text type="h2" id={pastEventsId}>
+            <Text type="titleL" id={pastEventsId}>
               {t("past_events")}
             </Text>
 

--- a/src/components/richText/RichText.tsx
+++ b/src/components/richText/RichText.tsx
@@ -23,7 +23,7 @@ const formatId = (children: ReactNode): string => {
 const myPortableTextComponents: Partial<PortableTextReactComponents> = {
   block: {
     h2: ({ children }) => (
-      <Text type="h2" id={formatId(children)}>
+      <Text type="titleL" id={formatId(children)}>
         {children}
       </Text>
     ),

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -26,7 +26,7 @@ export default async function CompensationCalculator({
 
   return (
     <div className={styles.container}>
-      {section.moduleTitle && <Text type="h2">{section.moduleTitle}</Text>}
+      {section.moduleTitle && <Text type="titleL">{section.moduleTitle}</Text>}
       <div className={styles.grid}>
         <div className={calculatorBgClassname}>
           <Text type="h3">{section.calculatorBlock.calculatorTitle}</Text>

--- a/src/components/sections/customerCasesEntry/CustomerCasesList.tsx
+++ b/src/components/sections/customerCasesEntry/CustomerCasesList.tsx
@@ -84,7 +84,7 @@ function CardInfo({
 
   return (
     <div className={styles.cardInfo}>
-      <Text type="h2" as="h3" className={styles.heading}>
+      <Text type="titleL" as="h3" className={styles.heading}>
         {selectedCustomerCase.basicTitle}
       </Text>
       <div className={styles.deliveries}>

--- a/src/components/sections/employeeHighlight/EmployeeHighlightCard.tsx
+++ b/src/components/sections/employeeHighlight/EmployeeHighlightCard.tsx
@@ -24,7 +24,7 @@ export function EmployeeHighlightCard({
             {basicTitle}
           </Text>
           <div className={styles.nameContainer}>
-            <Text type={"h2"} className={styles.name}>
+            <Text type={"titleL"} className={styles.name}>
               {name}
             </Text>
           </div>

--- a/src/components/sections/events/EventsClient.tsx
+++ b/src/components/sections/events/EventsClient.tsx
@@ -75,7 +75,7 @@ export default function EventsClient({
   return (
     <>
       <div className={styles.titleSection}>
-        <Text type={"h2"}>{section.basicTitle}</Text>
+        <Text type={"titleL"}>{section.basicTitle}</Text>
         <Text type={"bodyNormal"} className={styles.introText}>
           {section.subtitle}
         </Text>

--- a/src/components/sections/generosity/Generosity.tsx
+++ b/src/components/sections/generosity/Generosity.tsx
@@ -13,7 +13,7 @@ export interface GenerosityProps {
 export default function Generosity({ section, language }: GenerosityProps) {
   return (
     <div className={styles.wrapper}>
-      <Text type={"h2"} className={styles.title}>
+      <Text type={"titleL"} className={styles.title}>
         {section.basicTitle}
       </Text>
       <div className={styles.content}>

--- a/src/components/sections/grid/Grid.tsx
+++ b/src/components/sections/grid/Grid.tsx
@@ -13,7 +13,7 @@ const Grid = ({ grid }: { grid: GridSection }) => {
   return (
     <article className={styles.article}>
       <div className={styles.grid}>
-        <Text type="h2" id="grid-title">
+        <Text type="titleL" id="grid-title">
           {grid.basicTitle}
         </Text>
         <ul aria-labelledby="grid-title" className={styles.list}>

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -70,7 +70,7 @@ function Content({
   content: ImageSplitProps["section"]["content"][0];
   isFirst: boolean;
 }) {
-  const [type, asType] = isFirst ? ["h2", "h2"] : ["h4", "h3"];
+  const [type, asType] = isFirst ? ["titleL", "h2"] : ["h4", "h3"];
 
   return (
     <>

--- a/src/components/sections/jobs/Jobs.tsx
+++ b/src/components/sections/jobs/Jobs.tsx
@@ -34,7 +34,7 @@ export default async function Jobs({ language, section }: JobsProps) {
     companyLocations && (
       <div className={styles.wrapper}>
         <div className={styles.titleSection}>
-          <Text type={"h2"}>{section.basicTitle}</Text>
+          <Text type={"titleL"}>{section.basicTitle}</Text>
           <Text type={"bodyNormal"}>{section.subtitle}</Text>
         </div>
         <JobPostingList

--- a/src/components/sections/learning/Learning.tsx
+++ b/src/components/sections/learning/Learning.tsx
@@ -14,7 +14,7 @@ export interface LearningProps {
 export default function Learning({ section }: LearningProps) {
   return (
     <div className={styles.wrapper}>
-      <Text type={"h2"} className={styles.title}>
+      <Text type={"titleL"} className={styles.title}>
         {section.basicTitle}
       </Text>
       <div className={styles.content}>

--- a/src/components/sections/openness/Openness.tsx
+++ b/src/components/sections/openness/Openness.tsx
@@ -12,7 +12,7 @@ export interface OpennessProps {
 export default function Openness({ section }: OpennessProps) {
   return (
     <div className={styles.wrapper}>
-      <Text type={"h2"} className={styles.title}>
+      <Text type={"titleL"} className={styles.title}>
         {section.basicTitle}
       </Text>
       <div className={styles.content}>

--- a/src/components/sections/punchLineBox/PunchLineBoxClient.tsx
+++ b/src/components/sections/punchLineBox/PunchLineBoxClient.tsx
@@ -30,7 +30,7 @@ export default function PunchLineBoxClient({
   );
   return (
     <>
-      <Text type="h2">
+      <Text type="titleL">
         <RotatingText
           animationKey={`${key}-title`}
           text={randomSentence.mainPunchLine}

--- a/src/components/sections/splitSection/SplitSection.tsx
+++ b/src/components/sections/splitSection/SplitSection.tsx
@@ -35,7 +35,7 @@ export default function SplitSection({ section, language }: SplitSectionProps) {
   return (
     <div className={styles.wrapper}>
       {title && (
-        <Text type="h2" className={styles.title}>
+        <Text type="titleL" className={styles.title}>
           {title}
         </Text>
       )}

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -2,7 +2,7 @@ import styles from "./text.module.css";
 
 export type TextType =
   | "titleXL"
-  | "h2"
+  | "titleL"
   | "h3"
   | "h4"
   | "h5"
@@ -24,7 +24,7 @@ export type TextType =
 
 const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
   titleXL: "h1",
-  h2: "h2",
+  titleL: "h2",
   h3: "h3",
   h4: "h4",
   h5: "h5",
@@ -47,7 +47,7 @@ const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
 
 const classMap: { [key in TextType]?: string } = {
   titleXL: styles.titleXL,
-  h2: styles.h2,
+  titleL: styles.titleL,
   h3: styles.h3,
   h4: styles.h4,
   h5: styles.h5,

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,4 +1,4 @@
-:where(.desktopLink, .titleXL, .h2, .h3, .h4, .h5, .h6, .bodyXl) {
+:where(.desktopLink, .titleXL, .titleL, .h3, .h4, .h5, .h6, .bodyXl) {
   margin: 0;
   font-family: var(--font-britti-sans);
 }
@@ -33,7 +33,7 @@
   }
 }
 
-.h2 {
+.titleL {
   font-size: 3.5rem;
   font-weight: 450;
   line-height: 114.286%;


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

H2 er bare endret til titleL der Text brukes. 