### PR TITLE
fix: use text component for label text

### DIFF
--- a/src/components/forms/checkboxColor/checkboxColor.tsx
+++ b/src/components/forms/checkboxColor/checkboxColor.tsx
@@ -33,7 +33,11 @@ const CheckboxColor = ({
           onChange={onChange}
         />
         <span className={styles.checkbox} />
-        {typeof label === "string" ? label : <PortableText value={label} />}
+        {typeof label === "string" ? (
+          <Text type="lead">{label}</Text>
+        ) : (
+          <PortableText value={label} />
+        )}
       </label>
       {error && (
         <span>


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

La til Text komponenten for label teksten ved checkboxen. 