### PR TITLE
feat(eventsPage): filter past events by year

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -99,6 +99,10 @@
     "future_events": "Coming events",
     "past_events": "Past events"
   },
+  "year_selector": {
+    "year": "Year",
+    "all": "All"
+  },
   "office_selector": {
     "location": "Location",
     "all": "All"

--- a/messages/no.json
+++ b/messages/no.json
@@ -98,6 +98,10 @@
     "future_events": "Kommende arrangementer",
     "past_events": "Tidligere arrangementer"
   },
+  "year_selector": {
+    "year": "År",
+    "all": "Alle"
+  },
   "office_selector": {
     "location": "Lokasjon",
     "all": "Alle"

--- a/messages/se.json
+++ b/messages/se.json
@@ -99,6 +99,10 @@
     "future_events": "Kommende arrangemang",
     "past_events": "Tidigare arrangemang"
   },
+  "year_selector": {
+    "year": "År",
+    "all": "Alla"
+  },
   "office_selector": {
     "location": "Kontor",
     "all": "Alla"

--- a/src/components/eventsPage/eventsPage.tsx
+++ b/src/components/eventsPage/eventsPage.tsx
@@ -1,8 +1,9 @@
 import { getTranslations } from "next-intl/server";
 
 import EventPosting from "src/components/eventPosting/EventPosting";
+import EventPostingListWithYearFilter from "src/components/sections/events/EventPostingListWithYearFilter";
 import Text from "src/components/text/Text";
-import { IEventPosting } from "studio/lib/interfaces/eventPosting";
+import { type IEventPosting } from "studio/lib/interfaces/eventPosting";
 
 import styles from "./eventsPage.module.css";
 
@@ -79,15 +80,10 @@ export default async function EventsPage({
               {t("past_events")}
             </Text>
 
-            <div className={styles.wrapper}>
-              {sortedPastEventPostings.map((event: IEventPosting) => (
-                <EventPosting
-                  eventPosting={event}
-                  key={event._key}
-                  language={params.locale}
-                />
-              ))}
-            </div>
+            <EventPostingListWithYearFilter
+              eventPostings={sortedPastEventPostings}
+              language={params.locale}
+            />
           </section>
         )}
       </section>

--- a/src/components/sections/events/EventPostingListWithYearFilter.tsx
+++ b/src/components/sections/events/EventPostingListWithYearFilter.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+
+import EventPosting from "src/components/eventPosting/EventPosting";
+import styles from "src/components/eventsPage/eventsPage.module.css";
+import YearSelector from "src/components/yearSelector/YearSelector";
+import { type IEventPosting } from "studio/lib/interfaces/eventPosting";
+
+export default function EventPostingListWithYearFilter({
+  eventPostings,
+  language,
+}: {
+  eventPostings: IEventPosting[];
+  language: string;
+}) {
+  const eventPostingsYears = [
+    ...new Set(
+      eventPostings
+        .filter((event) => event.date)
+        .map((event) => event.date!.slice(0, 4)),
+    ),
+  ];
+  const preselectedYear = eventPostingsYears[0];
+
+  const [yearFilter, setYearFilter] = useState<string | null>(preselectedYear);
+
+  const filteredEventPostings = eventPostings.filter(
+    (event) => yearFilter === null || event.date.startsWith(yearFilter),
+  );
+
+  return (
+    <>
+      <YearSelector
+        years={eventPostingsYears}
+        preselectedYear={preselectedYear}
+        onFilterChange={setYearFilter}
+      />
+
+      <div className={styles.wrapper}>
+        {filteredEventPostings.map((event: IEventPosting) => (
+          <EventPosting
+            eventPosting={event}
+            key={event._key}
+            language={language}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/yearSelector/YearSelector.tsx
+++ b/src/components/yearSelector/YearSelector.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+import { Tag } from "src/components/tag";
+import Text from "src/components/text/Text";
+
+import styles from "./yearSelector.module.css";
+
+interface YearSelectorProps {
+  years: string[];
+  preselectedYear?: string | null;
+  onFilterChange: (location: string | null) => void;
+}
+
+function sortNumeric(locations: string[]) {
+  return locations.sort().reverse();
+}
+
+export default function YearSelector({
+  years,
+  preselectedYear = null,
+  onFilterChange,
+}: YearSelectorProps) {
+  const [yearFilter, setYearFilter] = useState<string | null>(preselectedYear);
+  const handleFilterChange = (year: string | null) => {
+    setYearFilter(year);
+    onFilterChange(year);
+  };
+
+  const t = useTranslations("year_selector");
+
+  return (
+    <div className={styles.filters}>
+      <Text type="label">{t("year")}</Text>
+
+      <Tag
+        active={!yearFilter}
+        type="button"
+        onClick={() => handleFilterChange(null)}
+        text={t("all")}
+      />
+
+      {sortNumeric(years).map((year) => (
+        <Tag
+          key={year}
+          active={yearFilter === year}
+          type="button"
+          onClick={() => handleFilterChange(year)}
+          text={year}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/yearSelector/yearSelector.module.css
+++ b/src/components/yearSelector/yearSelector.module.css
@@ -1,0 +1,7 @@
+.filters {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.75rem 0.75rem 0;
+}


### PR DESCRIPTION
Can be tested at https://variant-no-git-42tte-feat-events-year-filter-variant1.vercel.app/no/events check pasted events and filter by year

## Checklist

<!-- All must be checked before you merge -->

- [ ] Give Sweden a headsup of the changes made so that they can update their website
- [x] The design works for both desktop and mobile
- [x] The new component doesn't already exist and exisitng component can't be expanded to cover the new functionality
- [x] New functions that can be used in multiple components has been put in a `utils` directory
- [x] The new link is added correctly in schema for the possibility to choose internal and external in Sanity Studio
