### PR TITLE
fix(Text): substitutes media tag with clamp for font-size

### DIFF
--- a/src/components/text/text.module.css
+++ b/src/components/text/text.module.css
@@ -22,166 +22,103 @@
 .caption,
 .list {
   font-family: var(--font-britti-sans);
-  line-height: 140%;
 }
 
 .titleXL {
-  font-size: 4.5rem;
-  font-style: normal;
   font-weight: 450;
-  line-height: 111.111%;
-
-  @media (width <=834px) {
-    font-size: 3.5rem;
-    line-height: 114.286%;
-  }
-
-  @media (width <=425px) {
-    font-size: 2.5rem;
-    line-height: 120%;
-  }
+  font-size: clamp(2.5rem, 6vw + 1rem, 4.5rem);
+  line-height: 1.11em;
 }
 
 .titleL {
-  font-size: 3.5rem;
+  font-size: clamp(2rem, 4vw + 1rem, 3.5rem);
   font-weight: 450;
-  line-height: 114.286%;
-
-  @media (width <=834px) {
-    font-size: 2.5rem;
-    line-height: 120%;
-  }
-
-  @media (width <=425px) {
-    font-size: 2rem;
-    line-height: 125%;
-  }
+  line-height: 1.1429em;
 }
 
 .titleM {
-  font-size: 2rem;
+  font-size: clamp(1.5rem, 3vw + 0.5rem, 2rem);
   font-weight: 450;
-  line-height: 125%;
-
-  @media (width <=425px) {
-    font-size: 1.5rem;
-    line-height: 133.333%;
-  }
+  line-height: 1.25em;
 }
 
 .titleS {
   font-size: 1.5rem;
   font-style: normal;
   font-weight: 450;
-  line-height: 133.3%;
+  line-height: 1.333em;
 }
 
 .titleXS {
   font-size: 1.25rem;
   font-style: normal;
   font-weight: 450;
-  line-height: 120%;
+  line-height: 1.2em;
 }
 
 .desktopLink {
   font-size: 1rem;
   font-style: normal;
   font-weight: 400;
-  line-height: 150%;
+  line-height: 1.5em;
   text-decoration-line: underline;
 }
 
 .subtitle {
-  font-size: 2.5rem;
+  font-size: clamp(2rem, 3vw + 1rem, 2.5rem);
   font-weight: 300;
-  line-height: 120%;
   letter-spacing: 0.025rem;
-
-  @media (width <=425px) {
-    font-size: 2rem;
-    line-height: 125%;
-  }
+  line-height: 1.2em;
 }
 
 .lead {
-  font-size: 1.5rem;
+  font-size: clamp(1.125rem, 1.75vw + 0.5rem, 1.5rem);
   font-style: normal;
   font-weight: 300;
-  line-height: 133.333%;
-
-  @media (width <=425px) {
-    font-size: 1.125rem;
-  }
+  line-height: 1.3333em;
 }
 
 .normal {
-  font-size: 1.125rem;
+  font-size: clamp(0.875rem, 2vw + 0.35rem, 1.125rem);
   font-style: normal;
   font-weight: 300;
-  line-height: 160%;
+  line-height: 1.6em;
   letter-spacing: 0.0125rem;
-
-  @media (width <=425px) {
-    font-size: 0.875rem;
-    line-height: 171.429%;
-  }
 }
 
 .description {
-  font-size: 1rem;
+  font-size: clamp(0.875rem, 2vw + 0.35rem, 1rem);
   font-weight: 300;
-  line-height: 150%;
-
-  @media (width <=425px) {
-    font-size: 0.875rem;
-    line-height: 114.286%;
-  }
+  line-height: clamp(1.1429em, 2vw + 0.5rem, 1.5em);
 }
 
 .bodyExtraSmall {
-  font-size: 0.875rem;
+  font-size: clamp(0.75rem, 1vw + 0.5rem, 0.875rem);
   font-weight: 400;
-  line-height: 128.571%;
+  line-height: 1.2857em;
   letter-spacing: 0.0088rem;
-
-  @media (width <=425px) {
-    font-size: 0.75rem;
-    line-height: 150%;
-    letter-spacing: 0.0075rem;
-  }
 }
 
 .label {
-  font-size: 1rem;
+  font-size: clamp(0.875rem, 2vw + 0.35rem, 1rem);
   font-style: normal;
   font-weight: 300;
-  line-height: 150%;
+  line-height: 1.1429em;
   letter-spacing: 0.02rem;
-
-  @media (width <=425px) {
-    font-size: 0.875rem;
-    line-height: 114.286%;
-    letter-spacing: 0.0175rem;
-  }
 }
 
 .labelL {
-  font-size: 1.25rem;
+  font-size: clamp(1.125rem, 2vw + 0.5rem, 1.25rem);
   font-style: normal;
   font-weight: 400;
-  line-height: 120%;
-
-  @media (width <=425px) {
-    font-size: 1.125rem;
-    line-height: 133.333%;
-  }
+  line-height: 1.2em;
 }
 
 .quoteNormal {
   font-size: 1.5rem;
   font-style: normal;
   font-weight: 400;
-  line-height: 130%;
+  line-height: 1.3em;
   white-space: pre-line;
 }
 
@@ -189,7 +126,7 @@
   font-size: 1.5rem;
   font-style: italic;
   font-weight: 400;
-  line-height: 130%;
+  line-height: 1.3em;
   white-space: pre-line;
 }
 
@@ -197,7 +134,7 @@
   font-size: var(--Font-size-Picture-label, 1rem);
   font-style: normal;
   font-weight: 400;
-  line-height: 150%;
+  line-height: 1.5em;
   letter-spacing: 0.05rem;
   padding: 0 0.5rem;
 }


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Har fjernet alle media tags og brukt clamp() på font-size og line-height der det gir mening. Clamp() kan bare brukes for en av line-heights, ellers fungerer det ikkje å bruke det. Dette er fordi slik koden var før ble det satt høyere line-height på små skjermer og ikkje mindre, som bryter med logikken til clamp. Lurer egentlig på hvorfor de har valgt å gjøre det sånn, ville tenkt at det motsatte ga meir mening? Har derfor bare brukt verdien for line-height på store skjermer og bruker "em" i stedet for "%" som skal gjøre den litt mer fleksibel for nøstede elementer. 