### PR TITLE
chore: rename h5 to titleXS

### DIFF
--- a/src/components/compensations/components/benefits/PensionSection.tsx
+++ b/src/components/compensations/components/benefits/PensionSection.tsx
@@ -88,7 +88,7 @@ export default function Pension({
       <div className={styles.pensionControls}>
         <div className={styles.formWrapper}>
           <fieldset className={styles.formFieldset}>
-            <Text type="h5">{t("pension.salaryAtCurrentEmployer")}</Text>
+            <Text type="titleXS">{t("pension.salaryAtCurrentEmployer")}</Text>
             <div className={styles.mobileInputWrapper}>
               <RangeSlider
                 min={MIN_SALARY}
@@ -123,7 +123,7 @@ export default function Pension({
           </fieldset>
 
           <fieldset className={styles.formFieldset}>
-            <Text type="h5">
+            <Text type="titleXS">
               <legend>{t("pension.percentPension")}</legend>
             </Text>
             <RangeSlider
@@ -139,7 +139,7 @@ export default function Pension({
           </fieldset>
 
           <fieldset className={styles.formFieldset}>
-            <Text type="h5">
+            <Text type="titleXS">
               <legend>{t("pension.IPS")}</legend>
             </Text>
             <RangeSlider

--- a/src/components/jobPosting/JobPosting.tsx
+++ b/src/components/jobPosting/JobPosting.tsx
@@ -31,7 +31,7 @@ export default function JobPosting({
       className={styles.jobPosting}
     >
       <div className={styles.role}>
-        <Text type={"h5"} as={"span"}>
+        <Text type={"titleXS"} as={"span"}>
           {jobPosting.role}
 
           {showLocations && (

--- a/src/components/richText/RichText.tsx
+++ b/src/components/richText/RichText.tsx
@@ -38,7 +38,7 @@ const myPortableTextComponents: Partial<PortableTextReactComponents> = {
       </Text>
     ),
     h5: ({ children }) => (
-      <Text type="h5" id={formatId(children)}>
+      <Text type="titleXS" id={formatId(children)}>
         {children}
       </Text>
     ),

--- a/src/components/sections/customerCasesEntry/CustomerCasesList.tsx
+++ b/src/components/sections/customerCasesEntry/CustomerCasesList.tsx
@@ -94,7 +94,7 @@ function CardInfo({
         </Text>
         <div className={styles.deliveriesList}>
           {deliveryNames.map((deliveryName, index, array) => (
-            <Text key={index} type="h5" as="span" color="light">
+            <Text key={index} type="titleXS" as="span" color="light">
               {t(deliveryName)}
               {index < array.length - 1 && (
                 <span className={styles.dotSeperator} />

--- a/src/components/sections/employeeHighlight/EmployeeHighlightCard.tsx
+++ b/src/components/sections/employeeHighlight/EmployeeHighlightCard.tsx
@@ -21,7 +21,7 @@ export function EmployeeHighlightCard({
         {employeePhoto && <SanityImage image={employeePhoto} />}
         <div className={styles.titleContainer}>
           <div className={styles.title}>
-            <Text type={"h5"} color="light">
+            <Text type={"titleXS"} color="light">
               {basicTitle}
             </Text>
           </div>

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -7,7 +7,7 @@ export type TextType =
   | "titleL"
   | "h3"
   | "h4"
-  | "h5"
+  | "titleXS"
   | "h6"
   | "desktopLink"
   | "labelL"
@@ -31,7 +31,7 @@ const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
   titleL: "h2",
   h3: "h3",
   h4: "h4",
-  h5: "h5",
+  titleXS: "h5",
   h6: "h6",
   desktopLink: "p",
   labelL: "span",
@@ -54,7 +54,7 @@ const classMap: { [key in TextType]?: string } = {
   titleL: styles.titleL,
   h3: styles.h3,
   h4: styles.h4,
-  h5: styles.h5,
+  titleXS: styles.titleXS,
   h6: styles.h6,
   desktopLink: styles.desktopLink,
   labelL: styles.labelL,

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,4 +1,4 @@
-:where(.desktopLink, .titleXL, .titleL, .h3, .h4, .h5, .h6, .bodyXl) {
+:where(.desktopLink, .titleXL, .titleL, .h3, .h4, .titleXS, .h6, .bodyXl) {
   margin: 0;
   font-family: var(--font-britti-sans);
 }
@@ -67,7 +67,7 @@
   line-height: 133.3%;
 }
 
-.h5 {
+.titleXS {
   font-size: 1.25rem;
   font-style: normal;
   font-weight: 450;

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,4 +1,13 @@
-:where(.desktopLink, .titleXL, .titleL, .titleM, .titleS, .titleXS, .h6, .bodyXl) {
+:where(
+  .desktopLink,
+  .titleXL,
+  .titleL,
+  .titleM,
+  .titleS,
+  .titleXS,
+  .h6,
+  .bodyXl
+) {
   margin: 0;
   font-family: var(--font-britti-sans);
 }


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Har endret h5 til titleXS.