### PR TITLE
fix: add preview for language, brand and region titles in studio

### DIFF
--- a/studio/schemas/documents/languageSettings.ts
+++ b/studio/schemas/documents/languageSettings.ts
@@ -29,6 +29,13 @@ const languageSettings = defineType({
       initialValue: () => [defaultLanguage],
     },
   ],
+  preview: {
+    prepare() {
+      return {
+        title: "Languages",
+      };
+    },
+  },
 });
 
 export default languageSettings;

--- a/studio/schemas/documents/siteSettings/brandAssets.ts
+++ b/studio/schemas/documents/siteSettings/brandAssets.ts
@@ -27,6 +27,13 @@ const brandAssets = defineType({
         "Upload the favicon for your site. It appears in the browser tab.",
     }),
   ],
+  preview: {
+    prepare() {
+      return {
+        title: "Brand Assets",
+      };
+    },
+  },
 });
 
 export default brandAssets;

--- a/studio/schemas/documents/siteSettings/locale.ts
+++ b/studio/schemas/documents/siteSettings/locale.ts
@@ -8,6 +8,7 @@ export const localeID = "locale";
 const locale = defineType({
   name: localeID,
   type: "document",
+  title: "Region",
   fields: [
     defineField({
       name: "locale",
@@ -36,6 +37,13 @@ const locale = defineType({
       },
     }),
   ],
+  preview: {
+    prepare() {
+      return {
+        title: "Region",
+      };
+    },
+  },
 });
 
 export default locale;


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Lagt til preview for titlene til dokumentene for language, brand assets og region i studio. 

<img width="813" height="323" alt="Screenshot 2025-11-13 at 11 06 27" src="https://github.com/user-attachments/assets/09de7b65-34bd-4cdb-9583-348218ba95ea" />

<img width="575" height="218" alt="Screenshot 2025-11-13 at 11 07 06" src="https://github.com/user-attachments/assets/bcea0b9f-4081-4d93-8049-7f204bf770e6" />
