### PR TITLE
fix: Update relase time and number of releases to show in changelog

### DIFF
--- a/.auto-changelog
+++ b/.auto-changelog
@@ -4,5 +4,6 @@
   "unreleased": false,
   "commitLimit": false,
   "startingVersion": "v3.0.0",
-  "package": true
+  "package": true,
+  "releaseLimit": 4
 }

--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -3,8 +3,7 @@ name: Update Changelog
 on:
   # Runs every Friday at 2:00 PM UTC
   schedule:
-    - cron: "0 13 * * 2"
-      # - cron: "0 13 * * 5" //Change to Friday once tested
+    - cron: "0 13 * * 5"
   workflow_dispatch: # allows manual trigger
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Release v3.0.0
 
-> 17 November 2025
+> 20 November 2025
 
 ### Merged to Main 🔀
 
+- feat: small change in locale no, for testing automatic changelog [1472](https://github.com/varianter/variant.no/pull/1472) --anemne
+- fix: fetch commits for changelog [1471](https://github.com/varianter/variant.no/pull/1471) --anemne
+- fix: remove recursive call to LiveVisualEditing [1470](https://github.com/varianter/variant.no/pull/1470) --Robin Hovind
 - fix: remoteURL [1465](https://github.com/varianter/variant.no/pull/1465) --anemne
 - fix: remove line from remoteurl to enable previewmode [1463](https://github.com/varianter/variant.no/pull/1463) --anemne
 - feat: preview mode in studio [1461](https://github.com/varianter/variant.no/pull/1461) --anemne
@@ -75,6 +78,7 @@
 - add description, [00d8044](https://github.com/varianter/variant.no/commit/00d8044e929c69cb6f65298c50307c3abd48887b) --Mikael Brevik
 - fix: punch box min height, [26c8b45](https://github.com/varianter/variant.no/commit/26c8b4555847686431fa42330c9ac823eb0d5d7a) --Mikael Brevik
 - fix: readds missing breakwords for punch, [6a691c1](https://github.com/varianter/variant.no/commit/6a691c1b57796f785923a80d67f7d1e313dc0737) --Mikael Brevik
+- fix: remove recursive call (LiveVisualEditing), reintroduce call to VisualEditing component instead, [52cd4e1](https://github.com/varianter/variant.no/commit/52cd4e1ecf98588a365099e3c4f24ccc7efcc7ef) --Robin Hovind
 - fix: remove padding for body temp, bad fix, [27cd4bf](https://github.com/varianter/variant.no/commit/27cd4bfa05ba421370ff651e7ed2c4f53fff8ada) --Mikael Brevik
 
 ## Release v3.0.3


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
