### PR TITLE
1467 lage blogpost eventsection i sanity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "19.2.0",
         "react-focus-on": "^3.9.4",
         "react-intersection-observer": "^9.15.1",
+        "rss-parser": "^3.13.0",
         "sanity": "^4.10.2",
         "sanity-plugin-iframe-pane": "^4.0.0",
         "sanity-plugin-internationalized-array": "^3.2.0",
@@ -19023,6 +19024,25 @@
       "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
       "license": "MIT"
     },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/rss-parser/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -20175,6 +20195,12 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/sax": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -23296,6 +23322,28 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "19.2.0",
     "react-focus-on": "^3.9.4",
     "react-intersection-observer": "^9.15.1",
+    "rss-parser": "^3.13.0",
     "sanity": "^4.10.2",
     "sanity-plugin-iframe-pane": "^4.0.0",
     "sanity-plugin-internationalized-array": "^3.2.0",

--- a/src/app/api/blog-articles/route.ts
+++ b/src/app/api/blog-articles/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import Parser from "rss-parser";
+
+const parser = new Parser({
+  customFields: {
+    item: [["content:encoded", "content"]],
+  },
+});
+
+export async function GET() {
+  const FEED_URL = "https://blog.variant.no/feed";
+
+  try {
+    const feed = await parser.parseURL(FEED_URL);
+
+    const articles = feed.items.map((item) => {
+      let thumbnail: { src: string; alt: string } | null = null;
+      let description = item.contentSnippet || "";
+
+      if (item.content) {
+        const imgMatch = item.content.match(
+          /<img[^>]+alt="([^"]*)"[^>]+src="([^">]+)"|<img[^>]+src="([^">]+)"[^>]+alt="([^"]*)"/,
+        );
+        if (imgMatch) {
+          const alt = imgMatch[1] || "";
+          const src = imgMatch[2] || "";
+          if (src) {
+            thumbnail = { src, alt };
+          }
+        }
+
+        const text = item.content.replace(/<[^>]*>?/gm, "");
+        description = text.substring(0, 125) + "...";
+      }
+
+      return {
+        title: item.title || "No title",
+        url: item.link || "",
+        pubDate: item.pubDate || "",
+        thumbnail,
+        description,
+        creator: item.creator || "",
+      };
+    });
+
+    return NextResponse.json(articles, {
+      headers: {
+        "Cache-Control": "s-maxage=3600, stale-while-revalidate",
+      },
+    });
+  } catch (error) {
+    console.error("Error when fetching RSS-feed:", error);
+    return NextResponse.json(
+      { error: "Could not fetch articles" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/blogArticles/route.ts
+++ b/src/app/api/blogArticles/route.ts
@@ -36,7 +36,7 @@ export async function GET() {
       return {
         title: item.title || "No title",
         url: item.link || "",
-        pubDate: item.pubDate || "",
+        publishedDate: item.pubDate || "",
         thumbnail,
         description,
         creator: item.creator || "",

--- a/src/components/sections/blog/Blog.tsx
+++ b/src/components/sections/blog/Blog.tsx
@@ -3,23 +3,24 @@
 import React, { useEffect, useState } from "react";
 
 import Text from "src/components/text/Text";
+import { MediumCardProps } from "studio/lib/interfaces/mediumCard";
 import { BlogSection } from "studio/lib/interfaces/pages";
 
 import styles from "./blog.module.css";
-import MediumCard, { MediumCardProps } from "./MediumCard";
+import MediumCard from "./MediumCard";
 
 export interface BlogSectionProps {
   section: BlogSection;
 }
 
 export default function Blog({ section }: BlogSectionProps) {
-  const [articles, setArticles] = useState<MediumCardProps[]>([]);
+  const [blogArticles, setArticles] = useState<MediumCardProps[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchArticles = async () => {
       try {
-        const response = await fetch("/api/blog-articles");
+        const response = await fetch("/api/blogArticles");
         const data = await response.json();
         setArticles(data);
       } catch (error) {
@@ -39,7 +40,7 @@ export default function Blog({ section }: BlogSectionProps) {
         <div>Loading...</div>
       ) : (
         <div className={styles.articles}>
-          {articles.slice(0, section.postNumber).map((article, index) => (
+          {blogArticles.slice(0, section.postNumber).map((article, index) => (
             <MediumCard
               key={index}
               article={{

--- a/src/components/sections/blog/Blog.tsx
+++ b/src/components/sections/blog/Blog.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+import Text from "src/components/text/Text";
+import { BlogSection } from "studio/lib/interfaces/pages";
+
+import styles from "./blog.module.css";
+import MediumCard, { MediumCardProps } from "./MediumCard";
+
+export interface BlogSectionProps {
+  section: BlogSection;
+}
+
+export default function Blog({ section }: BlogSectionProps) {
+  const [articles, setArticles] = useState<MediumCardProps[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchArticles = async () => {
+      try {
+        const response = await fetch("/api/blog-articles");
+        const data = await response.json();
+        setArticles(data);
+      } catch (error) {
+        console.error("Failed to fetch articles:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchArticles();
+  }, []);
+
+  return (
+    <div className={styles.wrapper}>
+      <Text type="titleL">{section.basicTitle}</Text>
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <div className={styles.articles}>
+          {articles.slice(0, section.postNumber).map((article, index) => (
+            <MediumCard
+              key={index}
+              article={{
+                ...article,
+                buttonTitle: section.buttonTitle || "Les mer",
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sections/blog/MediumCard.tsx
+++ b/src/components/sections/blog/MediumCard.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+import CustomLink from "src/components/link/CustomLink";
+import Text from "src/components/text/Text";
+import { ILink, LinkType } from "studio/lib/interfaces/navigation";
+
+import styles from "./blog.module.css";
+
+export interface MediumCardProps {
+  title: string;
+  url?: string;
+  pubDate?: string;
+  thumbnail?: { src: string; alt: string } | null;
+  description?: string;
+  creator?: string;
+  buttonTitle?: string;
+}
+
+const MediumCard: React.FC<{ article: MediumCardProps }> = ({ article }) => {
+  const formattedDate = article.pubDate
+    ? new Date(article.pubDate).toLocaleDateString("no-NO")
+    : "";
+
+  const link: ILink | undefined = article.url
+    ? {
+        _key: article.url,
+        _type: "link",
+        linkTitle: article.buttonTitle || "Les mer",
+        linkType: LinkType.External,
+        url: article.url,
+        newTab: true,
+      }
+    : undefined;
+
+  return (
+    <div className={styles.cardWrapper}>
+      <div className={styles.cardContent}>
+        <Text type="titleM">{article.title}</Text>
+        <div className={styles.cardSubtitle}>
+          <Text type="labelL">{formattedDate}</Text>
+          <span className={styles.dotSeparator}>•</span>
+          <Text type="labelL">{article.creator}</Text>
+        </div>
+        <Text type="normal">{article.description}</Text>
+        <div className={styles.articleButton}>
+          {link && <CustomLink link={link} />}
+        </div>
+      </div>
+      {article.thumbnail && (
+        <img
+          src={article.thumbnail.src}
+          alt={article.thumbnail.alt}
+          className={styles.cardImage}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MediumCard;

--- a/src/components/sections/blog/MediumCard.tsx
+++ b/src/components/sections/blog/MediumCard.tsx
@@ -2,23 +2,14 @@ import React from "react";
 
 import CustomLink from "src/components/link/CustomLink";
 import Text from "src/components/text/Text";
+import { MediumCardProps } from "studio/lib/interfaces/mediumCard";
 import { ILink, LinkType } from "studio/lib/interfaces/navigation";
 
 import styles from "./blog.module.css";
 
-export interface MediumCardProps {
-  title: string;
-  url?: string;
-  pubDate?: string;
-  thumbnail?: { src: string; alt: string } | null;
-  description?: string;
-  creator?: string;
-  buttonTitle?: string;
-}
-
 const MediumCard: React.FC<{ article: MediumCardProps }> = ({ article }) => {
-  const formattedDate = article.pubDate
-    ? new Date(article.pubDate).toLocaleDateString("no-NO")
+  const formattedDate = article.publishedDate
+    ? new Date(article.publishedDate).toLocaleDateString("no-NO")
     : "";
 
   const link: ILink | undefined = article.url

--- a/src/components/sections/blog/blog.module.css
+++ b/src/components/sections/blog/blog.module.css
@@ -1,0 +1,82 @@
+.cardWrapper {
+  display: flex;
+  flex-direction: row;
+  padding: 2rem;
+  border: 2px solid;
+  border-radius: 1rem;
+  border-color: var(--background-bg-light-primary);
+  justify-content: space-between;
+  background-color: var(--background-bg-light-primary);
+
+  @media (width <= 834px) {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 1rem;
+    padding: 1rem;
+  }
+}
+
+.cardContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+  max-width: 60%;
+  justify-content: space-between;
+
+  @media (width <= 834px) {
+    max-width: 100%;
+  }
+}
+
+.cardSubtitle {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0.5rem;
+}
+
+.cardImage {
+  display: flex;
+  max-width: 20rem;
+  object-fit: contain;
+
+  @media (width <= 834px) {
+    display: flex;
+    justify-self: center;
+    max-width: 100%;
+  }
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  max-width: var(--max-content-width-large);
+  margin: 0 auto;
+  padding: 5rem 0;
+  gap: 2rem;
+}
+
+.articles {
+  display: grid;
+  gap: 1rem;
+  justify-content: center;
+  padding: 1rem;
+  border-radius: 1rem;
+  background-color: var(--background-bg-yellow);
+}
+
+.articleButton {
+  margin-top: auto;
+  width: fit-content;
+}
+
+.dotSeparator {
+  display: inline-block;
+}
+
+.dotSeperator::after {
+  content: "·";
+  margin: 0 0.38rem;
+}

--- a/src/middlewares/nonceMiddleware.ts
+++ b/src/middlewares/nonceMiddleware.ts
@@ -13,7 +13,7 @@ const contentSecurityPolicy = (nonce: string) => {
       process.env.NODE_ENV !== "production" ? "'unsafe-eval'" : ""
     };
     style-src 'self' 'unsafe-inline';
-    img-src 'self' data: https://cdn.sanity.io/;
+    img-src 'self' data: https://cdn.sanity.io/ https://cdn-images-1.medium.com/ https://miro.medium.com/;
     media-src 'self';
     frame-src 'self' https://vercel.live/;
     base-uri 'self';

--- a/src/utils/renderSection.tsx
+++ b/src/utils/renderSection.tsx
@@ -1,6 +1,7 @@
 import { QueryResponseInitial } from "@sanity/react-loader";
 
 import EventRegistration from "src/components/hubspot/eventRegistration/eventRegistration";
+import Blog from "src/components/sections/blog/Blog";
 import CompensationCalculator from "src/components/sections/compensation-calculator/CompensationCalculator";
 import ContactBox from "src/components/sections/contact-box/ContactBox";
 import CustomerCasesEntry from "src/components/sections/customerCasesEntry/CustomerCasesEntry";
@@ -221,6 +222,8 @@ const SectionRenderer = ({
       return <GridSectionComponent section={section} />;
     case "eventRegistration":
       return <EventRegistration section={section} />;
+    case "blogSection":
+      return <Blog section={section} />;
     default:
       return null;
   }

--- a/studio/lib/interfaces/mediumCard.ts
+++ b/studio/lib/interfaces/mediumCard.ts
@@ -1,0 +1,9 @@
+export interface MediumCardProps {
+  title: string;
+  url?: string;
+  publishedDate?: string;
+  thumbnail?: { src: string; alt: string } | null;
+  description?: string;
+  creator?: string;
+  buttonTitle?: string;
+}

--- a/studio/lib/interfaces/pages.ts
+++ b/studio/lib/interfaces/pages.ts
@@ -257,6 +257,14 @@ export interface EventRegistrationSection {
   interests: string[];
 }
 
+export interface BlogSection {
+  _type: "blogSection";
+  _key: string;
+  basicTitle: string;
+  buttonTitle: string;
+  postNumber: number;
+}
+
 export type Section =
   | HeroSection
   | LogoSaladSection
@@ -278,7 +286,8 @@ export type Section =
   | HandbookSection
   | SplitSection
   | FieldGrid
-  | EventRegistrationSection;
+  | EventRegistrationSection
+  | BlogSection;
 
 export interface PageBuilder {
   _createdAt: string;

--- a/studio/lib/queries/pages.ts
+++ b/studio/lib/queries/pages.ts
@@ -90,6 +90,11 @@ const SECTIONS_FRAGMENT = groq`
         }
       }
     },
+    _type == "blogSection" => {
+      "basicTitle": ${translatedFieldFragment("basicTitle")},
+      "buttonTitle": ${translatedFieldFragment("buttonTitle")},
+      "postNumber": postNumber,
+    },
     _type == "employees" => {
       "basicTitle": ${translatedFieldFragment("basicTitle")}
     },

--- a/studio/schemas/documents/pageBuilder.ts
+++ b/studio/schemas/documents/pageBuilder.ts
@@ -2,6 +2,7 @@ import { defineField, defineType } from "sanity";
 
 import { isInternationalizedString } from "studio/lib/interfaces/global";
 import { titleID } from "studio/schemas/fields/text";
+import { blogSection } from "studio/schemas/objects/sections/blog";
 import { compensationCalculator } from "studio/schemas/objects/sections/compensation-calculator";
 import contactBox from "studio/schemas/objects/sections/contact-box";
 import { customerCasesEntry } from "studio/schemas/objects/sections/customerCasesEntry";
@@ -55,6 +56,7 @@ const pageBuilder = defineType({
         logoSalad,
         imageSplitSection,
         imageSection,
+        blogSection,
         employees,
         customerCasesEntry,
         contactBox,

--- a/studio/schemas/objects/sections/blog.ts
+++ b/studio/schemas/objects/sections/blog.ts
@@ -1,0 +1,50 @@
+import { DocumentsIcon } from "@sanity/icons";
+import { defineField } from "sanity";
+
+import { titleID } from "studio/schemas/fields/text";
+
+const blogSectionID = "blogSection";
+
+export const blogSection = defineField({
+  name: blogSectionID,
+  title: "Blog",
+  type: "object",
+  icon: DocumentsIcon,
+  fields: [
+    {
+      name: titleID.basic,
+      title: "Title",
+      description:
+        "Enter the title for the blog section (e.g., 'Latest from Variant Blog')",
+      type: "internationalizedArrayString",
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: "buttonTitle",
+      title: "Button Title",
+      description: "Enter the title for the 'Read More' button",
+      type: "internationalizedArrayString",
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: "postNumber",
+      title: "Number of blog posts",
+      description:
+        "Enter the number of blog posts you want to show in the Blog Section. It has to be between 1-10.",
+      type: "number",
+      validation: (rule) =>
+        rule
+          .required()
+          .min(1)
+          .max(10)
+          .error("Please enter a number between 1 and 10"),
+    },
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: "Blog Section",
+      };
+    },
+  },
+});

--- a/studio/schemas/objects/sections/blog.ts
+++ b/studio/schemas/objects/sections/blog.ts
@@ -15,14 +15,15 @@ export const blogSection = defineField({
       name: titleID.basic,
       title: "Title",
       description:
-        "Enter the title for the blog section (e.g., 'Latest from Variant Blog')",
+        "Enter the title for the blog section with blog posts from our Medium " +
+        "blog at https://blog.variant.no (e.g., 'Latest from Variant Blog').",
       type: "internationalizedArrayString",
       validation: (rule) => rule.required(),
     },
     {
       name: "buttonTitle",
       title: "Button Title",
-      description: "Enter the title for the 'Read More' button",
+      description: "Enter the title for the 'Read More' button.",
       type: "internationalizedArrayString",
       validation: (rule) => rule.required(),
     },
@@ -30,7 +31,8 @@ export const blogSection = defineField({
       name: "postNumber",
       title: "Number of blog posts",
       description:
-        "Enter the number of blog posts you want to show in the Blog Section. It has to be between 1-10.",
+        "Enter the number of blog posts you want to show in the Blog Section. " +
+        "It has to be between 1-10.",
       type: "number",
       validation: (rule) =>
         rule


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [X] The design works for both desktop and mobile
- [X] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [X] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Legger til ny seksjon i sanity studio som gjør det mulig å vise dei siste blog-postene fra Medium på nettsiden. Alle felt kreves utfylt nå, dette kan endres på senere. Og det er mulig å velge antall blog-poster man vil vise, fra 1-10. 

En ny route er laget for å hente de siste 10 bloggpostene fra medium sin feed via rss. 

I frontend er det laget et midlertidig design slik at det er mulig å se hva man kan hente fra medium i studio.