### PR TITLE
feat: add frontpage featured cases selection in shared studio

### DIFF
--- a/src/components/sections/customerCasesEntry/CustomerCasesEntry.tsx
+++ b/src/components/sections/customerCasesEntry/CustomerCasesEntry.tsx
@@ -33,9 +33,7 @@ async function CustomerCasesEntry({ language, section }: CustomerCasesProps) {
       CustomerCaseEntry[] | null
     >(FRONTPAGE_FEATURED_CASES_QUERY, { language, domain }, { perspective });
 
-    if (featuredCasesResult.data && featuredCasesResult.data.length > 0) {
-      customerCases = featuredCasesResult.data;
-    }
+    customerCases = featuredCasesResult.data ?? [];
   } catch {
     // Singleton document may not exist yet
   }

--- a/src/components/sections/customerCasesEntry/CustomerCasesEntry.tsx
+++ b/src/components/sections/customerCasesEntry/CustomerCasesEntry.tsx
@@ -31,7 +31,7 @@ async function CustomerCasesEntry({ language, section }: CustomerCasesProps) {
   try {
     const featuredCasesResult = await loadSharedQuery<
       CustomerCaseEntry[] | null
-    >(FRONTPAGE_FEATURED_CASES_QUERY, { language }, { perspective });
+    >(FRONTPAGE_FEATURED_CASES_QUERY, { language, domain }, { perspective });
 
     if (featuredCasesResult.data && featuredCasesResult.data.length > 0) {
       customerCases = featuredCasesResult.data;

--- a/src/components/sections/customerCasesEntry/CustomerCasesEntry.tsx
+++ b/src/components/sections/customerCasesEntry/CustomerCasesEntry.tsx
@@ -8,7 +8,10 @@ import { CustomerCasesEntrySection } from "studio/lib/interfaces/pages";
 import { CUSTOMER_CASES_PAGE_SITEMAP_QUERY } from "studio/lib/queries/specialPages";
 import { loadStudioQuery } from "studio/lib/store";
 import { CustomerCaseEntry } from "studioShared/lib/interfaces/customerCases";
-import { CUSTOMER_CASE_ENTRY_QUERY } from "studioShared/lib/queries/customerCases";
+import {
+  CUSTOMER_CASE_ENTRY_QUERY,
+  FRONTPAGE_FEATURED_CASES_QUERY,
+} from "studioShared/lib/queries/customerCases";
 import { loadSharedQuery } from "studioShared/lib/store";
 
 import styles from "./customerCasesEntry.module.css";
@@ -23,16 +26,28 @@ async function CustomerCasesEntry({ language, section }: CustomerCasesProps) {
   const { perspective } = await getDraftModeInfo();
   const domain = domainFromHostname((await headers()).get("host"));
 
-  const customerCaseResult = await loadSharedQuery<CustomerCaseEntry[]>(
-    CUSTOMER_CASE_ENTRY_QUERY,
-    {
-      domain,
-      language,
-    },
-    {
-      perspective,
-    },
-  );
+  let customerCases: CustomerCaseEntry[] = [];
+
+  try {
+    const featuredCasesResult = await loadSharedQuery<
+      CustomerCaseEntry[] | null
+    >(FRONTPAGE_FEATURED_CASES_QUERY, { language }, { perspective });
+
+    if (featuredCasesResult.data && featuredCasesResult.data.length > 0) {
+      customerCases = featuredCasesResult.data;
+    }
+  } catch {
+    // Singleton document may not exist yet
+  }
+
+  if (customerCases.length === 0) {
+    const allCasesResult = await loadSharedQuery<CustomerCaseEntry[]>(
+      CUSTOMER_CASE_ENTRY_QUERY,
+      { domain, language },
+      { perspective },
+    );
+    customerCases = allCasesResult.data ?? [];
+  }
 
   const customerCasePageSlug = (
     await loadStudioQuery<{ slug: string } | null>(
@@ -44,7 +59,7 @@ async function CustomerCasesEntry({ language, section }: CustomerCasesProps) {
   ).data?.slug;
 
   return (
-    customerCaseResult && (
+    customerCases.length > 0 && (
       <div className={styles.firstWrapper}>
         <div className={styles.titleWrapper}>
           <Text type="titleM" as="h2">
@@ -52,7 +67,7 @@ async function CustomerCasesEntry({ language, section }: CustomerCasesProps) {
           </Text>
         </div>
         <CustomerCasesList
-          customerCases={customerCaseResult.data}
+          customerCases={customerCases}
           language={language}
           customerCasePageSlug={customerCasePageSlug}
         />

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -15,7 +15,9 @@ export function absoluteUrlFromNextRequest(
   return absoluteUrl;
 }
 
-const FALLBACK_DOMAIN = "variant.no";
+const FALLBACK_DOMAIN = process.env.NEXT_PUBLIC_SWEDISH
+  ? "variant.se"
+  : "variant.no";
 
 /**
  * attempts to extract the relevant Variant domain, without subdomains, from the given hostname

--- a/studioShared/deskStructure.ts
+++ b/studioShared/deskStructure.ts
@@ -17,8 +17,6 @@ export const deskStructure: StructureResolver = (S) =>
         .title("Frontpage Settings")
         .icon(StarIcon)
         .child(
-          S.document()
-            .schemaType(frontpageSettingsID)
-            .documentId(frontpageSettingsID),
+          S.documentTypeList(frontpageSettingsID).title("Frontpage Settings"),
         ),
     ]);

--- a/studioShared/deskStructure.ts
+++ b/studioShared/deskStructure.ts
@@ -1,7 +1,8 @@
-import { ProjectsIcon } from "@sanity/icons";
+import { ProjectsIcon, StarIcon } from "@sanity/icons";
 import { StructureResolver } from "sanity/structure";
 
 import { customerCaseID } from "./schemas/documents/customerCase";
+import { frontpageSettingsID } from "./schemas/documents/frontpageSettings";
 
 export const deskStructure: StructureResolver = (S) =>
   S.list()
@@ -11,4 +12,13 @@ export const deskStructure: StructureResolver = (S) =>
         .title("Customer cases")
         .icon(ProjectsIcon)
         .child(S.documentTypeList(customerCaseID).title("Customer cases")),
+      S.divider(),
+      S.listItem()
+        .title("Frontpage Settings")
+        .icon(StarIcon)
+        .child(
+          S.document()
+            .schemaType(frontpageSettingsID)
+            .documentId(frontpageSettingsID),
+        ),
     ]);

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -150,7 +150,7 @@ export const CUSTOMER_CASE_ENTRY_QUERY = groq`
 `;
 
 export const FRONTPAGE_FEATURED_CASES_QUERY = groq`
-  *[_type == "frontpageSettings"][0].featuredCases[] -> {
+  *[_type == "frontpageSettings" && $domain in domains][0].featuredCases[] -> {
     ${CUSTOMER_CASE_BASE_FRAGMENT},
     "projectInfo": projectInfo {
       customer,

--- a/studioShared/lib/queries/customerCases.ts
+++ b/studioShared/lib/queries/customerCases.ts
@@ -149,6 +149,29 @@ export const CUSTOMER_CASE_ENTRY_QUERY = groq`
   }
 `;
 
+export const FRONTPAGE_FEATURED_CASES_QUERY = groq`
+  *[_type == "frontpageSettings"][0].featuredCases[] -> {
+    ${CUSTOMER_CASE_BASE_FRAGMENT},
+    "projectInfo": projectInfo {
+      customer,
+      "deliveries": {
+        "design": deliveries.design[] {
+          _key,
+          "designDelivery": ${translatedFieldFragment("designDelivery")}
+        },
+        "development": deliveries.development[] {
+          _key,
+          "developmentDelivery": ${translatedFieldFragment("developmentDelivery")}
+        },
+        "projectManagement": deliveries.projectManagement[] {
+          _key,
+          "projectManagementDelivery": ${translatedFieldFragment("projectManagementDelivery")}
+        }
+      },
+    },
+  }
+`;
+
 export const CUSTOMER_CASES_SITEMAP_QUERY = groq`
   *[_type == "customerCase"] {
     _updatedAt,

--- a/studioShared/schema.ts
+++ b/studioShared/schema.ts
@@ -3,7 +3,8 @@ import { type SchemaTypeDefinition } from "sanity";
 import { richText } from "studio/schemas/fields/text";
 
 import customerCases from "./schemas/documents/customerCase";
+import frontpageSettings from "./schemas/documents/frontpageSettings";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [customerCases, richText],
+  types: [customerCases, frontpageSettings, richText],
 };

--- a/studioShared/schemas/documents/frontpageSettings.ts
+++ b/studioShared/schemas/documents/frontpageSettings.ts
@@ -1,0 +1,41 @@
+import { StarIcon } from "@sanity/icons";
+import { defineField, defineType } from "sanity";
+
+import { customerCaseID } from "./customerCase";
+
+export const frontpageSettingsID = "frontpageSettings";
+
+const frontpageSettings = defineType({
+  name: frontpageSettingsID,
+  type: "document",
+  title: "Frontpage Settings",
+  icon: StarIcon,
+  fields: [
+    defineField({
+      name: "featuredCases",
+      title: "Featured Cases",
+      description:
+        "Customer cases to feature on the frontpage. Maximum 3 cases.",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: customerCaseID }],
+          options: {
+            disableNew: true,
+          },
+        },
+      ],
+      validation: (rule) => rule.max(3).unique(),
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: "Frontpage Settings",
+      };
+    },
+  },
+});
+
+export default frontpageSettings;

--- a/studioShared/schemas/documents/frontpageSettings.ts
+++ b/studioShared/schemas/documents/frontpageSettings.ts
@@ -1,6 +1,8 @@
 import { StarIcon } from "@sanity/icons";
 import { defineField, defineType } from "sanity";
 
+import { domainsField } from "studioShared/schemas/fields/domains";
+
 import { customerCaseID } from "./customerCase";
 
 export const frontpageSettingsID = "frontpageSettings";
@@ -11,6 +13,7 @@ const frontpageSettings = defineType({
   title: "Frontpage Settings",
   icon: StarIcon,
   fields: [
+    defineField({ ...domainsField, validation: (rule) => rule.required() }),
     defineField({
       name: "featuredCases",
       title: "Featured Cases",
@@ -30,9 +33,13 @@ const frontpageSettings = defineType({
     }),
   ],
   preview: {
-    prepare() {
+    select: {
+      domains: "domains",
+    },
+    prepare({ domains }) {
       return {
-        title: "Frontpage Settings",
+        title: `Frontpage Settings`,
+        subtitle: Array.isArray(domains) ? domains.join(", ") : undefined,
       };
     },
   },


### PR DESCRIPTION
Add a Frontpage Settings singleton in the shared studio where editors can hand-pick up to 3 customer cases to feature on the frontpage. Falls back to showing all cases if none are configured.