### PR TITLE
chore: rename h4 to titleS

### DIFF
--- a/src/components/customerCases/customerCase/featuredCases/FeaturedCases.tsx
+++ b/src/components/customerCases/customerCase/featuredCases/FeaturedCases.tsx
@@ -33,7 +33,7 @@ export default function FeaturedCases({
                 <SanityImage image={featuredCase.image} isShared />
               </div>
               <div className={styles.textContent}>
-                <Text type={"h4"}>{featuredCase.basicTitle}</Text>
+                <Text type={"titleS"}>{featuredCase.basicTitle}</Text>
                 <Text type={"description"}>{featuredCase.description}</Text>
               </div>
             </Link>

--- a/src/components/customerCases/customerCase/sections/list/ListBlock.tsx
+++ b/src/components/customerCases/customerCase/sections/list/ListBlock.tsx
@@ -14,7 +14,7 @@ export default function ListBlock({ section }: ListBlockProps) {
     section.description && (
       <div className={styles.wrapper}>
         <div className={styles.listwrapper}>
-          <Text type="h4">{section.description}</Text>
+          <Text type="titleS">{section.description}</Text>
           <div className={styles.tagwrapper}>
             {section.list?.map((listItem) => (
               <div className={styles.tag} key={listItem._key}>

--- a/src/components/customerCases/customerCase/sections/text/TextSection.tsx
+++ b/src/components/customerCases/customerCase/sections/text/TextSection.tsx
@@ -25,7 +25,7 @@ export default function TextSection({ section }: TextSectionProps) {
           <div>
             {section.sectionTitle && (
               <div className={styles.title}>
-                <Text type={"h4"}>{section.sectionTitle}</Text>
+                <Text type={"titleS"}>{section.sectionTitle}</Text>
               </div>
             )}
             <Text

--- a/src/components/employeeCard/EmployeeCard.tsx
+++ b/src/components/employeeCard/EmployeeCard.tsx
@@ -43,7 +43,7 @@ export default function EmployeeCard({
             </div>
           </Link>
           <div className={styles.employeeInfoWrapper}>
-            <Text type="h4" as="h3">
+            <Text type="titleS" as="h3">
               <Link
                 href={`/${language}/${employeePageSlug}/${aliasFromEmail(employee.email)}`}
                 className={styles.employeeNameLink}

--- a/src/components/richText/RichText.tsx
+++ b/src/components/richText/RichText.tsx
@@ -33,7 +33,7 @@ const myPortableTextComponents: Partial<PortableTextReactComponents> = {
       </Text>
     ),
     h4: ({ children }) => (
-      <Text type="h4" id={formatId(children)}>
+      <Text type="titleS" id={formatId(children)}>
         {children}
       </Text>
     ),

--- a/src/components/sections/hero/Hero.tsx
+++ b/src/components/sections/hero/Hero.tsx
@@ -36,7 +36,7 @@ export const Hero = ({ hero, isLanding = false }: HeroProps) => {
           {hero.eyebrow && <Text type="bodyBig">{hero.eyebrow}</Text>}
           {hero.title && <Text type="titleXL">{hero.title}</Text>}
           {hero.description && (
-            <Text type="h4" as="p">
+            <Text type="titleS" as="p">
               {hero.description}
             </Text>
           )}

--- a/src/components/sections/image-split/ImageSplit.tsx
+++ b/src/components/sections/image-split/ImageSplit.tsx
@@ -70,7 +70,7 @@ function Content({
   content: ImageSplitProps["section"]["content"][0];
   isFirst: boolean;
 }) {
-  const [type, asType] = isFirst ? ["titleL", "h2"] : ["h4", "h3"];
+  const [type, asType] = isFirst ? ["titleL", "h2"] : ["titleS", "h3"];
 
   return (
     <>

--- a/src/components/sections/textContent/TextContent.tsx
+++ b/src/components/sections/textContent/TextContent.tsx
@@ -45,7 +45,7 @@ const renderTextParagraph = ({
 }: ITextParagraph) => (
   <div className={styles.container}>
     <div className={styles.paragraphWrapper}>
-      <Text type="h4" as="h2">
+      <Text type="titleS" as="h2">
         {paragraphHeader}
       </Text>
       <Text type="bodyNormal">{textContent}</Text>

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -6,7 +6,7 @@ export type TextType =
   | "titleXL"
   | "titleL"
   | "h3"
-  | "h4"
+  | "titleS"
   | "h5"
   | "h6"
   | "desktopLink"
@@ -30,7 +30,7 @@ const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
   titleXL: "h1",
   titleL: "h2",
   h3: "h3",
-  h4: "h4",
+  titleS: "h4",
   h5: "h5",
   h6: "h6",
   desktopLink: "p",
@@ -53,7 +53,7 @@ const classMap: { [key in TextType]?: string } = {
   titleXL: styles.titleXL,
   titleL: styles.titleL,
   h3: styles.h3,
-  h4: styles.h4,
+  titleS: styles.titleS,
   h5: styles.h5,
   h6: styles.h6,
   desktopLink: styles.desktopLink,

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,4 +1,4 @@
-:where(.desktopLink, .titleXL, .titleL, .h3, .h4, .h5, .h6, .bodyXl) {
+:where(.desktopLink, .titleXL, .titleL, .h3, .titleS, .h5, .h6, .bodyXl) {
   margin: 0;
   font-family: var(--font-britti-sans);
 }
@@ -60,7 +60,7 @@
   }
 }
 
-.h4 {
+.titleS {
   font-size: 1.5rem;
   font-style: normal;
   font-weight: 450;


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Har endret h4 til titleS, richText endres fortsatt så lite som mulig. 