### PR TITLE
1486 contact box bug på mobil

### DIFF
--- a/src/components/employeeCard/employeeCard.module.css
+++ b/src/components/employeeCard/employeeCard.module.css
@@ -53,13 +53,23 @@
 .employeeImage {
   display: block;
   height: 206px;
-  min-width: 206px;
+  min-width: 150px; /* Mobile */
   width: 100%;
   max-width: var(--Text-paragraph, 537px);
   position: relative;
   background-color: var(--background-bg-dark);
   border-radius: var(--medium, 12px);
   overflow: hidden;
+
+  /* Desktop */
+  @media (width >= 800px) {
+    min-width: 206px;
+  }
+
+  /* Most tablets and bigger phones */
+  @media (width >= 400px) and (width < 800px) {
+    min-width: 170px;
+  }
 }
 
 .employeeImage--dark {

--- a/src/components/sections/contact-box/contact-box.module.css
+++ b/src/components/sections/contact-box/contact-box.module.css
@@ -51,6 +51,11 @@
 .contactSelector {
   display: flex;
   gap: 1rem;
+
+  /* Mobile */
+  @media (width <= 440px) {
+    flex-direction: column;
+  }
 }
 
 .tagList {
@@ -61,6 +66,11 @@
   min-width: 120px;
   margin: 0;
   padding: 0;
+
+  /* Mobile */
+  @media (width <= 440px) {
+    flex-direction: row;
+  }
 }
 
 .tagList li {

--- a/src/components/sections/employees/employees.module.css
+++ b/src/components/sections/employees/employees.module.css
@@ -72,8 +72,13 @@
 
 .peopleContainer {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 1.5rem;
+
+  /* Desktop */
+  @media (width >= 1024px) {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  }
 }
 
 .showMore {


### PR DESCRIPTION
## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [ ] The design works for both desktop and mobile
- [ ] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [ ] New functions that can be used in multiple components has been put in a `utils` directory
- [ ] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio

Bilder på mobil skal nå passe inn i contact-box. Har også endret på mobil-design for at bildet ikke blir veldig lite med å plassere det under taglist istedet for ved siden av. 