### PR TITLE
feat: preview mode in studio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ NEXT_PUBLIC_SANITY_API_VERSION=<Your Sanity API Version>
 SANITY_API_TOKEN_DEV=<Your Sanity API Developer Token>
 SANITY_API_TOKEN_PROD=<Your Sanity API Viewer Token>
 
+# Preview/Draft mode secret (generate a random string)
+SANITY_PREVIEW_SECRET=<Random secret string for preview authentication>
+NEXT_PUBLIC_SANITY_STUDIO_PREVIEW_SECRET=<Random secret string for preview authentication>
+
 # ENV KEYS FOR SHARED STUDIO
 NEXT_PUBLIC_SANITY_SHARED_PROJECT_ID=<Your Sanity SHARED Project ID>
 NEXT_PUBLIC_SANITY_SHARED_DATASET=<Your Sanity SHARED Dataset>

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ NEXT_PUBLIC_SANITY_API_VERSION=<Your Sanity API Version>
 SANITY_API_TOKEN_DEV=<Your Sanity API Developer Token>
 SANITY_API_TOKEN_PROD=<Your Sanity API Viewer Token>
 
-# Preview/Draft mode secret (generate a random string)
+# Preview/Draft mode secret (generate a random string, should be the same for both env variables)
 SANITY_PREVIEW_SECRET=<Random secret string for preview authentication>
 NEXT_PUBLIC_SANITY_STUDIO_PREVIEW_SECRET=<Random secret string for preview authentication>
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,7 +22,7 @@ const securityHeaders = [
   },
   {
     key: "X-Frame-Options",
-    value: "DENY",
+    value: "SAMEORIGIN",
   },
   {
     key: "Permissions-Policy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-focus-on": "^3.9.4",
         "react-intersection-observer": "^9.15.1",
         "sanity": "^4.10.2",
+        "sanity-plugin-iframe-pane": "^4.0.0",
         "sanity-plugin-internationalized-array": "^3.2.0",
         "sanity-plugin-media": "^4.0.0",
         "sanity-plugin-simpler-color-input": "^3.1.1"
@@ -19364,6 +19365,28 @@
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "styled-components": "^6.1.15"
+      }
+    },
+    "node_modules/sanity-plugin-iframe-pane": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-iframe-pane/-/sanity-plugin-iframe-pane-4.0.0.tgz",
+      "integrity": "sha512-ta3hGPnwaMCpfRxe+ihlAST/4RSnnDFQlzZyXwMVvxj+alD0VuS9hSuuxfaP7iCIER+udR1FYkYRmIuf2KcR7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^3.7.4",
+        "@sanity/incompatible-plugin": "^1.0.5",
+        "@sanity/preview-url-secret": "^2.1.14",
+        "@sanity/ui": "^3.0.5",
+        "framer-motion": "^12.23.12",
+        "suspend-react": "0.1.3"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "react": "^18.3 || ^19",
+        "sanity": "^4",
+        "styled-components": "^6"
       }
     },
     "node_modules/sanity-plugin-internationalized-array": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-focus-on": "^3.9.4",
     "react-intersection-observer": "^9.15.1",
     "sanity": "^4.10.2",
+    "sanity-plugin-iframe-pane": "^4.0.0",
     "sanity-plugin-internationalized-array": "^3.2.0",
     "sanity-plugin-media": "^4.0.0",
     "sanity-plugin-simpler-color-input": "^3.1.1"

--- a/src/app/api/disable-draft/route.ts
+++ b/src/app/api/disable-draft/route.ts
@@ -1,9 +1,18 @@
 import { draftMode } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
-import { absoluteUrlFromNextRequest } from "src/utils/url";
-
 export async function GET(request: NextRequest) {
+  const slug = request.nextUrl.searchParams.get("slug");
+  const locale = request.nextUrl.searchParams.get("locale");
   (await draftMode()).disable();
-  return NextResponse.redirect(absoluteUrlFromNextRequest(request, "/"));
+
+  const previewLocale = locale || "no";
+  const previewSlug = slug || "";
+  const path =
+    previewSlug === "/" || previewSlug === ""
+      ? `/${previewLocale}`
+      : `/${previewLocale}/${previewSlug}`;
+
+  const url = new URL(path, request.nextUrl.origin);
+  return NextResponse.redirect(url);
 }

