### PR TITLE
chore: rename bodyXL to subtitle

### DIFF
--- a/src/app/(main)/[locale]/event/[...key]/page.tsx
+++ b/src/app/(main)/[locale]/event/[...key]/page.tsx
@@ -120,7 +120,7 @@ export default async function EventPage(props: EventPageProps) {
       <div className={styles.contentWrapper}>
         <div className={styles.eventInfo}>
           <Text type="titleXL">{eventTitle}</Text>
-          <Text type="bodyXl">{subtitle}</Text>
+          <Text type="subtitle">{subtitle}</Text>
           <EventInformation
             date={date}
             time={time}

--- a/src/components/customerCases/customerCase/sections/text/TextSection.tsx
+++ b/src/components/customerCases/customerCase/sections/text/TextSection.tsx
@@ -31,7 +31,7 @@ export default function TextSection({ section }: TextSectionProps) {
             <Text
               type={
                 section.textBlockType === "highlighted"
-                  ? "bodyXl"
+                  ? "subtitle"
                   : "bodyNormal"
               }
             >

--- a/src/components/sections/textContent/TextContent.tsx
+++ b/src/components/sections/textContent/TextContent.tsx
@@ -66,6 +66,6 @@ const renderTextQuote = ({ author, quote }: ITextQuote) => (
     <Text color="tertiary" type="bodyNormal">
       {author}
     </Text>
-    <Text type="bodyXl">{quote}</Text>
+    <Text type="subtitle">{quote}</Text>
   </div>
 );

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -18,7 +18,7 @@ export type TextType =
   | "description"
   | "bodyNormal"
   | "bodyBig"
-  | "bodyXl"
+  | "subtitle"
   | "mobileH1"
   | "mobileBodyNormal"
   | "caption"
@@ -42,7 +42,7 @@ const elementMap: { [key in TextType]: keyof JSX.IntrinsicElements } = {
   description: "p",
   bodyNormal: "p",
   bodyBig: "p",
-  bodyXl: "p",
+  subtitle: "p",
   mobileH1: "h1",
   mobileBodyNormal: "p",
   caption: "span",
@@ -65,7 +65,7 @@ const classMap: { [key in TextType]?: string } = {
   description: styles.description,
   bodyNormal: styles.bodyNormal,
   bodyBig: styles.bodyBig,
-  bodyXl: styles.bodyXl,
+  subtitle: styles.subtitle,
   mobileH1: styles.mobileH1,
   mobileBodyNormal: styles.mobileBodyNormal,
   caption: styles.caption,

--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -1,4 +1,4 @@
-:where(.desktopLink, .titleXL, .titleL, .h3, .h4, .h5, .h6, .bodyXl) {
+:where(.desktopLink, .titleXL, .titleL, .h3, .h4, .h5, .h6, .subtitle) {
   margin: 0;
   font-family: var(--font-britti-sans);
 }
@@ -82,7 +82,7 @@
   text-decoration-line: underline;
 }
 
-.bodyXl {
+.subtitle {
   font-size: 2.5rem;
   font-weight: 300;
   line-height: 120%;


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Har endret bodyXL til subtitle.