### PR TITLE
chore: rename h3 to titleM

### DIFF
--- a/src/components/customErrorMessage/CustomErrorMessage.tsx
+++ b/src/components/customErrorMessage/CustomErrorMessage.tsx
@@ -24,7 +24,7 @@ const CustomErrorMessage = ({
   return (
     <section className={styles.wrapper} role="alert" aria-live="assertive">
       <div className={styles.error}>
-        <Text type="h3">{title}</Text>
+        <Text type="titleM">{title}</Text>
         <Text>{body}</Text>
         <div className={styles.buttonWrapper}>
           {button && (

--- a/src/components/customerCases/customerCase/sections/customerCaseConsultants/CustomerCaseConsultants.tsx
+++ b/src/components/customerCases/customerCase/sections/customerCaseConsultants/CustomerCaseConsultants.tsx
@@ -29,7 +29,7 @@ export default async function CustomerCaseConsultants({
 
   return (
     <div className={styles.wrapper}>
-      <Text type={"h3"}>{t("in_project")}</Text>
+      <Text type={"titleM"}>{t("in_project")}</Text>
       <div className={styles.content}>
         {consultants.map((consultant) => (
           <CustomerCaseEmployeeCard

--- a/src/components/customerCases/customerCase/sections/results/ResultsBlock.tsx
+++ b/src/components/customerCases/customerCase/sections/results/ResultsBlock.tsx
@@ -38,7 +38,7 @@ function StackedHighlights({ section, blockColor }: ResultsBlockProps) {
           {section.quote?.map((quote) => (
             <div className={styles.highlightCard} key={quote._key}>
               <div className={styles.innerContent}>
-                <Text type="h3">{quote.quoteText}</Text>
+                <Text type="titleM">{quote.quoteText}</Text>
                 <Text type="description" color="tertiary">
                   {quote.quoteAuthor}
                 </Text>

--- a/src/components/eventPosting/EventPosting.tsx
+++ b/src/components/eventPosting/EventPosting.tsx
@@ -56,7 +56,7 @@ export default function EventPosting({
         locations={showLocations ? eventPosting.locations : undefined}
       />
       <div className={styles.eventTitle}>
-        <Text type="h3">{eventPosting.eventTitle}</Text>
+        <Text type="titleM">{eventPosting.eventTitle}</Text>
       </div>
       <Text type="description">{eventPosting.eventDescription}</Text>
 

--- a/src/components/hubspot/eventRegistration/status/statusTemplate/statusTemplate.tsx
+++ b/src/components/hubspot/eventRegistration/status/statusTemplate/statusTemplate.tsx
@@ -20,7 +20,7 @@ export default function StatusTemplate({
   return (
     <div className={styles.statusTemplate}>
       <img className={styles.image} src={imgSrc} alt={imgAlt} />
-      <Text type="h3">{title}</Text>
+      <Text type="titleM">{title}</Text>
       {children}
     </div>
   );

--- a/src/components/richText/RichText.tsx
+++ b/src/components/richText/RichText.tsx
@@ -28,7 +28,7 @@ const myPortableTextComponents: Partial<PortableTextReactComponents> = {
       </Text>
     ),
     h3: ({ children }) => (
-      <Text type="h3" id={formatId(children)}>
+      <Text type="titleM" id={formatId(children)}>
         {children}
       </Text>
     ),

--- a/src/components/sections/compensation-calculator/CompensationCalculator.tsx
+++ b/src/components/sections/compensation-calculator/CompensationCalculator.tsx
@@ -29,7 +29,7 @@ export default async function CompensationCalculator({
       {section.moduleTitle && <Text type="titleL">{section.moduleTitle}</Text>}
       <div className={styles.grid}>
         <div className={calculatorBgClassname}>
-          <Text type="h3">{section.calculatorBlock.calculatorTitle}</Text>
+          <Text type="titleM">{section.calculatorBlock.calculatorTitle}</Text>
           <Text type="bodyBig">
             {section.calculatorBlock.calculatorDescription}
           </Text>

--- a/src/components/sections/contact-box/ContactBoxContent.tsx
+++ b/src/components/sections/contact-box/ContactBoxContent.tsx
@@ -32,7 +32,7 @@ export default async function ContactBoxContent({
     <section className={styles.contactBox}>
       <div className={`${styles.contactBox__inner} ${backgroundClass}`}>
         <div className={styles.textContent}>
-          <Text type="h3" as="h2">
+          <Text type="titleM" as="h2">
             {data.basicTitle}
           </Text>
 

--- a/src/components/sections/customerCasesEntry/CustomerCasesEntry.tsx
+++ b/src/components/sections/customerCasesEntry/CustomerCasesEntry.tsx
@@ -47,7 +47,7 @@ async function CustomerCasesEntry({ language, section }: CustomerCasesProps) {
     customerCaseResult && (
       <div className={styles.firstWrapper}>
         <div className={styles.titleWrapper}>
-          <Text type="h3" as="h2">
+          <Text type="titleM" as="h2">
             {section.basicTitle}
           </Text>
         </div>

--- a/src/components/sections/gridSection/GridSection.tsx
+++ b/src/components/sections/gridSection/GridSection.tsx
@@ -58,7 +58,7 @@ const FieldCard = ({ field }: { field: Field }) => {
               </>
             )}
           </div>
-          <Text type="h3" as="h2">
+          <Text type="titleM" as="h2">
             {title}
           </Text>
           {description && <Text type="bodyBig">{description}</Text>}

--- a/src/components/sections/handbook/HandbookSection.tsx
+++ b/src/components/sections/handbook/HandbookSection.tsx
@@ -29,7 +29,7 @@ export async function Handbook({ section, language }: HandbookProps) {
 
   return (
     <div className={handbookBgClassname}>
-      <Text type="h3" color="light">
+      <Text type="titleM" color="light">
         {handbookTitle}
       </Text>
       <div className={styles.lightFont}>

--- a/src/components/sections/learning/Learning.tsx
+++ b/src/components/sections/learning/Learning.tsx
@@ -33,7 +33,7 @@ export default function Learning({ section }: LearningProps) {
               <Text type="labelL" color="light">
                 {section.articleTag}
               </Text>
-              <Text type="h3" color="light">
+              <Text type="titleM" color="light">
                 {section.articleTitle}
               </Text>
               <Text type="bodyBig" color="light">

--- a/src/components/sections/logoSalad/LogoSalad.tsx
+++ b/src/components/sections/logoSalad/LogoSalad.tsx
@@ -13,7 +13,7 @@ export const LogoSalad = ({ logoSalad }: LogoSaladProps) => {
     <article className={styles.wrapper} id={logoSalad._key}>
       <div>
         <div className={styles.title}>
-          <Text type="h3">{logoSalad.title}</Text>
+          <Text type="titleM">{logoSalad.title}</Text>
         </div>
         <ul className={styles.logoWrapper}>
           {logoSalad.logos.map((logo) => (

--- a/src/components/smileyBox/SmileyBox.tsx
+++ b/src/components/smileyBox/SmileyBox.tsx
@@ -32,7 +32,7 @@ export default function SmileyBox({
     <div className={styles.wrapper} style={cssVariables}>
       <Smiley smileySide={smileySide} smileyType={smileyType} />
       <div className={styles.description}>
-        <Text type={"h3"}>{description}</Text>
+        <Text type={"titleM"}>{description}</Text>
       </div>
     </div>
   );

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -5,7 +5,7 @@ import styles from "./text.module.css";
 export type TextType =
   | "titleXL"
   | "titleL"
-  | "h3"
+  | "titleM"
   | "h4"
   | "h5"
   | "h6"
@@ -29,7 +29,7 @@ export type TextColor = "dark" | "light" | "tertiary" | "error";
 const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
   titleXL: "h1",
   titleL: "h2",
-  h3: "h3",
+  titleM: "h3",
   h4: "h4",
   h5: "h5",
   h6: "h6",
@@ -52,7 +52,7 @@ const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
 const classMap: { [key in TextType]?: string } = {
   titleXL: styles.titleXL,
   titleL: styles.titleL,
-  h3: styles.h3,
+  titleM: styles.titleM,
   h4: styles.h4,
   h5: styles.h5,
   h6: styles.h6,

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,4 +1,4 @@
-:where(.desktopLink, .titleXL, .titleL, .h3, .h4, .h5, .h6, .bodyXl) {
+:where(.desktopLink, .titleXL, .titleL, .titleM, .h4, .h5, .h6, .bodyXl) {
   margin: 0;
   font-family: var(--font-britti-sans);
 }
@@ -49,7 +49,7 @@
   }
 }
 
-.h3 {
+.titleM {
   font-size: 2rem;
   font-weight: 450;
   line-height: 125%;


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Har endret h3 til titleM der det gir mening å endre den. 