--- a/src/app/api/draft/route.ts
+++ b/src/app/api/draft/route.ts
@@ -1,31 +1,19 @@
 export const dynamic = "force-dynamic";
 
-import { validatePreviewUrl } from "@sanity/preview-url-secret";
 import { draftMode } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
-import { absoluteUrlFromNextRequest } from "src/utils/url";
-import { client } from "studio/lib/client";
-import { token } from "studio/lib/token";
-
-const clientWithToken = client.withConfig({ token });
-
 export async function GET(request: NextRequest) {
-  try {
-    const { isValid, redirectTo = "/" } = await validatePreviewUrl(
-      clientWithToken,
-      request.url,
-    );
+  const secret = request.nextUrl.searchParams.get("secret");
 
-    if (!isValid) {
+  try {
+    if (!secret || secret !== process.env.SANITY_PREVIEW_SECRET) {
       return new Response("Invalid secret", { status: 401 });
     }
 
     (await draftMode()).enable();
 
-    return NextResponse.redirect(
-      absoluteUrlFromNextRequest(request, redirectTo),
-    );
+    return NextResponse.redirect(new URL(request.url, request.nextUrl.origin));
   } catch (error) {
     console.error("Error in /api/draft:", error);
     return new Response("Internal Server Error", { status: 500 });

--- a/src/app/api/draft/route.ts
+++ b/src/app/api/draft/route.ts
@@ -5,6 +5,8 @@ import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
   const secret = request.nextUrl.searchParams.get("secret");
+  const slug = request.nextUrl.searchParams.get("slug");
+  const locale = request.nextUrl.searchParams.get("locale");
 
   try {
     if (!secret || secret !== process.env.SANITY_PREVIEW_SECRET) {
@@ -13,7 +15,15 @@ export async function GET(request: NextRequest) {
 
     (await draftMode()).enable();
 
-    return NextResponse.redirect(new URL(request.url, request.nextUrl.origin));
+    const previewLocale = locale || "no";
+    const previewSlug = slug || "";
+    const path =
+      previewSlug === "/" || previewSlug === ""
+        ? `/${previewLocale}`
+        : `/${previewLocale}/${previewSlug}`;
+
+    const url = new URL(path, request.nextUrl.origin);
+    return NextResponse.redirect(url);
   } catch (error) {
     console.error("Error in /api/draft:", error);
     return new Response("Internal Server Error", { status: 500 });

--- a/src/middlewares/nonceMiddleware.ts
+++ b/src/middlewares/nonceMiddleware.ts
@@ -18,7 +18,7 @@ const contentSecurityPolicy = (nonce: string) => {
     frame-src 'self' https://vercel.live/;
     base-uri 'self';
     form-action 'self';
-    frame-ancestors 'none';
+    frame-ancestors 'self';
     object-src 'none';
   `;
   return csp.replace(/\s{2,}/g, " ").trim();

--- a/src/utils/draftmode.ts
+++ b/src/utils/draftmode.ts
@@ -9,6 +9,6 @@ export interface DraftModeInfo {
 export async function getDraftModeInfo(): Promise<DraftModeInfo> {
   const draftModeResult = await draftMode();
   const isDraftMode = draftModeResult.isEnabled;
-  const perspective = isDraftMode ? "previewDrafts" : "published";
+  const perspective = isDraftMode ? "drafts" : "published";
   return { isDraftMode, perspective };
 }

--- a/studio/components/Preview.tsx
+++ b/studio/components/Preview.tsx
@@ -9,7 +9,6 @@ import {
 } from "@sanity/ui";
 import { useEffect, useRef, useState } from "react";
 import { AiOutlineReload } from "react-icons/ai";
-import { BiLinkExternal } from "react-icons/bi";
 import type { SanityDocument } from "sanity";
 
 import resolveProductionUrl from "studio/presentation/resolve";

--- a/studio/components/Preview.tsx
+++ b/studio/components/Preview.tsx
@@ -72,14 +72,6 @@ export function PreviewIFrame({ document }: PreviewIFrameProps) {
                 aria-label="Reload"
                 onClick={handleReload}
               />
-              <Button
-                fontSize={[1]}
-                icon={BiLinkExternal}
-                padding={[2]}
-                text="Open"
-                tone="primary"
-                onClick={() => window.open(displayUrl, "_blank")}
-              />
             </Flex>
           </Flex>
         </Card>

--- a/studio/components/Preview.tsx
+++ b/studio/components/Preview.tsx
@@ -40,7 +40,6 @@ export function PreviewIFrame({ document }: PreviewIFrameProps) {
 
     const url = resolveProductionUrl(displayedDoc) ?? "";
     setDisplayUrl(url);
-    console.log("Preview URL:", url);
   }, [displayedDoc]);
 
   if (!displayUrl) {

--- a/studio/components/Preview.tsx
+++ b/studio/components/Preview.tsx
@@ -1,0 +1,108 @@
+import {
+  Box,
+  Button,
+  Card,
+  Flex,
+  Spinner,
+  Text,
+  ThemeProvider,
+} from "@sanity/ui";
+import { useEffect, useRef, useState } from "react";
+import { AiOutlineReload } from "react-icons/ai";
+import { BiLinkExternal } from "react-icons/bi";
+import type { SanityDocument } from "sanity";
+
+import resolveProductionUrl from "studio/presentation/resolve";
+
+/**
+ * The props Sanity passes to a custom document view component.
+ */
+interface PreviewIFrameProps {
+  document: {
+    displayed?: SanityDocument;
+  };
+}
+
+export function PreviewIFrame({ document }: PreviewIFrameProps) {
+  const [iframeKey, setIframeKey] = useState(1);
+  const [displayUrl, setDisplayUrl] = useState("");
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const displayedDoc = document.displayed;
+
+  function handleReload() {
+    if (!iframeRef.current) return;
+    setIframeKey((prev) => prev + 1);
+  }
+
+  useEffect(() => {
+    if (!displayedDoc) return;
+
+    const url = resolveProductionUrl(displayedDoc) ?? "";
+    setDisplayUrl(url);
+    console.log("Preview URL:", url);
+  }, [displayedDoc]);
+
+  if (!displayUrl) {
+    return (
+      <ThemeProvider>
+        <Flex padding={5} align="center" justify="center">
+          <Spinner />
+        </Flex>
+      </ThemeProvider>
+    );
+  }
+
+  return (
+    <ThemeProvider>
+      <Flex direction="column" style={{ height: "100%" }}>
+        <Card padding={2} borderBottom>
+          <Flex align="center" gap={2}>
+            <Box flex={1}>
+              <Text size={0} textOverflow="ellipsis">
+                {displayUrl}
+              </Text>
+            </Box>
+            <Flex align="center" gap={1}>
+              <Button
+                fontSize={[1]}
+                padding={2}
+                icon={AiOutlineReload}
+                title="Reload"
+                text="Reload"
+                aria-label="Reload"
+                onClick={handleReload}
+              />
+              <Button
+                fontSize={[1]}
+                icon={BiLinkExternal}
+                padding={[2]}
+                text="Open"
+                tone="primary"
+                onClick={() => window.open(displayUrl, "_blank")}
+              />
+            </Flex>
+          </Flex>
+        </Card>
+
+        <Card tone="transparent" padding={0} style={{ height: "100%" }}>
+          <Flex align="center" justify="center" style={{ height: "100%" }}>
+            <iframe
+              key={iframeKey}
+              ref={iframeRef}
+              title="preview"
+              style={{
+                width: "100%",
+                height: "100%",
+                border: 0,
+                maxHeight: "100%",
+              }}
+              src={displayUrl}
+              referrerPolicy="origin-when-cross-origin"
+            />
+          </Flex>
+        </Card>
+      </Flex>
+    </ThemeProvider>
+  );
+}

--- a/studio/deskStructure.ts
+++ b/studio/deskStructure.ts
@@ -17,6 +17,7 @@ import {
 } from "@sanity/icons";
 import { StructureBuilder } from "sanity/structure";
 
+import { PreviewIFrame } from "./components/Preview";
 import { companyInfoID } from "./schemas/documents/admin/companyInfo";
 import { companyLocationID } from "./schemas/documents/admin/companyLocation";
 import { defaultSeoID } from "./schemas/documents/admin/defaultSeo";
@@ -160,10 +161,25 @@ const pagesSection = (S: StructureBuilder) =>
   S.listItem()
     .title("Pages")
     .icon(ProjectsIcon)
-    .child(S.documentTypeList(pageBuilderID).title("Pages"));
+    .child(
+      S.documentTypeList(pageBuilderID)
+        .title("Pages")
+        .child((documentId) =>
+          S.document()
+            .documentId(documentId)
+            .schemaType(pageBuilderID)
+            .views([
+              S.view.form(),
+              S.view
+                .component(PreviewIFrame)
+                .options({}) // language? locale params? slug?
+                .title("Preview"),
+            ]),
+        ),
+    );
 
 //Section for set pages
-const specialPagesSection = (S: StructureBuilder) =>
+export const specialPagesSection = (S: StructureBuilder) =>
   S.listItem()
     .title("Special Pages")
     .icon(SparkleIcon)
@@ -178,7 +194,11 @@ const specialPagesSection = (S: StructureBuilder) =>
               S.document()
                 .schemaType(compensationsId)
                 .documentId(compensationsId)
-                .title("Compensations"),
+                .title("Compensations")
+                .views([
+                  S.view.form(),
+                  S.view.component(PreviewIFrame).title("Preview"),
+                ]),
             ),
           S.listItem()
             .title("Customer Cases")
@@ -187,7 +207,11 @@ const specialPagesSection = (S: StructureBuilder) =>
               S.document()
                 .schemaType(customerCasesPageID)
                 .documentId(customerCasesPageID)
-                .title("Customer Cases"),
+                .title("Customer Cases")
+                .views([
+                  S.view.form(),
+                  S.view.component(PreviewIFrame).title("Preview"),
+                ]),
             ),
         ]),
     );

--- a/studio/deskStructure.ts
+++ b/studio/deskStructure.ts
@@ -176,7 +176,7 @@ const pagesSection = (S: StructureBuilder) =>
     );
 
 //Section for set pages
-export const specialPagesSection = (S: StructureBuilder) =>
+const specialPagesSection = (S: StructureBuilder) =>
   S.listItem()
     .title("Special Pages")
     .icon(SparkleIcon)

--- a/studio/deskStructure.ts
+++ b/studio/deskStructure.ts
@@ -170,10 +170,7 @@ const pagesSection = (S: StructureBuilder) =>
             .schemaType(pageBuilderID)
             .views([
               S.view.form(),
-              S.view
-                .component(PreviewIFrame)
-                .options({}) // language? locale params? slug?
-                .title("Preview"),
+              S.view.component(PreviewIFrame).title("Preview"),
             ]),
         ),
     );

--- a/studio/lib/client.ts
+++ b/studio/lib/client.ts
@@ -9,10 +9,10 @@ export const client = createClient({
   dataset,
   projectId,
   useCdn,
-  perspective:
-    process.env.NODE_ENV === "development" ? "previewDrafts" : "published",
+  perspective: process.env.NODE_ENV === "development" ? "drafts" : "published",
   stega: {
     enabled: false,
     studioUrl: "/studio",
   },
+  token: process.env.SANITY_PREVIEW_SECRET,
 });

--- a/studio/lib/client.ts
+++ b/studio/lib/client.ts
@@ -14,5 +14,5 @@ export const client = createClient({
     enabled: false,
     studioUrl: "/studio",
   },
-  token: process.env.SANITY_PREVIEW_SECRET,
+  token: process.env.SANITY_API_TOKEN_PROD,
 });

--- a/studio/lib/client.ts
+++ b/studio/lib/client.ts
@@ -14,5 +14,4 @@ export const client = createClient({
     enabled: false,
     studioUrl: "/studio",
   },
-  token: process.env.SANITY_API_TOKEN_PROD,
 });

--- a/studio/presentation/resolve.ts
+++ b/studio/presentation/resolve.ts
@@ -1,0 +1,25 @@
+// resolveProductionUrl.ts
+import type { SanityDocument } from "sanity";
+
+const remoteUrl = process.env.NEXT_PUBLIC_URL || "https://www.variant.no";
+const localUrl = `http://localhost:3000`;
+
+const secret = process.env.SANITY_STUDIO_PREVIEW_SECRET || "";
+
+//function getSlug(slug: any) {
+//  if (!slug) return "/";
+//  if (slug.current) return slug.current;
+//  return "/";
+//}
+
+export default function resolveProductionUrl(doc: SanityDocument) {
+  console.log(doc); //bare for at doc skal brukes og den slutter å klage
+  const baseUrl =
+    window.location.hostname === "localhost" ? localUrl : remoteUrl;
+  const previewUrl = new URL(baseUrl);
+  //const slug = doc.slug;
+  console.log("Resolving preview URL for slug:", secret);
+  previewUrl.searchParams.append(`/api/draft`, secret);
+  //previewUrl.searchParams.append(`slug`, getSlug(slug));
+  return previewUrl.pathname.toString();
+}

--- a/studio/presentation/resolve.ts
+++ b/studio/presentation/resolve.ts
@@ -53,7 +53,6 @@ export default function resolveProductionUrl(doc: SanityDocument) {
     doc.slug as Slug | string | InternationalizedSlug[] | undefined,
     language,
   );
-  console.log("Document slug for preview:", slug);
   if (slug) {
     previewUrl.searchParams.append("slug", slug);
   }

--- a/studio/presentation/resolve.ts
+++ b/studio/presentation/resolve.ts
@@ -1,25 +1,62 @@
 // resolveProductionUrl.ts
-import type { SanityDocument } from "sanity";
+import type { SanityDocument, Slug } from "sanity";
 
 const remoteUrl = process.env.NEXT_PUBLIC_URL || "https://www.variant.no";
 const localUrl = `http://localhost:3000`;
 
-const secret = process.env.SANITY_STUDIO_PREVIEW_SECRET || "";
+const secret = process.env.NEXT_PUBLIC_SANITY_STUDIO_PREVIEW_SECRET || "";
 
-//function getSlug(slug: any) {
-//  if (!slug) return "/";
-//  if (slug.current) return slug.current;
-//  return "/";
-//}
+interface InternationalizedSlug {
+  _key: string;
+  value: string;
+}
+
+function getSlug(
+  slug: Slug | string | InternationalizedSlug[] | undefined | null,
+  locale?: string,
+): string {
+  if (!slug) return "";
+
+  if (Array.isArray(slug)) {
+    const localizedSlug = slug.find((s) => s._key === locale);
+    return localizedSlug?.value || slug[0]?.value || "";
+  }
+
+  if (typeof slug === "object" && "current" in slug && slug.current) {
+    return slug.current;
+  }
+
+  if (typeof slug === "string") return slug;
+
+  return "";
+}
+
+function getLanguage(doc: SanityDocument): string {
+  if (doc.language && typeof doc.language === "string") return doc.language;
+  if (doc._lang && typeof doc._lang === "string") return doc._lang;
+  // Default to 'no' if no language is specified
+  return "no";
+}
 
 export default function resolveProductionUrl(doc: SanityDocument) {
-  console.log(doc); //bare for at doc skal brukes og den slutter å klage
   const baseUrl =
     window.location.hostname === "localhost" ? localUrl : remoteUrl;
   const previewUrl = new URL(baseUrl);
-  //const slug = doc.slug;
-  console.log("Resolving preview URL for slug:", secret);
-  previewUrl.searchParams.append(`/api/draft`, secret);
-  //previewUrl.searchParams.append(`slug`, getSlug(slug));
-  return previewUrl.pathname.toString();
+  previewUrl.pathname = "/api/draft";
+  const isDraft = doc._id.startsWith("drafts.");
+  if (!isDraft) {
+    previewUrl.pathname = "/api/disable-draft";
+  }
+  previewUrl.searchParams.append("secret", secret);
+  const language = getLanguage(doc);
+  const slug = getSlug(
+    doc.slug as Slug | string | InternationalizedSlug[] | undefined,
+    language,
+  );
+  console.log("Document slug for preview:", slug);
+  if (slug) {
+    previewUrl.searchParams.append("slug", slug);
+  }
+  previewUrl.searchParams.append("locale", language);
+  return previewUrl.toString();
 }

--- a/studio/studioConfig.tsx
+++ b/studio/studioConfig.tsx
@@ -64,6 +64,7 @@ const config: WorkspaceOptions = {
       previewUrl: {
         previewMode: {
           enable: "/api/draft",
+          disable: "/api/disable-draft",
         },
       },
     }),


### PR DESCRIPTION
Mulliggjør previewmode for pages, slik at man kan se endringer man gjør i sanntid. Det er satt opp et eget Ifame i studio, hvor endringene kan vise. 

relates to #1450 

## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
