### PR TITLE
1438 titles of job posting and event posting is missing

### DIFF
--- a/studio/schemas/documents/admin/eventPostings.ts
+++ b/studio/schemas/documents/admin/eventPostings.ts
@@ -7,7 +7,7 @@ export const eventPostingsID = "eventPostings";
 const eventPostings = defineType({
   name: eventPostingsID,
   type: "document",
-  title: "Event Postings",
+  title: "Events hereeeeee",
   fields: [
     {
       name: "eventPostingsArray",
@@ -16,6 +16,13 @@ const eventPostings = defineType({
       of: [{ type: eventPostingID }],
     },
   ],
+  preview: {
+    prepare() {
+      return {
+        title: "Event Postings",
+      };
+    },
+  },
 });
 
 export default eventPostings;

--- a/studio/schemas/documents/admin/eventPostings.ts
+++ b/studio/schemas/documents/admin/eventPostings.ts
@@ -7,7 +7,7 @@ export const eventPostingsID = "eventPostings";
 const eventPostings = defineType({
   name: eventPostingsID,
   type: "document",
-  title: "Events hereeeeee",
+  title: "Event Postings",
   fields: [
     {
       name: "eventPostingsArray",

--- a/studio/schemas/documents/admin/jobPostings.ts
+++ b/studio/schemas/documents/admin/jobPostings.ts
@@ -16,6 +16,13 @@ const jobPostings = defineType({
       of: [{ type: jobPostingID }],
     },
   ],
+  preview: {
+    prepare() {
+      return {
+        title: "Job Postings",
+      };
+    },
+  },
 });
 
 export default jobPostings;


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Liten fix for å legge til tittel på event og job postings dokument.