### PR TITLE
fix: use customer case page slug on customer case list link

### DIFF
--- a/src/components/sections/customerCasesEntry/CustomerCasesList.tsx
+++ b/src/components/sections/customerCasesEntry/CustomerCasesList.tsx
@@ -43,6 +43,7 @@ const CustomerCaseList = ({
                 customerCases={customerCases}
                 selectedCustomerCase={selectedCustomerCase}
                 setSelectedCustomerCase={setSelectedCustomerCase}
+                customerCasePageSlug={customerCasePageSlug}
                 language={language}
               />
               <Link
@@ -110,11 +111,13 @@ function TagRow({
   customerCases,
   selectedCustomerCase,
   setSelectedCustomerCase,
+  customerCasePageSlug,
   language,
 }: {
   customerCases: CustomerCaseEntry[];
   selectedCustomerCase: CustomerCaseEntry;
   setSelectedCustomerCase: (customerCase: CustomerCaseEntry) => void;
+  customerCasePageSlug?: string;
   language: string;
 }) {
   const t = useTranslations("customer_case");
@@ -142,7 +145,7 @@ function TagRow({
       {customerCases.length > 3 && (
         <div className={styles.customerLink}>
           <LinkButton
-            link={`/${language}/cases`}
+            link={`/${language}/${customerCasePageSlug}`}
             background="dark"
             type="primary"
             size="M"


### PR DESCRIPTION
## Description
case page should now use the url slug given by sanity instead of `/case`

## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
