### PR TITLE
fix: route /en/kalkulator to /en/compensations

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -246,6 +246,17 @@ const nextConfig = {
         ],
         permanent: true,
       },
+      {
+        source: "/en/kalkulator",
+        destination: "https://www.variant.no/en/compensations",
+        has: [
+          {
+            type: "host",
+            value: "www.variant.no",
+          },
+        ],
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Issue
When navigating to www.variant.no/kalkulator with a browser with preferred-language set to English, the user is routed to /en/kalkulator which does not exist.

This PR redirects the user to the correct /en/compensations page.

## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
