### PR TITLE
fix: remove recursive call to LiveVisualEditing

### DIFF
--- a/studio/lib/loaders/AutomaticVisualEditing.tsx
+++ b/studio/lib/loaders/AutomaticVisualEditing.tsx
@@ -3,6 +3,7 @@
 "use client";
 
 import { useLiveMode } from "@sanity/react-loader";
+import { VisualEditing } from "next-sanity/visual-editing";
 import { useEffect } from "react";
 
 import { client } from "studio/lib/client";
@@ -18,6 +19,5 @@ export default function LiveVisualEditing() {
       location.href = "/api/disable-draft";
     }
   }, []);
-
-  return <LiveVisualEditing />;
+  return <VisualEditing />;
 }


### PR DESCRIPTION
Dont allow LiveVisualEditing to call itself recursively. 
This was probably a bug introduced in the last round of updates (removing VisualEditing), only discovered now after Drafts mode has been implemented.

Reintroduce a return of the VisualEditing component now available in next-sanity/visual-editing.



## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
